### PR TITLE
fix(bug-05): use active_sid for mesh_node_bind after session refresh

### DIFF
--- a/crates/bbs-mesh/src/transport.rs
+++ b/crates/bbs-mesh/src/transport.rs
@@ -783,6 +783,11 @@ async fn dispatch_message(
     // On UnknownSession (e.g. server restarted while the transport retained a
     // stale session ID), evict the stale mapping, mint a fresh session, and
     // retry the command once with the new ID.
+    //
+    // `active_sid` tracks whichever session ID was actually used to process the
+    // command so that subsequent credential operations (mesh_node_bind) target
+    // the correct — potentially refreshed — session.
+    let mut active_sid = session;
     let response = match host.process_command(session, cmd.clone()).await {
         Ok(r) => r,
         Err(HostError::UnknownSession(stale)) => {
@@ -802,6 +807,8 @@ async fn dispatch_message(
                 .lock()
                 .expect("state mutex poisoned")
                 .get_or_insert(sender_prefix, fresh);
+            // Track the fresh session so credential operations below use it.
+            active_sid = fresh_sid;
             // Attempt auto-login on the refreshed session before replaying the command.
             if node_credential_ttl_days > 0 {
                 if let Err(e) = host
@@ -829,8 +836,8 @@ async fn dispatch_message(
     if node_credential_ttl_days > 0 {
         match &response {
             Response::LoggedIn { .. } => {
-                if let Err(e) = host.mesh_node_bind(session, sender_prefix).await {
-                    warn!(?session, "mesh: node_bind error: {e}");
+                if let Err(e) = host.mesh_node_bind(active_sid, sender_prefix).await {
+                    warn!(?active_sid, "mesh: node_bind error: {e}");
                 }
             }
             Response::LoggedOut => {


### PR DESCRIPTION
## Summary

- Fixes stale session ID used in `mesh_node_bind` after server-restart eviction
- When the server restarts and the mesh transport holds a stale session, `dispatch_message` now tracks the refreshed session ID in `active_sid`
- Credential binding and node-bind operations below the eviction block use `active_sid` instead of the original stale `session`

## Root cause

`dispatch_message` evicted the stale session and minted a fresh one via `get_or_insert`, but the subsequent `mesh_node_bind` call still referenced the original `session` variable. This caused credential binding to silently fail, leaving the refreshed session without its auto-login credentials.

## Test plan
- [ ] Register a node, restart the BBS server, send a message from the node — verify auto-login succeeds and binding is applied to the new session
- [ ] Confirm existing mesh unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)