### PR TITLE
fix(bug-08): prevent TOCTOU race in set_enabled(true)

### DIFF
--- a/crates/bbs-plugin-api/src/registry.rs
+++ b/crates/bbs-plugin-api/src/registry.rs
@@ -59,6 +59,13 @@ pub enum PluginState {
     Running,
     /// Configured but not started (not yet launched or cleanly stopped).
     Stopped,
+    /// The plugin is being started — the spawn is in progress.
+    ///
+    /// This is a transitional state set under the mutex *before* the lock is
+    /// released for the spawn attempt.  A concurrent `set_enabled(true)` call
+    /// that sees this state will bail out rather than spawning a second
+    /// orphaned child process.
+    Starting,
     /// The process exited unexpectedly.
     Crashed {
         /// Human-readable exit reason (exit code, signal, etc.).

--- a/crates/bbs-process-transport/src/manager.rs
+++ b/crates/bbs-process-transport/src/manager.rs
@@ -415,8 +415,12 @@ impl PluginRegistryApi for ProcessPluginManager {
 
         m.config.enabled = enabled;
 
-        if enabled && m.transport.is_none() {
-            // Start it.
+        if enabled && m.transport.is_none() && m.state != PluginState::Starting {
+            // Mark the plugin as Starting *before* releasing the lock so that
+            // any concurrent set_enabled(true) call sees the transitional state
+            // and bails out without spawning a second orphaned child process
+            // (TOCTOU fix).
+            m.state = PluginState::Starting;
             let log_buffer = Arc::clone(&m.log_buffer);
             let config = m.config.clone();
             drop(plugins);
@@ -432,9 +436,8 @@ impl PluginRegistryApi for ProcessPluginManager {
                 Err(e) => {
                     let mut plugins = self.plugins.lock().await;
                     if let Some(m) = plugins.get_mut(name) {
-                        m.state = PluginState::Crashed {
-                            reason: e.to_string(),
-                        };
+                        // Roll back to Stopped so a future call can retry.
+                        m.state = PluginState::Stopped;
                     }
                     return Err(e);
                 }

--- a/crates/bbs-process-transport/tests/process.rs
+++ b/crates/bbs-process-transport/tests/process.rs
@@ -33,9 +33,6 @@ use bbs_process_transport::ProcessTransport;
 /// Path to the compiled echo_plugin binary (injected by Cargo at test time).
 const ECHO_PLUGIN: &str = env!("CARGO_BIN_EXE_echo_plugin");
 
-/// How long to wait for the plugin to emit its scripted sequence after start.
-const SETTLE: Duration = Duration::from_millis(250);
-
 fn scripted_config(name: &str) -> ProcessPluginConfig {
     ProcessPluginConfig {
         name: name.to_owned(),
@@ -58,13 +55,24 @@ fn hold_config(name: &str) -> ProcessPluginConfig {
     }
 }
 
-/// Start a transport, give the plugin time to emit its messages, and return
-/// the transport for further inspection / stopping.
+/// Start a transport, wait until `min_commands` have been dispatched to
+/// `host` (or the 10-second deadline passes), then return the transport.
 async fn start(config: ProcessPluginConfig, host: Arc<MockHost>) -> ProcessTransport {
-    let host: Arc<dyn Host> = host;
-    let t = ProcessTransport::init(config, host).await.unwrap();
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(10);
+    let mock = Arc::clone(&host);
+    let t = ProcessTransport::init(config, host as Arc<dyn Host>)
+        .await
+        .unwrap();
     t.start().await.unwrap();
-    tokio::time::sleep(SETTLE).await;
+    // Poll until at least one command arrives (scripted plugin always sends
+    // at least one recv before closing) so tests don't race against the child
+    // process startup time.
+    loop {
+        if !mock.commands_received().is_empty() || tokio::time::Instant::now() >= deadline {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(25)).await;
+    }
     t
 }
 
@@ -87,7 +95,17 @@ async fn scripted_plugin_session() {
 
     let transport = start(scripted_config("scripted-session"), Arc::clone(&host)).await;
 
-    let cmds = host.commands_received();
+    // The scripted plugin sends two recv messages; poll until both arrive.
+    let cmds = {
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(10);
+        loop {
+            let c = host.commands_received();
+            if c.len() >= 2 || tokio::time::Instant::now() >= deadline {
+                break c;
+            }
+            tokio::time::sleep(Duration::from_millis(25)).await;
+        }
+    };
     assert_eq!(cmds.len(), 2, "expected exactly 2 commands; got {cmds:?}");
 
     // First recv: "help" → Command::Help
@@ -135,8 +153,8 @@ async fn awaiting_reply_state_machine() {
 
     let transport = start(scripted_config("await-test"), Arc::clone(&host)).await;
 
-    // Poll up to 2 s so the test stays stable under parallel execution where the
-    // OS scheduler may not give the echo_plugin child enough CPU within SETTLE.
+    // Poll up to 10 s so the test stays stable under parallel execution where the
+    // OS scheduler may not give the echo_plugin child CPU immediately.
     let cmds = {
         let deadline = tokio::time::Instant::now() + Duration::from_secs(10);
         loop {
@@ -237,10 +255,21 @@ async fn session_ended_after_plugin_close() {
     let session_id = cmds[0].0;
 
     // After close the session should be gone from the map → notify Dropped.
-    let outcome = transport
-        .notify(session_id, Notification::Text("late mail".to_owned()))
-        .await
-        .unwrap();
+    // Poll until the transport processes the close event; the scripted plugin
+    // sends close immediately after its two recv messages.
+    let outcome = {
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(10);
+        loop {
+            let o = transport
+                .notify(session_id, Notification::Text("late mail".to_owned()))
+                .await
+                .unwrap();
+            if matches!(o, NotifyOutcome::Dropped) || tokio::time::Instant::now() >= deadline {
+                break o;
+            }
+            tokio::time::sleep(Duration::from_millis(25)).await;
+        }
+    };
 
     assert!(
         matches!(outcome, NotifyOutcome::Dropped),


### PR DESCRIPTION
## Summary

- Add `PluginState::Starting` variant to `bbs-plugin-api` as a transitional state
- In `set_enabled(true)`, set `m.state = PluginState::Starting` **while still holding the lock** before dropping it and calling `spawn_transport`
- A concurrent `set_enabled(true)` call now sees `Starting` and returns early, preventing two spawns racing to create an orphaned child process
- On spawn failure, state is reset to `Stopped` so callers can retry

Also fixes a pre-existing flaky-test hazard in the process integration tests:
`scripted_plugin_session` and `session_ended_after_plugin_close` used a fixed 250 ms `SETTLE` sleep that was too short under parallel execution. Replaced with deadline-based polling (up to 10 s) matching the pattern already used by `awaiting_reply_state_machine` and `notify_delivers_to_open_session`.

## Test plan

- [ ] `cargo test -p bbs-process-transport` passes (all 25 tests: 17 unit + 8 integration)
- [ ] `cargo test --workspace` passes
- [ ] `cargo clippy --workspace -- -D warnings` clean
- [ ] Manually verify two concurrent `set_enabled(true)` calls only start one process

🤖 Generated with [Claude Code](https://claude.com/claude-code)