### PR TITLE
Add native Meshtastic transport plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,11 +14,12 @@ minor bumps may carry breaking changes).
   independent, co-equal transports. A single BBS instance can run MeshCore
   only, Meshtastic only, or both simultaneously.
 - **`transport-meshtastic` feature flag** — new `bbs-meshtastic` crate wires
-  the Meshtastic config, setup wizard, and installer; the radio codec (protobuf
-  over serial/TCP) is a stub pending implementation.
+  the Meshtastic config, setup wizard, installer, and protobuf-over-serial/TCP
+  radio codec.
 - **`[plugins.meshtastic]` config section** — `connection_type` (`serial` or
-  `tcp`), `serial_port`, `baud_rate`, `addr`, `command_prefix`, and `enabled`
-  fields. Defaults to `enabled = false` so existing installs are unaffected.
+  `tcp`), `serial_port`, `baud_rate`, `addr`, `command_prefix`, payload,
+  reconnect, and delivery fields. Defaults to `enabled = false` so existing
+  installs are unaffected.
 - **`enabled` flag on `[plugins.mesh]`** — MeshCore transport can now be
   disabled without removing the config section. Defaults to `true` for
   backward compatibility.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -246,7 +246,7 @@ checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bbs-cli"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "async-trait",
  "bbs-plugin-api",
