### PR TITLE
fix(bug-03): update plugin state when process exits cleanly

### DIFF
--- a/crates/bbs-process-transport/src/manager.rs
+++ b/crates/bbs-process-transport/src/manager.rs
@@ -17,7 +17,7 @@ use tokio::process::Command as TokioCommand;
 use tokio::sync::{mpsc, Mutex};
 use tracing::{info, warn};
 
-use crate::transport::ProcessTransport;
+use crate::transport::{ExitEvent, ProcessTransport};
 
 const LOG_RING_CAP: usize = 500;
 const LOG_TAIL: usize = 50;
@@ -236,18 +236,17 @@ impl ProcessPluginManager {
 
         let transport = ProcessTransport::new(config.clone(), Arc::clone(&self.host));
 
-        // Wire up crash-restart BEFORE start() so there is no window where
-        // a very-fast crash could go unnoticed.
-        if config.restart_on_crash {
-            if let Some(crash_rx) = transport.take_crash_receiver() {
-                tokio::spawn(crash_restart_loop(
-                    name.clone(),
-                    crash_rx,
-                    config.restart_delay_secs,
-                    Arc::clone(&self.plugins),
-                    Arc::clone(&self.host),
-                ));
-            }
+        // Wire up the exit-handling loop BEFORE start() so there is no window
+        // where a very-fast exit could go unnoticed.
+        if let Some(exit_rx) = transport.take_exit_receiver() {
+            tokio::spawn(plugin_exit_loop(
+                name.clone(),
+                exit_rx,
+                config.restart_on_crash,
+                config.restart_delay_secs,
+                Arc::clone(&self.plugins),
+                Arc::clone(&self.host),
+            ));
         }
 
         transport
@@ -514,66 +513,103 @@ impl PluginRegistryApi for ProcessPluginManager {
     }
 }
 
-// ── Crash restart loop ────────────────────────────────────────────────────────
+// ── Plugin exit loop ───────────────────────────────────────────────────────
 
-/// Spawned once per plugin that has `restart_on_crash = true`.
+/// Spawned once per plugin that has been started.
 ///
-/// Receives a crash signal from `ProcessTransport`'s watcher task, waits the
-/// configured delay, respawns the process, and updates the manager's state.
-/// When the new process is running its own crash channel replaces `rx` so the
-/// loop continues watching the new child.  The loop exits when:
+/// Receives an [`ExitEvent`] from `ProcessTransport`'s watcher task and acts:
 ///
-/// - The sender is dropped (plugin was removed or disabled)
-/// - A respawn attempt fails (state is set to `Crashed`)
-async fn crash_restart_loop(
+/// - [`ExitEvent::Crash`]: waits the configured delay, respawns the process,
+///   and updates state.  The loop then watches the new child via its fresh
+///   receiver.  The loop exits when:
+///   - The sender is dropped (plugin was removed or disabled)
+///   - A respawn attempt fails (state is set to `Crashed`)
+///
+/// - [`ExitEvent::Stopped`]: updates state to `PluginState::Stopped` and
+///   exits.  The plugin exited cleanly or with `restart_on_crash = false`.
+async fn plugin_exit_loop(
     name: String,
-    mut rx: mpsc::Receiver<()>,
+    mut rx: mpsc::Receiver<ExitEvent>,
+    restart_on_crash: bool,
     delay_secs: u64,
     plugins: Arc<Mutex<HashMap<String, ManagedPlugin>>>,
     host: Arc<dyn Host>,
 ) {
-    while rx.recv().await.is_some() {
-        warn!(plugin = %name, delay_secs, "crashed — restarting");
-        tokio::time::sleep(Duration::from_secs(delay_secs)).await;
-
-        let (config, _log_buffer) = {
-            let map = plugins.lock().await;
-            let Some(m) = map.get(&name) else { return };
-            (m.config.clone(), Arc::clone(&m.log_buffer))
-        };
-
-        let new_transport = ProcessTransport::new(config, Arc::clone(&host));
-        // Take the crash receiver for the new process before it starts.
-        let new_rx = new_transport.take_crash_receiver();
-
-        match new_transport.start().await {
-            Ok(()) => {
-                {
-                    let mut map = plugins.lock().await;
-                    if let Some(m) = map.get_mut(&name) {
-                        m.transport = Some(new_transport);
-                        m.state = PluginState::Running;
-                        m.restart_count += 1;
-                    }
-                }
-                info!(plugin = %name, "restarted after crash");
-                // Switch to watching the new process.
-                match new_rx {
-                    Some(new_rx) => rx = new_rx,
-                    None => break, // restart_on_crash was false on new config — stop looping
-                }
-            }
-            Err(e) => {
-                warn!(plugin = %name, error = %e, "restart failed");
+    while let Some(event) = rx.recv().await {
+        match event {
+            ExitEvent::Stopped => {
+                // Clean exit or restart_on_crash=false — mark as Stopped.
+                info!(plugin = %name, "process stopped; updating state to Stopped");
                 let mut map = plugins.lock().await;
                 if let Some(m) = map.get_mut(&name) {
-                    m.transport = None;
-                    m.state = PluginState::Crashed {
-                        reason: e.to_string(),
-                    };
+                    // Only update if still Running — don't clobber Disabled or
+                    // a state already set by an explicit stop/restart call.
+                    if m.state == PluginState::Running {
+                        m.state = PluginState::Stopped;
+                        m.transport = None;
+                    }
                 }
                 break;
             }
-        }
+
+            ExitEvent::Crash => {
+                // restart_on_crash=true and non-zero exit.
+                if !restart_on_crash {
+                    // Defensive: this variant should only arrive when
+                    // restart_on_crash is true, but guard anyway.
+                    let mut map = plugins.lock().await;
+                    if let Some(m) = map.get_mut(&name) {
+                        if m.state == PluginState::Running {
+                            m.state = PluginState::Stopped;
+                            m.transport = None;
+                        }
+                    }
+                    break;
+                }
+
+                warn!(plugin = %name, delay_secs, "crashed — restarting");
+                tokio::time::sleep(Duration::from_secs(delay_secs)).await;
+
+                let (config, _log_buffer) = {
+                    let map = plugins.lock().await;
+                    let Some(m) = map.get(&name) else { return };
+                    (m.config.clone(), Arc::clone(&m.log_buffer))
+                };
+
+                let new_transport = ProcessTransport::new(config, Arc::clone(&host));
+                // Take the crash receiver for the new process before it starts.
+                let new_rx = new_transport.take_exit_receiver();
+
+                match new_transport.start().await {
+                    Ok(()) => {
+                        {
+                            let mut map = plugins.lock().await;
+                            if let Some(m) = map.get_mut(&name) {
+                                m.transport = Some(new_transport);
+                                m.state = PluginState::Running;
+                                m.restart_count += 1;
+                            }
+                        }
+                        info!(plugin = %name, "restarted after crash");
+                        // Switch to watching the new process.
+                        match new_rx {
+                            Some(new_rx) => rx = new_rx,
+                            None => break,
+                        }
+                    }
+                    Err(e) => {
+                        warn!(plugin = %name, error = %e, "restart failed");
+                        let mut map = plugins.lock().await;
+                        if let Some(m) = map.get_mut(&name) {
+                            m.transport = None;
+                            m.state = PluginState::Crashed {
+                                reason: e.to_string(),
+                            };
+                        }
+                        break;
+                    }
+                }
+            } // end ExitEvent::Crash
+        } // end match event
     }
 }

--- a/crates/bbs-process-transport/src/transport.rs
+++ b/crates/bbs-process-transport/src/transport.rs
@@ -24,6 +24,22 @@ use tracing::{debug, info, warn};
 
 use crate::ipc::{HostMsg, PluginMsg};
 
+// -- Exit event ----------------------------------------------------------------
+
+/// Signals sent from the process-watcher task to the manager's exit-handling loop.
+///
+/// The channel always exists (regardless of `restart_on_crash`) so the manager
+/// can learn about *any* process exit and keep `PluginState` accurate.
+#[derive(Debug)]
+pub(crate) enum ExitEvent {
+    /// The process exited with a non-zero code and `restart_on_crash` is true.
+    /// The manager should restart the plugin.
+    Crash,
+    /// The process exited cleanly (code 0) **or** `restart_on_crash` is false.
+    /// The manager should transition the plugin state to `Stopped`.
+    Stopped,
+}
+
 // ── Session state ─────────────────────────────────────────────────────────────
 
 struct SessionEntry {
@@ -64,11 +80,11 @@ pub struct ProcessTransport {
     /// Version string reported by the plugin in its `ready` message.
     plugin_version: Arc<std::sync::Mutex<Option<String>>>,
     shutdown_tx: watch::Sender<bool>,
-    /// Fires `()` when the child exits with a non-zero code (crash).
-    /// Only populated when `config.restart_on_crash` is true.
-    crash_tx: Option<mpsc::Sender<()>>,
-    /// Taken once by the manager to wire up the auto-restart loop.
-    crash_rx: std::sync::Mutex<Option<mpsc::Receiver<()>>>,
+    /// Fires an [`ExitEvent`] whenever the child process exits.
+    /// Always populated so both crash and clean exits are reported to the manager.
+    exit_tx: mpsc::Sender<ExitEvent>,
+    /// Taken once by the manager to wire up the exit-handling loop.
+    exit_rx: std::sync::Mutex<Option<mpsc::Receiver<ExitEvent>>>,
 }
 
 impl ProcessTransport {
@@ -76,12 +92,7 @@ impl ProcessTransport {
         // Leak the name string once to get a &'static str.
         // This is a deliberate one-time allocation per plugin name.
         let transport_name: &'static str = Box::leak(config.name.clone().into_boxed_str());
-        let (crash_tx, crash_rx) = if config.restart_on_crash {
-            let (tx, rx) = mpsc::channel(4);
-            (Some(tx), Some(rx))
-        } else {
-            (None, None)
-        };
+        let (exit_tx, exit_rx) = mpsc::channel(4);
         Self {
             transport_name,
             config,
@@ -91,17 +102,17 @@ impl ProcessTransport {
             payload_limit: Arc::new(AtomicUsize::new(0)),
             plugin_version: Arc::new(std::sync::Mutex::new(None)),
             shutdown_tx: watch::channel(false).0,
-            crash_tx,
-            crash_rx: std::sync::Mutex::new(crash_rx),
+            exit_tx,
+            exit_rx: std::sync::Mutex::new(Some(exit_rx)),
         }
     }
 
-    /// Take the crash receiver so the manager can drive the auto-restart loop.
+    /// Take the exit receiver so the manager can drive the exit-handling loop.
     ///
-    /// Returns `None` when `restart_on_crash` is false or when already taken.
+    /// Returns `None` when already taken.
     /// Must be called before [`Plugin::start`].
-    pub(crate) fn take_crash_receiver(&self) -> Option<mpsc::Receiver<()>> {
-        self.crash_rx.lock().expect("crash_rx poisoned").take()
+    pub(crate) fn take_exit_receiver(&self) -> Option<mpsc::Receiver<ExitEvent>> {
+        self.exit_rx.lock().expect("exit_rx poisoned").take()
     }
 
     /// Version string reported by the plugin in its `ready` message.
@@ -262,10 +273,14 @@ impl Plugin for ProcessTransport {
             }
         });
 
-        // Process watcher task — detects crashes and notifies the manager.
+        // Process watcher task — detects exit and notifies the manager.
+        //
+        // Always fires an ExitEvent so the manager can update PluginState:
+        //   - non-zero exit + restart_on_crash=true  -> ExitEvent::Crash
+        //   - all other exits (clean or no-restart)  -> ExitEvent::Stopped
         let plugin_name3 = self.config.name.clone();
         let restart = self.config.restart_on_crash;
-        let crash_tx = self.crash_tx.clone();
+        let exit_tx = self.exit_tx.clone();
         tokio::spawn(async move {
             match child.wait().await {
                 Ok(status) => {
@@ -274,15 +289,18 @@ impl Plugin for ProcessTransport {
                             plugin = %plugin_name3,
                             "process exited with {status} — notifying manager for restart"
                         );
-                        // Signal the crash-restart loop in ProcessPluginManager.
-                        if let Some(tx) = crash_tx {
-                            let _ = tx.send(()).await;
-                        }
+                        let _ = exit_tx.send(ExitEvent::Crash).await;
                     } else {
                         info!(plugin = %plugin_name3, "process exited with {status}");
+                        let _ = exit_tx.send(ExitEvent::Stopped).await;
                     }
                 }
-                Err(e) => warn!(plugin = %plugin_name3, "wait() error: {e}"),
+                Err(e) => {
+                    warn!(plugin = %plugin_name3, "wait() error: {e}");
+                    // Treat a wait error as a clean stop so the manager does not
+                    // leave the plugin stuck in Running state forever.
+                    let _ = exit_tx.send(ExitEvent::Stopped).await;
+                }
             }
         });
 


### PR DESCRIPTION
## Summary

- Introduce `ExitEvent` enum (`Crash` | `Stopped`) in `bbs-process-transport` to carry exit-type information from the watcher task to the manager
- The exit channel is now unconditionally created (was conditional on `restart_on_crash`) so *every* process exit is reported
- Replace `crash_restart_loop` with `plugin_exit_loop` that handles both variants: `Crash` triggers the existing restart logic; `Stopped` transitions `PluginState` to `Stopped` and clears the transport reference
- Previously, a clean exit (code 0) or any exit when `restart_on_crash = false` left `PluginState` stuck at `Running` indefinitely

## Root cause

In `transport.rs` the watcher task only sent on the crash channel when `restart && !status.success()`. All other exit paths were silently ignored, leaving `ManagedPlugin.state = PluginState::Running` even after the process died.

## Test plan

- [x] `cargo test -p bbs-process-transport` -- all 17 unit tests pass (pre-existing `scripted_plugin_session` integration test failure is unrelated to this change and was failing before this PR)
- [x] Pre-commit checks pass (fmt, clippy, full test suite, doc build)
- [ ] Manual: start a plugin with `restart_on_crash = false`, let it exit cleanly, verify `state: stopped` in plugin list
- [ ] Manual: start a plugin with `restart_on_crash = false`, let it crash, verify `state: stopped` (not stuck at `running`)

Generated with Claude Code