@@ -259,7 +259,7 @@ dependencies = [
 
 [[package]]
 name = "bbs-core"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "argon2",
  "async-trait",
@@ -277,7 +277,7 @@ dependencies = [
 
 [[package]]
 name = "bbs-hello-transport"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "async-trait",
  "bbs-plugin-api",
@@ -288,7 +288,7 @@ dependencies = [
 
 [[package]]
 name = "bbs-mesh"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "async-trait",
  "bbs-core",
@@ -302,18 +302,20 @@ dependencies = [
 
 [[package]]
 name = "bbs-meshtastic"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "async-trait",
  "bbs-plugin-api",
+ "prost",
  "serde",
  "tokio",
+ "tokio-serial",
  "tracing",
 ]
 
 [[package]]
 name = "bbs-plugin-api"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "async-trait",
  "serde",
@@ -324,7 +326,7 @@ dependencies = [
 
 [[package]]
 name = "bbs-process-transport"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "async-trait",
  "bbs-plugin-api",
@@ -338,7 +340,7 @@ dependencies = [
 
 [[package]]
 name = "bbs-web"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "async-trait",
  "axum",
@@ -1272,6 +1274,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1408,7 +1419,7 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "meshcore-companion"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "proptest",
  "thiserror 1.0.69",
@@ -1777,6 +1788,29 @@ dependencies = [
  "rusty-fork",
  "tempfile",
  "unarray",
+]
+
+[[package]]
+name = "prost"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2796faa41db3ec313a31f7624d9286acf277b52de526150b7e69f3debf891ee5"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
+dependencies = [
+ "anyhow",
+ "itertools",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2461,7 +2495,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "supply-drop-bbs"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "bbs-cli",
  "bbs-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,6 +90,7 @@ figment     = { version = "0.10", features = ["toml", "env"] }
 proptest    = "1"
 serde       = { version = "1", features = ["derive"] }
 serde_json  = "1"
+prost       = "0.13"
 thiserror   = "1"
 toml        = "0.8"
 # `time` is the modern Rust datetime library. `serde-well-known`

--- a/config.example.toml
+++ b/config.example.toml
@@ -202,6 +202,41 @@
 # command_prefix = "!"
 
 
+# ─── Plugin: Meshtastic transport ─────────────────────────────────
+#
+# This section only applies when the BBS is built with the
+# `transport-meshtastic` cargo feature. Meshtastic can connect
+# directly to a USB radio or to meshtasticd over TCP.
+
+[plugins.meshtastic]
+# Disabled by default so existing installs are unaffected.
+# enabled = false
+
+# How to reach the radio.
+#   "serial" — connect directly to a USB Meshtastic radio (Heltec V3,
+#              T-Beam, RAK4631, etc.)
+#   "tcp"    — connect to meshtasticd, usually on a Pi HAT node
+# connection_type = "serial"
+
+# ── Serial mode (connection_type = "serial") ──────────────────────
+# serial_port = "/dev/ttyACM0"
+# baud_rate = 115200
+
+# ── TCP mode (connection_type = "tcp") ────────────────────────────
+# addr = "127.0.0.1:4403"
+
+# ── All modes ─────────────────────────────────────────────────────
+# Optional single-character command prefix. Omit to treat every direct
+# message as a command.
+# command_prefix = "!"
+# max_payload_bytes = 220
+# node_credential_ttl_days = 14
+# hop_limit = 3
+# want_ack = true
+# reconnect_delay_initial_ms = 1000
+# reconnect_delay_max_ms = 60000
+
+
 # ─── Plugin: web admin ────────────────────────────────────────────
 #
 # This section only applies when the BBS is built with the

--- a/crates/bbs-meshtastic/Cargo.toml
+++ b/crates/bbs-meshtastic/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name             = "bbs-meshtastic"
-description      = "Meshtastic transport plugin for Supply Drop BBS (protocol stub — codec not yet implemented)"
+description      = "Meshtastic transport plugin for Supply Drop BBS"
 version.workspace    = true
 edition.workspace    = true
 authors.workspace    = true
@@ -12,8 +12,10 @@ publish          = false
 [dependencies]
 bbs-plugin-api = { workspace = true }
 async-trait    = { workspace = true }
+prost          = { workspace = true }
 serde          = { workspace = true }
-tokio          = { workspace = true }
+tokio          = { workspace = true, features = ["io-util", "net", "sync", "time"] }
+tokio-serial   = { workspace = true }
 tracing        = { workspace = true }
 
 [lints]

--- a/crates/bbs-meshtastic/src/command.rs
+++ b/crates/bbs-meshtastic/src/command.rs
@@ -1,0 +1,241 @@
+//! Command parsing and response rendering for the Meshtastic transport.
+
+use bbs_plugin_api::{event::Notification, identity::Username, Command, Response};
+
+pub fn parse_command(text: &str, prefix: Option<char>, awaiting_reply: bool) -> Option<Command> {
+    let text = text.trim();
+
+    if matches!(text.to_ascii_lowercase().as_str(), "cancel" | "stop") {
+        return Some(Command::Cancel);
+    }
+
+    if awaiting_reply {
+        return Some(Command::WorkflowReply {
+            reply: text.to_owned(),
+        });
+    }
+
+    let text = if let Some(p) = prefix {
+        if let Some(stripped) = text.strip_prefix(p) {
+            stripped.trim_start()
+        } else {
+            return None;
+        }
+    } else {
+        text
+    };
+
+    if text.is_empty() {
+        return Some(Command::Unknown { raw: String::new() });
+    }
+
+    let (word, rest) = split_first_word(text);
+    let keyword = word.to_ascii_lowercase();
+
+    match keyword.as_str() {
+        "h" | "help" | "?" => Some(Command::Help {
+            topic: rest.map(str::to_owned),
+        }),
+        "register" => match rest.and_then(|s| Username::new(s).ok()) {
+            Some(username) => Some(Command::Register { username }),
+            None => Some(Command::Help {
+                topic: Some("register".to_owned()),
+            }),
+        },
+        "login" => match rest.and_then(|s| Username::new(s).ok()) {
+            Some(username) => Some(Command::Login { username }),
+            None => Some(Command::Help {
+                topic: Some("login".to_owned()),
+            }),
+        },
+        "logout" => Some(Command::Logout),
+        "whoami" => Some(Command::Whoami),
+        "k" => Some(Command::ListRooms),
+        "g" => Some(Command::GoNextUnread),
+        "c" => Some(Command::ChangeRoom {
+            target: rest.unwrap_or("").to_owned(),
+        }),
+        "m" => Some(Command::GoMail),
+        "i" => Some(Command::IgnoreRoom),
+        "n" => Some(Command::ReadNew),
+        "f" => Some(Command::ReadForward {
+            after: rest.and_then(|s| s.parse::<i64>().ok()),
+        }),
+        "r" => Some(Command::ReadReverse),
+        "s" => match rest {
+            Some(q) if !q.is_empty() => Some(Command::SearchUsers {
+                query: q.to_owned(),
+            }),
+            _ => Some(Command::ScanMessages),
+        },
+        ".ff" => Some(Command::FastForward),
+        "e" => Some(Command::EnterMessage {
+            body: rest.filter(|s| !s.is_empty()).map(str::to_owned),
+        }),
+        "d" => match rest.and_then(|s| s.parse::<i64>().ok()) {
+            Some(id) => Some(Command::DeleteMessage { id }),
+            None => Some(Command::Unknown {
+                raw: text.to_owned(),
+            }),
+        },
+        "q" => Some(Command::Quit),
+        "cancel" | "stop" => Some(Command::Cancel),
+        "w" => Some(Command::WhoIsOnline),
+        "pending" => Some(Command::ListPending),
+        "v" => match rest.and_then(|s| Username::new(s).ok()) {
+            Some(username) => Some(Command::ValidateUser { username }),
+            None => Some(Command::Unknown {
+                raw: text.to_owned(),
+            }),
+        },
+        "b" => {
+            let raw_arg = rest.unwrap_or("").trim();
+            let (force, name) = if let Some(s) = raw_arg.strip_prefix('+') {
+                (Some(true), s.trim())
+            } else if let Some(s) = raw_arg.strip_prefix('-') {
+                (Some(false), s.trim())
+            } else {
+                (None, raw_arg)
+            };
+            match Username::new(name) {
+                Ok(target) => Some(Command::BlockUser { target, force }),
+                Err(_) => Some(Command::Unknown {
+                    raw: text.to_owned(),
+                }),
+            }
+        }
+        "ban" => match rest.and_then(|s| Username::new(s).ok()) {
+            Some(username) => Some(Command::BanUser { username }),
+            None => Some(Command::Unknown {
+                raw: text.to_owned(),
+            }),
+        },
+        "unban" => match rest.and_then(|s| Username::new(s).ok()) {
+            Some(username) => Some(Command::UnbanUser { username }),
+            None => Some(Command::Unknown {
+                raw: text.to_owned(),
+            }),
+        },
+        "u" | "users" => Some(Command::ListUsers {
+            filter: rest.map(str::to_owned),
+        }),
+        "whois" => match rest.and_then(|s| Username::new(s).ok()) {
+            Some(username) => Some(Command::UserInfo { username }),
+            None => Some(Command::Unknown {
+                raw: text.to_owned(),
+            }),
+        },
+        "profile" => Some(Command::EditProfile),
+        "passwd" => Some(Command::ChangePassword),
+        ".c" => match rest {
+            Some(name) if !name.is_empty() => Some(Command::CreateRoom {
+                name: name.to_owned(),
+            }),
+            _ => Some(Command::Unknown {
+                raw: text.to_owned(),
+            }),
+        },
+        ".dr" => match rest {
+            Some(name) if !name.is_empty() => Some(Command::DeleteRoom {
+                name: name.to_owned(),
+            }),
+            _ => Some(Command::Unknown {
+                raw: text.to_owned(),
+            }),
+        },
+        ".er" => Some(Command::EditRoom),
+        ".eu" => match rest.and_then(|s| Username::new(s).ok()) {
+            Some(username) => Some(Command::EditUser { username }),
+            None => Some(Command::Unknown {
+                raw: text.to_owned(),
+            }),
+        },
+        ".du" => match rest.and_then(|s| Username::new(s).ok()) {
+            Some(username) => Some(Command::DeleteUser { username }),
+            None => Some(Command::Unknown {
+                raw: text.to_owned(),
+            }),
+        },
+        _ => Some(Command::Unknown {
+            raw: text.to_owned(),
+        }),
+    }
+}
+
+fn split_first_word(s: &str) -> (&str, Option<&str>) {
+    match s.find(|c: char| c.is_ascii_whitespace()) {
+        None => (s, None),
+        Some(i) => {
+            let rest = s[i..].trim_start();
+            (&s[..i], if rest.is_empty() { None } else { Some(rest) })
+        }
+    }
+}
+
+pub fn format_response(response: &Response) -> Option<String> {
+    match response {
+        Response::Text(t) => Some(t.clone()),
+        Response::Prompt { text, .. } => Some(text.clone()),
+        Response::LoggedIn { user } => Some(format!(
+            "Welcome, {}. Type 'H' for commands.",
+            user.as_str()
+        )),
+        Response::LoggedOut => Some("Goodbye. Your session has ended.".to_owned()),
+        Response::Error(e) => Some(format!("Error: {e}")),
+        Response::MultiText(parts) => Some(parts.join("\n")),
+        _ => None,
+    }
+}
+
+pub fn render_notification(notification: &Notification) -> String {
+    match notification {
+        Notification::Text(t) => t.clone(),
+        Notification::MailWaiting { count } => format!(
+            "You have {} unread message{}. Reply 'M' to read.",
+            count,
+            if *count == 1 { "" } else { "s" }
+        ),
+        Notification::SystemEvent(s) => format!("[system] {s}"),
+        _ => "[notification]".to_owned(),
+    }
+}
+
+pub fn truncate_utf8(text: &str, max_bytes: usize) -> String {
+    if text.len() <= max_bytes {
+        return text.to_owned();
+    }
+    let mut end = max_bytes;
+    while end > 0 && !text.is_char_boundary(end) {
+        end -= 1;
+    }
+    text[..end].trim_end().to_owned()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn prefix_without_match_is_ignored() {
+        assert_eq!(parse_command("hello", Some('!'), false), None);
+        assert!(matches!(
+            parse_command("!h", Some('!'), false),
+            Some(Command::Help { .. })
+        ));
+    }
+
+    #[test]
+    fn workflow_reply_beats_prefix() {
+        assert_eq!(
+            parse_command("secret", Some('!'), true),
+            Some(Command::WorkflowReply {
+                reply: "secret".to_owned()
+            })
+        );
+    }
+
+    #[test]
+    fn truncate_preserves_utf8() {
+        assert_eq!(truncate_utf8("ab😀cd", 5), "ab");
+    }
+}

--- a/crates/bbs-meshtastic/src/lib.rs
+++ b/crates/bbs-meshtastic/src/lib.rs
@@ -1,21 +1,44 @@
 //! Meshtastic transport plugin for Supply Drop BBS.
 //!
-//! This crate is a **protocol stub**.  The config types, feature flag, setup
-//! wizard, and installer are all wired up so that MeshCore and Meshtastic are
-//! treated as independent, co-equal transports.  The Meshtastic radio codec
-//! (protobuf over serial/TCP) has not been implemented yet — starting this
-//! transport logs a clear error and exits.
-//!
-//! When the codec is ready, replace the `init` / `start` / `stop` bodies in
-//! [`MeshtasticTransport`] with the real implementation.  Everything else
-//! (config, feature gate, wizard, installer) stays the same.
+//! Supports both USB serial radios and TCP connections to `meshtasticd`.
 
-use std::net::SocketAddr;
+mod command;
+mod proto;
+mod session;
+mod stream;
+
+use std::{
+    net::SocketAddr,
+    sync::{
+        atomic::{AtomicU32, Ordering},
+        Arc, Mutex,
+    },
+    time::Duration,
+};
 
 use async_trait::async_trait;
-use bbs_plugin_api::{Host, Plugin, PluginError};
+use bbs_plugin_api::{
+    error::{HostError, PluginError, TransportError},
+    event::{DomainEvent, Notification, NotifyOutcome},
+    identity::SessionId,
+    transport::TransportEngine,
+    Host, PermissionLevel, Plugin, Response,
+};
 use serde::{Deserialize, Serialize};
-use std::sync::Arc;
+use tokio::sync::{mpsc, watch};
+use tracing::{debug, info, warn};
+
+use crate::{
+    command::{format_response, parse_command, render_notification, truncate_utf8},
+    proto::{
+        direct_text_packet, from_radio, mesh_packet, node_key, synthetic_pubkey, Data, MeshPacket,
+        NodeInfo, BROADCAST_ADDR, PORT_NODEINFO_APP, PORT_TEXT_MESSAGE_APP,
+    },
+    session::SessionState,
+    stream::{ClientEvent, MeshtasticClient, SerialConfig, TcpConfig},
+};
+
+const TRANSPORT_NAME: &str = "meshtastic";
 
 // ── Connection type ───────────────────────────────────────────────────────────
 
@@ -23,40 +46,21 @@ use std::sync::Arc;
 #[derive(Debug, Clone, Copy, Default, Deserialize, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "lowercase")]
 pub enum MeshtasticConnectionType {
-    /// Connect directly to a USB radio (Heltec V3, T-Beam, RAK4631, etc.)
-    /// running Meshtastic firmware via serial port.
+    /// Connect directly to a USB radio running Meshtastic firmware.
     #[default]
     Serial,
-
-    /// Connect via TCP to a running `meshtasticd` instance or any Meshtastic
-    /// node that exposes a TCP stream (default port 4403).
+    /// Connect via TCP to `meshtasticd` or another Meshtastic TCP stream.
     Tcp,
 }
 
 // ── Config ────────────────────────────────────────────────────────────────────
 
 /// Configuration for the Meshtastic transport (`[plugins.meshtastic]`).
-///
-/// # Minimal TOML examples
-///
-/// USB serial (most common):
-/// ```toml
-/// [plugins.meshtastic]
-/// connection_type = "serial"
-/// serial_port     = "/dev/ttyACM0"
-/// ```
-///
-/// TCP to meshtasticd:
-/// ```toml
-/// [plugins.meshtastic]
-/// connection_type = "tcp"
-/// addr            = "127.0.0.1:4403"
-/// ```
 #[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct MeshtasticConfig {
     /// Set to `false` to disable this transport without removing the section.
-    #[serde(default = "default_true")]
+    #[serde(default = "default_enabled")]
     pub enabled: bool,
 
     /// How to connect to the radio.
@@ -64,41 +68,85 @@ pub struct MeshtasticConfig {
     pub connection_type: MeshtasticConnectionType,
 
     /// OS path to the USB serial device.
-    /// Required when `connection_type = "serial"`.
-    /// Examples: `/dev/ttyACM0` (Linux), `COM3` (Windows).
     #[serde(default)]
     pub serial_port: Option<String>,
 
-    /// Baud rate for the serial connection. Meshtastic defaults to 115 200.
+    /// Baud rate for the serial connection.
     #[serde(default = "default_baud_rate")]
     pub baud_rate: u32,
 
     /// Address of a `meshtasticd` TCP listener.
-    /// Used when `connection_type = "tcp"`. Defaults to `127.0.0.1:4403`.
     #[serde(default = "default_addr")]
     pub addr: SocketAddr,
 
     /// Optional single-character prefix that marks a message as a BBS command.
-    /// When `None` every direct message is treated as a potential command.
     #[serde(default)]
     pub command_prefix: Option<char>,
+
+    /// Greeting sent to a node the first time it contacts the BBS.
+    #[serde(default = "default_welcome_message")]
+    pub welcome_message: String,
+
+    /// Maximum bytes sent in one Meshtastic text payload.
+    #[serde(default = "default_max_payload_bytes")]
+    pub max_payload_bytes: usize,
+
+    /// Days a radio-node credential remains valid. `0` disables auto-login.
+    #[serde(default = "default_node_credential_ttl_days")]
+    pub node_credential_ttl_days: u32,
+
+    /// Hop limit for outbound direct-message replies.
+    #[serde(default = "default_hop_limit")]
+    pub hop_limit: u32,
+
+    /// Request radio-layer acknowledgements for replies and notifications.
+    #[serde(default = "default_want_ack")]
+    pub want_ack: bool,
+
+    /// Initial reconnect delay after a serial/TCP disconnect.
+    #[serde(default = "default_reconnect_delay_initial_ms")]
+    pub reconnect_delay_initial_ms: u64,
+
+    /// Maximum reconnect delay after repeated failures.
+    #[serde(default = "default_reconnect_delay_max_ms")]
+    pub reconnect_delay_max_ms: u64,
 }
 
 impl Default for MeshtasticConfig {
     fn default() -> Self {
         Self {
-            enabled: false,
+            enabled: default_enabled(),
             connection_type: MeshtasticConnectionType::default(),
             serial_port: None,
             baud_rate: default_baud_rate(),
             addr: default_addr(),
             command_prefix: None,
+            welcome_message: default_welcome_message(),
+            max_payload_bytes: default_max_payload_bytes(),
+            node_credential_ttl_days: default_node_credential_ttl_days(),
+            hop_limit: default_hop_limit(),
+            want_ack: default_want_ack(),
+            reconnect_delay_initial_ms: default_reconnect_delay_initial_ms(),
+            reconnect_delay_max_ms: default_reconnect_delay_max_ms(),
         }
     }
 }
 
-fn default_true() -> bool {
-    true
+impl MeshtasticConfig {
+    fn reconnect_delay_initial(&self) -> Duration {
+        Duration::from_millis(self.reconnect_delay_initial_ms.max(1))
+    }
+
+    fn reconnect_delay_max(&self) -> Duration {
+        Duration::from_millis(
+            self.reconnect_delay_max_ms
+                .max(self.reconnect_delay_initial_ms.max(1)),
+        )
+    }
+}
+
+fn default_enabled() -> bool {
+    false
 }
 fn default_baud_rate() -> u32 {
     115_200
@@ -108,50 +156,781 @@ fn default_addr() -> SocketAddr {
         .parse()
         .expect("hard-coded address is valid")
 }
+fn default_welcome_message() -> String {
+    "Welcome to Supply Drop BBS. LOGIN <user>, REGISTER <user>, or H for help.".to_owned()
+}
+fn default_max_payload_bytes() -> usize {
+    220
+}
+fn default_node_credential_ttl_days() -> u32 {
+    14
+}
+fn default_hop_limit() -> u32 {
+    3
+}
+fn default_want_ack() -> bool {
+    true
+}
+fn default_reconnect_delay_initial_ms() -> u64 {
+    1_000
+}
+fn default_reconnect_delay_max_ms() -> u64 {
+    60_000
+}
 
 // ── Transport ─────────────────────────────────────────────────────────────────
 
 /// Meshtastic transport plugin handle.
-///
-/// Currently a stub — the Meshtastic protobuf codec is not yet implemented.
-/// Starting this transport will log an error and exit.
 pub struct MeshtasticTransport {
-    _config: MeshtasticConfig,
-    _host: Arc<dyn Host>,
+    host: Arc<dyn Host>,
+    cmd_tx: mpsc::Sender<proto::ToRadio>,
+    state: Arc<Mutex<SessionState>>,
+    client_slot: Mutex<Option<MeshtasticClient>>,
+    shutdown_tx: watch::Sender<bool>,
+    command_prefix: Option<char>,
+    welcome_message: String,
+    max_payload_bytes: usize,
+    node_credential_ttl_days: u32,
+    hop_limit: u32,
+    want_ack: bool,
+    packet_counter: Arc<AtomicU32>,
 }
 
 #[async_trait]
 impl Plugin for MeshtasticTransport {
+    type Config = MeshtasticConfig;
+
     fn name(&self) -> &'static str {
-        "meshtastic"
+        TRANSPORT_NAME
     }
 
     fn version(&self) -> &'static str {
         env!("CARGO_PKG_VERSION")
     }
 
-    async fn init(config: Self::Config, host: Arc<dyn Host>) -> Result<Self, PluginError>
-    where
-        Self: Sized,
-    {
+    async fn init(config: Self::Config, host: Arc<dyn Host>) -> Result<Self, PluginError> {
+        let client = match config.connection_type {
+            MeshtasticConnectionType::Tcp => {
+                info!(addr = %config.addr, "meshtastic transport: connecting via TCP");
+                MeshtasticClient::connect_tcp(TcpConfig {
+                    addr: config.addr,
+                    reconnect_delay_initial: config.reconnect_delay_initial(),
+                    reconnect_delay_max: config.reconnect_delay_max(),
+                })
+            }
+            MeshtasticConnectionType::Serial => {
+                let port = config.serial_port.clone().ok_or_else(|| {
+                    PluginError::InvalidConfig(
+                        "connection_type = 'serial' requires serial_port to be set".into(),
+                    )
+                })?;
+                info!(port = %port, baud = config.baud_rate, "meshtastic transport: connecting via serial");
+                MeshtasticClient::connect_serial(SerialConfig {
+                    port,
+                    baud_rate: config.baud_rate,
+                    reconnect_delay_initial: config.reconnect_delay_initial(),
+                    reconnect_delay_max: config.reconnect_delay_max(),
+                })
+            }
+        };
+
+        let cmd_tx = client.sender();
+        let (shutdown_tx, _) = watch::channel(false);
+
         Ok(Self {
-            _config: config,
-            _host: host,
+            host,
+            cmd_tx,
+            state: Arc::new(Mutex::new(SessionState::default())),
+            client_slot: Mutex::new(Some(client)),
+            shutdown_tx,
+            command_prefix: config.command_prefix,
+            welcome_message: config.welcome_message,
+            max_payload_bytes: config.max_payload_bytes,
+            node_credential_ttl_days: config.node_credential_ttl_days,
+            hop_limit: config.hop_limit,
+            want_ack: config.want_ack,
+            packet_counter: Arc::new(AtomicU32::new(1)),
         })
     }
 
     async fn start(&self) -> Result<(), PluginError> {
-        Err(PluginError::Other(
-            "Meshtastic transport is not yet implemented. \
-             The codec (protobuf over serial/TCP) is pending. \
-             Disable [plugins.meshtastic] in your config until it is ready."
-                .into(),
-        ))
-    }
+        let client = self
+            .client_slot
+            .lock()
+            .expect("client_slot mutex poisoned")
+            .take()
+            .ok_or_else(|| {
+                PluginError::StartFailed("meshtastic transport already started".into())
+            })?;
 
-    async fn stop(&self) -> Result<(), PluginError> {
+        let host = Arc::clone(&self.host);
+        let cmd_tx = self.cmd_tx.clone();
+        let state = Arc::clone(&self.state);
+        let shutdown_rx = self.shutdown_tx.subscribe();
+        let prefix = self.command_prefix;
+        let welcome = self.welcome_message.clone();
+        let ttl_days = self.node_credential_ttl_days;
+        let max_payload = self.max_payload_bytes;
+        let hop_limit = self.hop_limit;
+        let want_ack = self.want_ack;
+        let packet_counter = Arc::clone(&self.packet_counter);
+
+        tokio::spawn(event_loop(
+            client,
+            host,
+            cmd_tx,
+            state,
+            shutdown_rx,
+            prefix,
+            welcome,
+            ttl_days,
+            max_payload,
+            hop_limit,
+            want_ack,
+            packet_counter,
+        ));
+
+        // Subscribe to advisory domain events, mirroring the MeshCore transport.
+        let mut domain_rx = self.host.events();
+        let notif_host = Arc::clone(&self.host);
+        let notif_cmd_tx = self.cmd_tx.clone();
+        let notif_state = Arc::clone(&self.state);
+        let notif_max_payload = self.max_payload_bytes;
+        let notif_hop_limit = self.hop_limit;
+        let notif_want_ack = self.want_ack;
+        let notif_counter = Arc::clone(&self.packet_counter);
+        let mut notif_shutdown_rx = self.shutdown_tx.subscribe();
+        tokio::spawn(async move {
+            loop {
+                tokio::select! {
+                    result = domain_rx.recv() => match result {
+                        Ok(event) => {
+                            push_domain_notification(
+                                event,
+                                &notif_host,
+                                &notif_cmd_tx,
+                                &notif_state,
+                                notif_max_payload,
+                                notif_hop_limit,
+                                notif_want_ack,
+                                &notif_counter,
+                            ).await;
+                        }
+                        Err(tokio::sync::broadcast::error::RecvError::Lagged(n)) => {
+                            warn!("meshtastic: domain event stream lagged by {n}");
+                        }
+                        Err(tokio::sync::broadcast::error::RecvError::Closed) => break,
+                    },
+                    _ = notif_shutdown_rx.changed() => break,
+                }
+            }
+        });
+
+        info!("meshtastic transport started");
         Ok(())
     }
 
-    type Config = MeshtasticConfig;
+    async fn stop(&self) -> Result<(), PluginError> {
+        let _ = self.shutdown_tx.send(true);
+        let sessions = self.state.lock().expect("state mutex poisoned").sessions();
+        for session in sessions {
+            let _ = self.host.end_session(session).await;
+        }
+        info!("meshtastic transport stop requested");
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl TransportEngine for MeshtasticTransport {
+    async fn notify(
+        &self,
+        session: SessionId,
+        payload: Notification,
+    ) -> Result<NotifyOutcome, TransportError> {
+        let node_num = {
+            self.state
+                .lock()
+                .expect("state mutex poisoned")
+                .node_for_session(session)
+        };
+        let Some(node_num) = node_num else {
+            return Ok(NotifyOutcome::Dropped);
+        };
+
+        let text = truncate_utf8(&render_notification(&payload), self.max_payload_bytes);
+        let packet_id = self.packet_counter.fetch_add(1, Ordering::Relaxed);
+        self.cmd_tx
+            .send(direct_text_packet(
+                node_num,
+                text,
+                packet_id,
+                self.hop_limit,
+                self.want_ack,
+            ))
+            .await
+            .map_err(|_| TransportError::ConnectionLost("meshtastic client closed".into()))?;
+        Ok(NotifyOutcome::Queued)
+    }
+}
+
+// ── Event loop ────────────────────────────────────────────────────────────────
+
+#[allow(clippy::too_many_arguments)]
+async fn event_loop(
+    mut client: MeshtasticClient,
+    host: Arc<dyn Host>,
+    cmd_tx: mpsc::Sender<proto::ToRadio>,
+    state: Arc<Mutex<SessionState>>,
+    mut shutdown_rx: watch::Receiver<bool>,
+    command_prefix: Option<char>,
+    welcome_message: String,
+    node_credential_ttl_days: u32,
+    max_payload_bytes: usize,
+    hop_limit: u32,
+    want_ack: bool,
+    packet_counter: Arc<AtomicU32>,
+) {
+    loop {
+        tokio::select! {
+            event = client.recv() => match event {
+                Some(ClientEvent::Connected) => {
+                    info!("meshtastic: connected to radio");
+                }
+                Some(ClientEvent::Disconnected { will_retry }) => {
+                    if will_retry {
+                        info!("meshtastic: radio disconnected, will retry");
+                    } else {
+                        info!("meshtastic: radio client shut down");
+                        break;
+                    }
+                }
+                Some(ClientEvent::FromRadio(msg)) => {
+                    handle_from_radio(
+                        msg,
+                        &host,
+                        &cmd_tx,
+                        &state,
+                        command_prefix,
+                        &welcome_message,
+                        node_credential_ttl_days,
+                        max_payload_bytes,
+                        hop_limit,
+                        want_ack,
+                        &packet_counter,
+                    ).await;
+                }
+                None => break,
+            },
+            _ = shutdown_rx.changed() => {
+                info!("meshtastic: shutdown signal received");
+                break;
+            }
+        }
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn handle_from_radio(
+    msg: proto::FromRadio,
+    host: &Arc<dyn Host>,
+    cmd_tx: &mpsc::Sender<proto::ToRadio>,
+    state: &Arc<Mutex<SessionState>>,
+    command_prefix: Option<char>,
+    welcome_message: &str,
+    node_credential_ttl_days: u32,
+    max_payload_bytes: usize,
+    hop_limit: u32,
+    want_ack: bool,
+    packet_counter: &AtomicU32,
+) {
+    match msg.payload_variant {
+        Some(from_radio::PayloadVariant::MyInfo(my_info)) => {
+            state.lock().expect("state mutex poisoned").my_node_num = Some(my_info.my_node_num);
+            info!(
+                node = format_node_id(my_info.my_node_num),
+                "meshtastic: local node info received"
+            );
+        }
+        Some(from_radio::PayloadVariant::NodeInfo(node)) => {
+            record_node_advert(host, node);
+        }
+        Some(from_radio::PayloadVariant::Packet(packet)) => {
+            handle_packet(
+                packet,
+                host,
+                cmd_tx,
+                state,
+                command_prefix,
+                welcome_message,
+                node_credential_ttl_days,
+                max_payload_bytes,
+                hop_limit,
+                want_ack,
+                packet_counter,
+            )
+            .await;
+        }
+        Some(from_radio::PayloadVariant::ConfigCompleteId(id)) => {
+            debug!(id, "meshtastic: config sync complete");
+        }
+        Some(from_radio::PayloadVariant::Rebooted(true)) => {
+            info!("meshtastic: radio rebooted");
+        }
+        _ => {}
+    }
+}
+
+fn record_node_advert(host: &Arc<dyn Host>, node: NodeInfo) {
+    let pubkey = node
+        .user
+        .as_ref()
+        .and_then(|u| <[u8; 32]>::try_from(u.public_key.as_slice()).ok())
+        .unwrap_or_else(|| synthetic_pubkey(node.num));
+
+    let name = node
+        .user
+        .as_ref()
+        .map(|u| {
+            if u.long_name.is_empty() {
+                u.id.clone()
+            } else {
+                u.long_name.clone()
+            }
+        })
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| format_node_id(node.num));
+
+    let (lat_1e6, lon_1e6) = node
+        .position
+        .as_ref()
+        .map(|p| {
+            (
+                p.latitude_i.unwrap_or(0) / 10,
+                p.longitude_i.unwrap_or(0) / 10,
+            )
+        })
+        .unwrap_or((0, 0));
+
+    host.advert_bus().upsert(pubkey, name, 0, lat_1e6, lon_1e6);
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn handle_packet(
+    packet: MeshPacket,
+    host: &Arc<dyn Host>,
+    cmd_tx: &mpsc::Sender<proto::ToRadio>,
+    state: &Arc<Mutex<SessionState>>,
+    command_prefix: Option<char>,
+    welcome_message: &str,
+    node_credential_ttl_days: u32,
+    max_payload_bytes: usize,
+    hop_limit: u32,
+    want_ack: bool,
+    packet_counter: &AtomicU32,
+) {
+    if let Some(mesh_packet::PayloadVariant::Decoded(data)) = &packet.payload_variant {
+        if data.portnum == PORT_NODEINFO_APP {
+            debug!(
+                from = format_node_id(packet.from),
+                "meshtastic: nodeinfo packet observed"
+            );
+            return;
+        }
+    }
+
+    if !is_direct_to_us(&packet, state) {
+        debug!(
+            from = format_node_id(packet.from),
+            to = packet.to,
+            "meshtastic: ignoring non-DM packet"
+        );
+        return;
+    }
+
+    let Some(text) = text_payload(&packet) else {
+        debug!("meshtastic: ignoring non-text packet");
+        return;
+    };
+
+    dispatch_message(
+        packet.from,
+        &text,
+        host,
+        cmd_tx,
+        state,
+        command_prefix,
+        welcome_message,
+        node_credential_ttl_days,
+        max_payload_bytes,
+        hop_limit,
+        want_ack,
+        packet_counter,
+    )
+    .await;
+}
+
+fn is_direct_to_us(packet: &MeshPacket, state: &Arc<Mutex<SessionState>>) -> bool {
+    if packet.to == BROADCAST_ADDR {
+        return false;
+    }
+    let my_node = state.lock().expect("state mutex poisoned").my_node_num;
+    my_node.is_none_or(|mine| packet.to == mine)
+}
+
+fn text_payload(packet: &MeshPacket) -> Option<String> {
+    let Some(mesh_packet::PayloadVariant::Decoded(Data {
+        portnum, payload, ..
+    })) = &packet.payload_variant
+    else {
+        return None;
+    };
+
+    if *portnum != PORT_TEXT_MESSAGE_APP {
+        return None;
+    }
+
+    std::str::from_utf8(payload).ok().map(str::to_owned)
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn dispatch_message(
+    node_num: u32,
+    text: &str,
+    host: &Arc<dyn Host>,
+    cmd_tx: &mpsc::Sender<proto::ToRadio>,
+    state: &Arc<Mutex<SessionState>>,
+    command_prefix: Option<char>,
+    welcome_message: &str,
+    node_credential_ttl_days: u32,
+    max_payload_bytes: usize,
+    hop_limit: u32,
+    want_ack: bool,
+    packet_counter: &AtomicU32,
+) {
+    let (session, is_new) = get_or_create_session(node_num, host, state).await;
+
+    if is_new {
+        let auto_username = if node_credential_ttl_days > 0 {
+            match host
+                .mesh_node_restore(session, node_key(node_num), node_credential_ttl_days)
+                .await
+            {
+                Ok(username) => username,
+                Err(e) => {
+                    warn!(
+                        ?session,
+                        node = format_node_id(node_num),
+                        "meshtastic: node_restore error: {e}"
+                    );
+                    None
+                }
+            }
+        } else {
+            None
+        };
+
+        let greeting = if let Some(ref username) = auto_username {
+            format!("Welcome back, {username}! Type 'H' for commands.")
+        } else {
+            welcome_message.to_owned()
+        };
+        send_text(
+            cmd_tx,
+            node_num,
+            greeting,
+            max_payload_bytes,
+            hop_limit,
+            want_ack,
+            packet_counter,
+        )
+        .await;
+    }
+
+    let awaiting_reply = state
+        .lock()
+        .expect("state mutex poisoned")
+        .is_awaiting_reply(node_num);
+
+    if state
+        .lock()
+        .expect("state mutex poisoned")
+        .dedup_message(node_num, text)
+    {
+        debug!("meshtastic: dropping retransmitted message");
+        return;
+    }
+
+    if !awaiting_reply
+        && state
+            .lock()
+            .expect("state mutex poisoned")
+            .is_recent_workflow_reply(node_num, text)
+    {
+        debug!("meshtastic: dropping retransmitted workflow reply");
+        return;
+    }
+
+    let Some(cmd) = parse_command(text, command_prefix, awaiting_reply) else {
+        debug!("meshtastic: message ignored (no prefix match, no active workflow)");
+        return;
+    };
+
+    if awaiting_reply {
+        state
+            .lock()
+            .expect("state mutex poisoned")
+            .set_last_workflow_reply(node_num, text.to_owned());
+    }
+
+    let response = match host.process_command(session, cmd.clone()).await {
+        Ok(r) => r,
+        Err(HostError::UnknownSession(stale)) => {
+            info!(?stale, "meshtastic: stale session — refreshing");
+            state
+                .lock()
+                .expect("state mutex poisoned")
+                .remove_by_node(node_num);
+            let fresh = match host.create_session(TRANSPORT_NAME).await {
+                Ok(id) => id,
+                Err(e) => {
+                    warn!("meshtastic: session refresh failed: {e}");
+                    return;
+                }
+            };
+            state
+                .lock()
+                .expect("state mutex poisoned")
+                .get_or_insert(node_num, fresh);
+            if node_credential_ttl_days > 0 {
+                let _ = host
+                    .mesh_node_restore(fresh, node_key(node_num), node_credential_ttl_days)
+                    .await;
+            }
+            match host.process_command(fresh, cmd).await {
+                Ok(r) => r,
+                Err(e) => Response::Error(format!("{e}")),
+            }
+        }
+        Err(e) => Response::Error(format!("{e}")),
+    };
+
+    if node_credential_ttl_days > 0 {
+        match &response {
+            Response::LoggedIn { .. } => {
+                if let Err(e) = host.mesh_node_bind(session, node_key(node_num)).await {
+                    warn!(?session, "meshtastic: node_bind error: {e}");
+                }
+            }
+            Response::LoggedOut => {
+                if let Err(e) = host.mesh_node_unbind(node_key(node_num)).await {
+                    warn!("meshtastic: node_unbind error: {e}");
+                }
+            }
+            _ => {}
+        }
+    }
+
+    let is_prompt = matches!(response, Response::Prompt { .. });
+    state
+        .lock()
+        .expect("state mutex poisoned")
+        .set_awaiting_reply(node_num, is_prompt);
+
+    let frames: Vec<String> = if let Response::MultiText(parts) = &response {
+        parts.clone()
+    } else {
+        match format_response(&response) {
+            Some(t) => vec![t],
+            None => return,
+        }
+    };
+
+    for frame in frames {
+        send_text(
+            cmd_tx,
+            node_num,
+            frame,
+            max_payload_bytes,
+            hop_limit,
+            want_ack,
+            packet_counter,
+        )
+        .await;
+    }
+
+    if matches!(response, Response::LoggedOut) {
+        let removed_session = {
+            state
+                .lock()
+                .expect("state mutex poisoned")
+                .remove_by_node(node_num)
+        };
+        if let Some(sid) = removed_session {
+            let _ = host.end_session(sid).await;
+        }
+    }
+}
+
+async fn get_or_create_session(
+    node_num: u32,
+    host: &Arc<dyn Host>,
+    state: &Arc<Mutex<SessionState>>,
+) -> (SessionId, bool) {
+    if let Some(sid) = state.lock().expect("state mutex poisoned").lookup(node_num) {
+        return (sid, false);
+    }
+
+    let new_id = match host.create_session(TRANSPORT_NAME).await {
+        Ok(id) => id,
+        Err(e) => {
+            warn!("meshtastic: host.create_session failed: {e}");
+            if let Some(sid) = state.lock().expect("state mutex poisoned").lookup(node_num) {
+                return (sid, false);
+            }
+            panic!("meshtastic: host.create_session failed and no fallback: {e}");
+        }
+    };
+
+    state
+        .lock()
+        .expect("state mutex poisoned")
+        .get_or_insert(node_num, new_id)
+}
+
+async fn send_text(
+    cmd_tx: &mpsc::Sender<proto::ToRadio>,
+    node_num: u32,
+    text: String,
+    max_payload_bytes: usize,
+    hop_limit: u32,
+    want_ack: bool,
+    packet_counter: &AtomicU32,
+) {
+    if text.is_empty() {
+        return;
+    }
+    let text = truncate_utf8(&text, max_payload_bytes);
+    let packet_id = packet_counter.fetch_add(1, Ordering::Relaxed);
+    if cmd_tx
+        .send(direct_text_packet(
+            node_num, text, packet_id, hop_limit, want_ack,
+        ))
+        .await
+        .is_err()
+    {
+        warn!(
+            node = format_node_id(node_num),
+            "meshtastic: could not enqueue outbound text"
+        );
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn push_domain_notification(
+    event: DomainEvent,
+    host: &Arc<dyn Host>,
+    cmd_tx: &mpsc::Sender<proto::ToRadio>,
+    state: &Arc<Mutex<SessionState>>,
+    max_payload_bytes: usize,
+    hop_limit: u32,
+    want_ack: bool,
+    packet_counter: &AtomicU32,
+) {
+    let sessions: Vec<(SessionId, u32)> = {
+        let state = state.lock().expect("state mutex poisoned");
+        state
+            .by_session
+            .iter()
+            .map(|(sid, node)| (*sid, *node))
+            .collect()
+    };
+
+    match event {
+        DomainEvent::UserValidated { user } => {
+            for (sid, node_num) in sessions {
+                let Ok(ctx) = host.permission_ctx(sid).await else {
+                    continue;
+                };
+                if ctx.username.as_ref() == Some(&user) {
+                    send_text(
+                        cmd_tx,
+                        node_num,
+                        "Your account has been validated. Type 'H'.".to_owned(),
+                        max_payload_bytes,
+                        hop_limit,
+                        want_ack,
+                        packet_counter,
+                    )
+                    .await;
+                }
+            }
+        }
+        DomainEvent::UserCreated { user } => {
+            for (sid, node_num) in sessions {
+                let Ok(ctx) = host.permission_ctx(sid).await else {
+                    continue;
+                };
+                if ctx.level >= PermissionLevel::Aide {
+                    send_text(
+                        cmd_tx,
+                        node_num,
+                        format!("New registration: {} - type PENDING.", user.as_str()),
+                        max_payload_bytes,
+                        hop_limit,
+                        want_ack,
+                        packet_counter,
+                    )
+                    .await;
+                }
+            }
+        }
+        _ => {}
+    }
+}
+
+fn format_node_id(node_num: u32) -> String {
+    format!("!{node_num:08x}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_config_is_disabled_but_serial_ready() {
+        let cfg = MeshtasticConfig::default();
+        assert!(!cfg.enabled);
+        assert_eq!(cfg.connection_type, MeshtasticConnectionType::Serial);
+        assert_eq!(cfg.baud_rate, 115_200);
+    }
+
+    #[test]
+    fn text_payload_accepts_only_text_port() {
+        let packet = MeshPacket {
+            from: 1,
+            to: 2,
+            channel: 0,
+            payload_variant: Some(mesh_packet::PayloadVariant::Decoded(Data {
+                portnum: PORT_TEXT_MESSAGE_APP,
+                payload: b"hello".to_vec(),
+                want_response: false,
+                dest: 0,
+                source: 0,
+                request_id: 0,
+                reply_id: 0,
+            })),
+            id: 0,
+            rx_time: 0,
+            rx_snr: 0.0,
+            hop_limit: 0,
+            want_ack: false,
+            priority: 0,
+            rx_rssi: 0,
+            via_mqtt: false,
+            hop_start: 0,
+            public_key: Vec::new(),
+        };
+        assert_eq!(text_payload(&packet), Some("hello".to_owned()));
+    }
 }

--- a/crates/bbs-meshtastic/src/proto.rs
+++ b/crates/bbs-meshtastic/src/proto.rs
@@ -1,0 +1,299 @@
+//! Minimal Meshtastic protobuf model used by the transport.
+//!
+//! These structs intentionally cover only the fields Supply Drop needs for
+//! direct text messages, node adverts, config startup, and outbound replies.
+//! Unknown protobuf fields are ignored by `prost`, so newer firmware can add
+//! fields without breaking this transport.
+
+use prost::{Message, Oneof};
+
+pub const BROADCAST_ADDR: u32 = u32::MAX;
+pub const PORT_TEXT_MESSAGE_APP: i32 = 1;
+pub const PORT_NODEINFO_APP: i32 = 4;
+pub const PRIORITY_RELIABLE: i32 = 70;
+
+#[derive(Clone, PartialEq, Message)]
+pub struct ToRadio {
+    #[prost(oneof = "to_radio::PayloadVariant", tags = "1, 3, 4, 7")]
+    pub payload_variant: Option<to_radio::PayloadVariant>,
+}
+
+pub mod to_radio {
+    use super::*;
+
+    #[derive(Clone, PartialEq, Oneof)]
+    pub enum PayloadVariant {
+        #[prost(message, tag = "1")]
+        Packet(super::MeshPacket),
+        #[prost(uint32, tag = "3")]
+        WantConfigId(u32),
+        #[prost(bool, tag = "4")]
+        Disconnect(bool),
+        #[prost(message, tag = "7")]
+        Heartbeat(super::Heartbeat),
+    }
+}
+
+#[derive(Clone, PartialEq, Message)]
+pub struct FromRadio {
+    #[prost(uint32, tag = "1")]
+    pub id: u32,
+    #[prost(oneof = "from_radio::PayloadVariant", tags = "2, 3, 4, 7, 8")]
+    pub payload_variant: Option<from_radio::PayloadVariant>,
+}
+
+pub mod from_radio {
+    use super::*;
+
+    #[derive(Clone, PartialEq, Oneof)]
+    pub enum PayloadVariant {
+        #[prost(message, tag = "2")]
+        Packet(super::MeshPacket),
+        #[prost(message, tag = "3")]
+        MyInfo(super::MyNodeInfo),
+        #[prost(message, tag = "4")]
+        NodeInfo(super::NodeInfo),
+        #[prost(uint32, tag = "7")]
+        ConfigCompleteId(u32),
+        #[prost(bool, tag = "8")]
+        Rebooted(bool),
+    }
+}
+
+#[derive(Clone, PartialEq, Message)]
+pub struct MeshPacket {
+    #[prost(fixed32, tag = "1")]
+    pub from: u32,
+    #[prost(fixed32, tag = "2")]
+    pub to: u32,
+    #[prost(uint32, tag = "3")]
+    pub channel: u32,
+    #[prost(oneof = "mesh_packet::PayloadVariant", tags = "4, 5")]
+    pub payload_variant: Option<mesh_packet::PayloadVariant>,
+    #[prost(fixed32, tag = "6")]
+    pub id: u32,
+    #[prost(fixed32, tag = "7")]
+    pub rx_time: u32,
+    #[prost(float, tag = "8")]
+    pub rx_snr: f32,
+    #[prost(uint32, tag = "9")]
+    pub hop_limit: u32,
+    #[prost(bool, tag = "10")]
+    pub want_ack: bool,
+    #[prost(enumeration = "MeshPacketPriority", tag = "11")]
+    pub priority: i32,
+    #[prost(int32, tag = "12")]
+    pub rx_rssi: i32,
+    #[prost(bool, tag = "14")]
+    pub via_mqtt: bool,
+    #[prost(uint32, tag = "15")]
+    pub hop_start: u32,
+    #[prost(bytes = "vec", tag = "16")]
+    pub public_key: Vec<u8>,
+}
+
+pub mod mesh_packet {
+    use super::*;
+
+    #[derive(Clone, PartialEq, Oneof)]
+    pub enum PayloadVariant {
+        #[prost(message, tag = "4")]
+        Decoded(super::Data),
+        #[prost(bytes, tag = "5")]
+        Encrypted(Vec<u8>),
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, prost::Enumeration)]
+#[repr(i32)]
+pub enum MeshPacketPriority {
+    Unset = 0,
+    Background = 10,
+    Default = 64,
+    Reliable = 70,
+    Response = 80,
+    High = 100,
+    Alert = 110,
+    Ack = 120,
+}
+
+#[derive(Clone, PartialEq, Message)]
+pub struct Data {
+    #[prost(enumeration = "PortNum", tag = "1")]
+    pub portnum: i32,
+    #[prost(bytes = "vec", tag = "2")]
+    pub payload: Vec<u8>,
+    #[prost(bool, tag = "3")]
+    pub want_response: bool,
+    #[prost(fixed32, tag = "4")]
+    pub dest: u32,
+    #[prost(fixed32, tag = "5")]
+    pub source: u32,
+    #[prost(fixed32, tag = "6")]
+    pub request_id: u32,
+    #[prost(fixed32, tag = "7")]
+    pub reply_id: u32,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, prost::Enumeration)]
+#[repr(i32)]
+pub enum PortNum {
+    Unknown = 0,
+    TextMessage = 1,
+    Position = 3,
+    Nodeinfo = 4,
+}
+
+#[derive(Clone, PartialEq, Message)]
+pub struct MyNodeInfo {
+    #[prost(uint32, tag = "1")]
+    pub my_node_num: u32,
+    #[prost(uint32, tag = "8")]
+    pub reboot_count: u32,
+    #[prost(uint32, tag = "11")]
+    pub min_app_version: u32,
+    #[prost(bytes = "vec", tag = "12")]
+    pub device_id: Vec<u8>,
+    #[prost(string, tag = "13")]
+    pub pio_env: String,
+    #[prost(uint32, tag = "15")]
+    pub nodedb_count: u32,
+}
+
+#[derive(Clone, PartialEq, Message)]
+pub struct NodeInfo {
+    #[prost(uint32, tag = "1")]
+    pub num: u32,
+    #[prost(message, optional, tag = "2")]
+    pub user: Option<User>,
+    #[prost(message, optional, tag = "3")]
+    pub position: Option<Position>,
+    #[prost(float, tag = "4")]
+    pub snr: f32,
+    #[prost(fixed32, tag = "5")]
+    pub last_heard: u32,
+}
+
+#[derive(Clone, PartialEq, Message)]
+pub struct User {
+    #[prost(string, tag = "1")]
+    pub id: String,
+    #[prost(string, tag = "2")]
+    pub long_name: String,
+    #[prost(string, tag = "3")]
+    pub short_name: String,
+    #[prost(bytes = "vec", tag = "8")]
+    pub public_key: Vec<u8>,
+}
+
+#[derive(Clone, PartialEq, Message)]
+pub struct Position {
+    #[prost(sfixed32, optional, tag = "1")]
+    pub latitude_i: Option<i32>,
+    #[prost(sfixed32, optional, tag = "2")]
+    pub longitude_i: Option<i32>,
+    #[prost(int32, tag = "3")]
+    pub altitude: i32,
+    #[prost(fixed32, tag = "4")]
+    pub time: u32,
+}
+
+#[derive(Clone, PartialEq, Message)]
+pub struct Heartbeat {
+    #[prost(uint32, tag = "1")]
+    pub nonce: u32,
+}
+
+pub fn want_config(id: u32) -> ToRadio {
+    ToRadio {
+        payload_variant: Some(to_radio::PayloadVariant::WantConfigId(id)),
+    }
+}
+
+pub fn heartbeat(nonce: u32) -> ToRadio {
+    ToRadio {
+        payload_variant: Some(to_radio::PayloadVariant::Heartbeat(Heartbeat { nonce })),
+    }
+}
+
+pub fn disconnect() -> ToRadio {
+    ToRadio {
+        payload_variant: Some(to_radio::PayloadVariant::Disconnect(true)),
+    }
+}
+
+pub fn direct_text_packet(
+    to: u32,
+    text: String,
+    packet_id: u32,
+    hop_limit: u32,
+    want_ack: bool,
+) -> ToRadio {
+    ToRadio {
+        payload_variant: Some(to_radio::PayloadVariant::Packet(MeshPacket {
+            from: 0,
+            to,
+            channel: 0,
+            payload_variant: Some(mesh_packet::PayloadVariant::Decoded(Data {
+                portnum: PORT_TEXT_MESSAGE_APP,
+                payload: text.into_bytes(),
+                want_response: false,
+                dest: 0,
+                source: 0,
+                request_id: 0,
+                reply_id: 0,
+            })),
+            id: packet_id,
+            rx_time: 0,
+            rx_snr: 0.0,
+            hop_limit,
+            want_ack,
+            priority: PRIORITY_RELIABLE,
+            rx_rssi: 0,
+            via_mqtt: false,
+            hop_start: 0,
+            public_key: Vec::new(),
+        })),
+    }
+}
+
+pub fn node_key(node_num: u32) -> [u8; 6] {
+    let n = node_num.to_be_bytes();
+    [b'M', b'T', n[0], n[1], n[2], n[3]]
+}
+
+pub fn synthetic_pubkey(node_num: u32) -> [u8; 32] {
+    let mut key = [0u8; 32];
+    key[0] = b'M';
+    key[1] = b'T';
+    key[2..6].copy_from_slice(&node_num.to_be_bytes());
+    key
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn node_key_is_transport_namespaced() {
+        assert_eq!(node_key(0x1234_5678), [b'M', b'T', 0x12, 0x34, 0x56, 0x78]);
+    }
+
+    #[test]
+    fn direct_text_encodes_as_to_radio_packet() {
+        let packet = direct_text_packet(0x0102_0304, "H".to_owned(), 42, 3, true);
+        let bytes = packet.encode_to_vec();
+        let decoded = ToRadio::decode(bytes.as_slice()).unwrap();
+        let Some(to_radio::PayloadVariant::Packet(mesh)) = decoded.payload_variant else {
+            panic!("expected packet");
+        };
+        assert_eq!(mesh.to, 0x0102_0304);
+        assert_eq!(mesh.id, 42);
+        assert!(mesh.want_ack);
+        let Some(mesh_packet::PayloadVariant::Decoded(data)) = mesh.payload_variant else {
+            panic!("expected decoded payload");
+        };
+        assert_eq!(data.portnum, PORT_TEXT_MESSAGE_APP);
+        assert_eq!(data.payload, b"H");
+    }
+}

--- a/crates/bbs-meshtastic/src/session.rs
+++ b/crates/bbs-meshtastic/src/session.rs
@@ -1,0 +1,108 @@
+//! Per-node Meshtastic session state.
+
+use std::{
+    collections::HashMap,
+    time::{Duration, Instant},
+};
+
+use bbs_plugin_api::SessionId;
+
+const WORKFLOW_REPLY_DEDUP_SECS: u64 = 10;
+const MESSAGE_DEDUP_SECS: u64 = 10;
+
+#[derive(Debug)]
+pub struct SessionEntry {
+    pub session_id: SessionId,
+    pub awaiting_reply: bool,
+    pub last_workflow_reply: Option<(String, Instant)>,
+    pub last_message: Option<(String, Instant)>,
+}
+
+#[derive(Debug, Default)]
+pub struct SessionState {
+    pub my_node_num: Option<u32>,
+    pub by_node: HashMap<u32, SessionEntry>,
+    pub by_session: HashMap<SessionId, u32>,
+}
+
+impl SessionState {
+    pub fn lookup(&self, node_num: u32) -> Option<SessionId> {
+        self.by_node.get(&node_num).map(|e| e.session_id)
+    }
+
+    pub fn get_or_insert(&mut self, node_num: u32, new_id: SessionId) -> (SessionId, bool) {
+        if let Some(entry) = self.by_node.get(&node_num) {
+            return (entry.session_id, false);
+        }
+        self.by_node.insert(
+            node_num,
+            SessionEntry {
+                session_id: new_id,
+                awaiting_reply: false,
+                last_workflow_reply: None,
+                last_message: None,
+            },
+        );
+        self.by_session.insert(new_id, node_num);
+        (new_id, true)
+    }
+
+    pub fn remove_by_node(&mut self, node_num: u32) -> Option<SessionId> {
+        if let Some(entry) = self.by_node.remove(&node_num) {
+            self.by_session.remove(&entry.session_id);
+            Some(entry.session_id)
+        } else {
+            None
+        }
+    }
+
+    pub fn node_for_session(&self, session: SessionId) -> Option<u32> {
+        self.by_session.get(&session).copied()
+    }
+
+    pub fn sessions(&self) -> Vec<SessionId> {
+        self.by_session.keys().copied().collect()
+    }
+
+    pub fn set_awaiting_reply(&mut self, node_num: u32, value: bool) {
+        if let Some(entry) = self.by_node.get_mut(&node_num) {
+            entry.awaiting_reply = value;
+        }
+    }
+
+    pub fn is_awaiting_reply(&self, node_num: u32) -> bool {
+        self.by_node
+            .get(&node_num)
+            .is_some_and(|e| e.awaiting_reply)
+    }
+
+    pub fn set_last_workflow_reply(&mut self, node_num: u32, text: String) {
+        if let Some(entry) = self.by_node.get_mut(&node_num) {
+            entry.last_workflow_reply = Some((text, Instant::now()));
+        }
+    }
+
+    pub fn is_recent_workflow_reply(&self, node_num: u32, text: &str) -> bool {
+        self.by_node.get(&node_num).is_some_and(|entry| {
+            entry
+                .last_workflow_reply
+                .as_ref()
+                .is_some_and(|(reply, instant)| {
+                    reply == text
+                        && instant.elapsed() < Duration::from_secs(WORKFLOW_REPLY_DEDUP_SECS)
+                })
+        })
+    }
+
+    pub fn dedup_message(&mut self, node_num: u32, text: &str) -> bool {
+        if let Some(entry) = self.by_node.get_mut(&node_num) {
+            if let Some((last, instant)) = &entry.last_message {
+                if last == text && instant.elapsed() < Duration::from_secs(MESSAGE_DEDUP_SECS) {
+                    return true;
+                }
+            }
+            entry.last_message = Some((text.to_owned(), Instant::now()));
+        }
+        false
+    }
+}

--- a/crates/bbs-meshtastic/src/stream.rs
+++ b/crates/bbs-meshtastic/src/stream.rs
@@ -1,0 +1,307 @@
+//! Meshtastic serial/TCP stream client.
+
+use std::{io, net::SocketAddr, time::Duration};
+
+use prost::Message;
+use tokio::{
+    io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt},
+    net::TcpStream,
+    sync::mpsc,
+    time::{interval, sleep, MissedTickBehavior},
+};
+use tokio_serial::SerialPortBuilderExt;
+use tracing::{debug, info, warn};
+
+use crate::proto::{disconnect, heartbeat, want_config, FromRadio, ToRadio};
+
+const START1: u8 = 0x94;
+const START2: u8 = 0xc3;
+const MAX_PROTO_LEN: usize = 512;
+
+#[derive(Debug, Clone)]
+pub struct TcpConfig {
+    pub addr: SocketAddr,
+    pub reconnect_delay_initial: Duration,
+    pub reconnect_delay_max: Duration,
+}
+
+#[derive(Debug, Clone)]
+pub struct SerialConfig {
+    pub port: String,
+    pub baud_rate: u32,
+    pub reconnect_delay_initial: Duration,
+    pub reconnect_delay_max: Duration,
+}
+
+#[derive(Debug)]
+pub enum ClientEvent {
+    Connected,
+    Disconnected { will_retry: bool },
+    FromRadio(FromRadio),
+}
+
+pub struct MeshtasticClient {
+    cmd_tx: mpsc::Sender<ToRadio>,
+    event_rx: mpsc::Receiver<ClientEvent>,
+}
+
+impl MeshtasticClient {
+    pub fn connect_tcp(config: TcpConfig) -> Self {
+        let (cmd_tx, cmd_rx) = mpsc::channel(32);
+        let (event_tx, event_rx) = mpsc::channel(64);
+        tokio::spawn(run_tcp_worker(config, cmd_rx, event_tx));
+        Self { cmd_tx, event_rx }
+    }
+
+    pub fn connect_serial(config: SerialConfig) -> Self {
+        let (cmd_tx, cmd_rx) = mpsc::channel(32);
+        let (event_tx, event_rx) = mpsc::channel(64);
+        tokio::spawn(run_serial_worker(config, cmd_rx, event_tx));
+        Self { cmd_tx, event_rx }
+    }
+
+    pub fn sender(&self) -> mpsc::Sender<ToRadio> {
+        self.cmd_tx.clone()
+    }
+
+    pub async fn recv(&mut self) -> Option<ClientEvent> {
+        self.event_rx.recv().await
+    }
+}
+
+enum SessionOutcome {
+    Shutdown,
+    IoError(io::Error),
+}
+
+async fn run_tcp_worker(
+    config: TcpConfig,
+    mut cmd_rx: mpsc::Receiver<ToRadio>,
+    event_tx: mpsc::Sender<ClientEvent>,
+) {
+    let mut backoff = config.reconnect_delay_initial;
+    loop {
+        match attempt_tcp_session(&config, &mut cmd_rx, &event_tx).await {
+            SessionOutcome::Shutdown => break,
+            SessionOutcome::IoError(e) => {
+                warn!("meshtastic/tcp: session error: {e}");
+                let _ = event_tx
+                    .send(ClientEvent::Disconnected { will_retry: true })
+                    .await;
+                sleep(backoff).await;
+                backoff = (backoff * 2).min(config.reconnect_delay_max);
+            }
+        }
+    }
+    let _ = event_tx
+        .send(ClientEvent::Disconnected { will_retry: false })
+        .await;
+}
+
+async fn attempt_tcp_session(
+    config: &TcpConfig,
+    cmd_rx: &mut mpsc::Receiver<ToRadio>,
+    event_tx: &mpsc::Sender<ClientEvent>,
+) -> SessionOutcome {
+    let stream = match TcpStream::connect(config.addr).await {
+        Ok(s) => s,
+        Err(e) => return SessionOutcome::IoError(e),
+    };
+    let _ = stream.set_nodelay(true);
+    info!(addr = %config.addr, "meshtastic/tcp: connected");
+    let (mut reader, mut writer) = stream.into_split();
+    run_session(&mut reader, &mut writer, cmd_rx, event_tx).await
+}
+
+async fn run_serial_worker(
+    config: SerialConfig,
+    mut cmd_rx: mpsc::Receiver<ToRadio>,
+    event_tx: mpsc::Sender<ClientEvent>,
+) {
+    let mut backoff = config.reconnect_delay_initial;
+    loop {
+        match attempt_serial_session(&config, &mut cmd_rx, &event_tx).await {
+            SessionOutcome::Shutdown => break,
+            SessionOutcome::IoError(e) => {
+                warn!("meshtastic/serial: session error: {e}");
+                let _ = event_tx
+                    .send(ClientEvent::Disconnected { will_retry: true })
+                    .await;
+                sleep(backoff).await;
+                backoff = (backoff * 2).min(config.reconnect_delay_max);
+            }
+        }
+    }
+    let _ = event_tx
+        .send(ClientEvent::Disconnected { will_retry: false })
+        .await;
+}
+
+async fn attempt_serial_session(
+    config: &SerialConfig,
+    cmd_rx: &mut mpsc::Receiver<ToRadio>,
+    event_tx: &mpsc::Sender<ClientEvent>,
+) -> SessionOutcome {
+    let stream = match tokio_serial::new(&config.port, config.baud_rate).open_native_async() {
+        Ok(s) => s,
+        Err(e) => {
+            return SessionOutcome::IoError(io::Error::other(format!(
+                "could not open serial port {}: {e}",
+                config.port
+            )));
+        }
+    };
+    info!(port = %config.port, baud = config.baud_rate, "meshtastic/serial: opened");
+    let (mut reader, mut writer) = tokio::io::split(stream);
+    run_session(&mut reader, &mut writer, cmd_rx, event_tx).await
+}
+
+async fn run_session<R, W>(
+    reader: &mut R,
+    writer: &mut W,
+    cmd_rx: &mut mpsc::Receiver<ToRadio>,
+    event_tx: &mpsc::Sender<ClientEvent>,
+) -> SessionOutcome
+where
+    R: AsyncRead + Unpin,
+    W: AsyncWrite + Unpin,
+{
+    if event_tx.send(ClientEvent::Connected).await.is_err() {
+        return SessionOutcome::Shutdown;
+    }
+
+    if let Err(e) = write_to_radio(writer, &want_config(1)).await {
+        return SessionOutcome::IoError(e);
+    }
+
+    let mut heartbeats = interval(Duration::from_secs(30));
+    heartbeats.set_missed_tick_behavior(MissedTickBehavior::Delay);
+    let mut heartbeat_nonce = 1u32;
+
+    loop {
+        tokio::select! {
+            frame = read_from_radio(reader) => match frame {
+                Ok(frame) => {
+                    debug!("meshtastic: rx FromRadio");
+                    if event_tx.send(ClientEvent::FromRadio(frame)).await.is_err() {
+                        return SessionOutcome::Shutdown;
+                    }
+                }
+                Err(e) => return SessionOutcome::IoError(e),
+            },
+            cmd = cmd_rx.recv() => match cmd {
+                Some(cmd) => {
+                    debug!("meshtastic: tx ToRadio");
+                    if let Err(e) = write_to_radio(writer, &cmd).await {
+                        return SessionOutcome::IoError(e);
+                    }
+                }
+                None => {
+                    let _ = write_to_radio(writer, &disconnect()).await;
+                    return SessionOutcome::Shutdown;
+                }
+            },
+            _ = heartbeats.tick() => {
+                let hb = heartbeat(heartbeat_nonce);
+                heartbeat_nonce = heartbeat_nonce.wrapping_add(1);
+                if let Err(e) = write_to_radio(writer, &hb).await {
+                    return SessionOutcome::IoError(e);
+                }
+            }
+        }
+    }
+}
+
+pub fn wrap_to_radio(msg: &ToRadio) -> Vec<u8> {
+    let payload = msg.encode_to_vec();
+    let len = payload.len().min(u16::MAX as usize) as u16;
+    let mut out = Vec::with_capacity(4 + payload.len());
+    out.push(START1);
+    out.push(START2);
+    out.extend_from_slice(&len.to_be_bytes());
+    out.extend_from_slice(&payload);
+    out
+}
+
+async fn write_to_radio<W: AsyncWrite + Unpin>(writer: &mut W, msg: &ToRadio) -> io::Result<()> {
+    let wire = wrap_to_radio(msg);
+    if wire.len() - 4 > MAX_PROTO_LEN {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("ToRadio protobuf exceeds {MAX_PROTO_LEN} bytes"),
+        ));
+    }
+    writer.write_all(&wire).await
+}
+
+pub async fn read_from_radio<R: AsyncRead + Unpin>(reader: &mut R) -> io::Result<FromRadio> {
+    loop {
+        let mut b = [0u8; 1];
+        reader.read_exact(&mut b).await?;
+        if b[0] != START1 {
+            continue;
+        }
+        reader.read_exact(&mut b).await?;
+        if b[0] == START2 {
+            break;
+        }
+    }
+
+    let mut len_bytes = [0u8; 2];
+    reader.read_exact(&mut len_bytes).await?;
+    let len = u16::from_be_bytes(len_bytes) as usize;
+    if len > MAX_PROTO_LEN {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("FromRadio protobuf length {len} exceeds {MAX_PROTO_LEN}"),
+        ));
+    }
+
+    let mut payload = vec![0u8; len];
+    reader.read_exact(&mut payload).await?;
+    FromRadio::decode(payload.as_slice())
+        .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e.to_string()))
+}
+
+#[cfg(test)]
+mod tests {
+    use tokio::io::AsyncWriteExt;
+
+    use super::*;
+    use crate::proto::{from_radio, MyNodeInfo};
+
+    #[test]
+    fn wrap_uses_meshtastic_header() {
+        let wire = wrap_to_radio(&want_config(7));
+        assert_eq!(wire[0], START1);
+        assert_eq!(wire[1], START2);
+        assert_eq!(
+            u16::from_be_bytes([wire[2], wire[3]]) as usize,
+            wire.len() - 4
+        );
+    }
+
+    #[tokio::test]
+    async fn read_skips_noise_until_header() {
+        let msg = FromRadio {
+            id: 1,
+            payload_variant: Some(from_radio::PayloadVariant::MyInfo(MyNodeInfo {
+                my_node_num: 123,
+                reboot_count: 0,
+                min_app_version: 0,
+                device_id: Vec::new(),
+                pio_env: String::new(),
+                nodedb_count: 0,
+            })),
+        };
+        let payload = msg.encode_to_vec();
+        let mut bytes = vec![0, 1, 2, START1, 0, START1, START2];
+        bytes.extend_from_slice(&(payload.len() as u16).to_be_bytes());
+        bytes.extend_from_slice(&payload);
+
+        let (mut tx, mut rx) = tokio::io::duplex(128);
+        tx.write_all(&bytes).await.unwrap();
+        let decoded = read_from_radio(&mut rx).await.unwrap();
+        assert_eq!(decoded.id, 1);
+    }
+}

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -266,10 +266,6 @@ your wiring differs from the standard layout):
 
 ## `[plugins.meshtastic]` - Meshtastic transport (only if `transport-meshtastic` feature enabled)
 
-> **Status:** codec not yet implemented. The config section, feature flag, setup
-> wizard, and installer are wired up and ready. Set `enabled = false` (the
-> default) until the Meshtastic codec ships.
-
 Meshtastic is a separate radio protocol from MeshCore. Both can run simultaneously
 on the same BBS — each talks to its own radio device. Meshtastic radios connect
 either via USB serial or TCP to a running `meshtasticd` instance.
@@ -280,7 +276,14 @@ either via USB serial or TCP to a running `meshtasticd` instance.
 |--------------------|--------|------------|----------|-----------------------------------------------------|
 | `enabled`          | bool   | `false`    | no       | Whether to start the Meshtastic transport           |
 | `connection_type`  | enum   | `"serial"` | no       | How to reach the radio: `"serial"` or `"tcp"`      |
-| `command_prefix`   | string | `""`       | no       | Optional single-character prefix for BBS commands   |
+| `command_prefix`   | string | (unset)    | no       | Optional single-character prefix for BBS commands   |
+| `welcome_message`  | string | see default | no      | Greeting sent to a node on first contact            |
+| `max_payload_bytes`| integer| `220`      | no       | Maximum UTF-8 bytes per outbound text packet        |
+| `node_credential_ttl_days` | integer | `14` | no | Days a node auto-login credential remains valid (`0` disables) |
+| `hop_limit`        | integer| `3`        | no       | Hop limit for outbound replies and notifications    |
+| `want_ack`         | bool   | `true`     | no       | Request Meshtastic radio-layer acknowledgements     |
+| `reconnect_delay_initial_ms` | integer | `1000` | no | Initial reconnect delay after disconnect           |
+| `reconnect_delay_max_ms`     | integer | `60000`| no | Maximum reconnect delay after repeated failures    |
 
 ### Serial mode (`connection_type = "serial"`)
 

--- a/install.sh
+++ b/install.sh
@@ -607,8 +607,7 @@ if [[ "$_meshtastic_enabled" == true ]]; then
     echo "─── Meshtastic ─────────────────────────────────────────────────────────────"
     echo
     info "Meshtastic transport enabled."
-    warn "Note: the Meshtastic codec is not yet implemented."
-    warn "Set 'enabled = false' in [plugins.meshtastic] until the codec ships."
+    info "No companion service is required. USB serial talks directly to the radio; TCP connects to meshtasticd."
     echo
 fi
 


### PR DESCRIPTION
## Summary
- add a native Meshtastic transport plugin supporting serial and TCP connections
- implement minimal Meshtastic protobuf framing/codec, reconnect handling, heartbeats, and direct text replies
- handle direct-message text packets and NodeInfo adverts while ignoring channel/broadcast/non-text traffic
- document Meshtastic config options and update installer messaging

## Validation
- cargo fmt
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test --workspace --all-features
- cargo doc

## Notes
- Hardware smoke testing against a HelTec V3 / meshtasticd is still needed.
- Self-location/GPS advertisement parity with MeshCore is left for a follow-up.