### PR TITLE
fix(bug-13): assert in wrap_payload when payload exceeds u16::MAX bytes

### DIFF
--- a/crates/meshcore-companion/src/frame.rs
+++ b/crates/meshcore-companion/src/frame.rs
@@ -558,6 +558,12 @@ pub fn encode_outbound(frame: &OutboundFrame) -> Vec<u8> {
 }
 
 fn wrap_payload(payload: &[u8]) -> Vec<u8> {
+    assert!(
+        payload.len() <= u16::MAX as usize,
+        "wrap_payload: payload length {} exceeds u16::MAX (65535); \
+         the frame header can only encode a 2-byte length",
+        payload.len()
+    );
     let mut wire = Vec::with_capacity(3 + payload.len());
     wire.push(FRAME_INBOUND_PREFIX);
     wire.extend_from_slice(&(payload.len() as u16).to_le_bytes());

--- a/crates/meshcore-companion/tests/codec.rs
+++ b/crates/meshcore-companion/tests/codec.rs
@@ -594,3 +594,21 @@ fn strip_then_decode_curr_time() {
     let frame = decode_inbound(stripped).unwrap();
     assert_eq!(frame, InboundFrame::CurrTime { unix_time: t });
 }
+
+// ── wrap_payload overflow guard ───────────────────────────────────────────────
+
+/// `encode_outbound` (via `wrap_payload`) must panic with a clear message when
+/// the serialised payload exceeds `u16::MAX` bytes rather than silently
+/// truncating the length field (BUG-13).
+#[test]
+#[should_panic(expected = "payload length")]
+fn encode_raw_oversized_payload_panics() {
+    // Build a Raw frame whose body is 65_536 bytes (u16::MAX + 1).
+    // The 1-byte command code + body puts the total payload at 65_537 bytes,
+    // which cannot be encoded in the 2-byte length field.
+    let oversized_body = vec![0u8; u16::MAX as usize + 1];
+    let _ = encode_outbound(&OutboundFrame::Raw {
+        code: 0xFF,
+        body: oversized_body,
+    });
+}


### PR DESCRIPTION
## Summary

- Adds an `assert!` in `wrap_payload` that panics with a clear diagnostic message when the serialized payload length exceeds `u16::MAX` (65535) bytes
- Adds a `#[should_panic]` test that encodes an oversized `Raw` frame to confirm the guard fires
- Prevents silent length truncation that would produce malformed frames rejected by remote peers

## Root cause

`encode_outbound` cast `payload.len()` to `u16` without checking for overflow. Payloads larger than 65535 bytes silently produced a frame with a wrong length field, causing remote peers to misparse subsequent frames.

## Test plan
- [ ] `encode_raw_oversized_payload_panics` test passes (`#[should_panic]`)
- [ ] Normal-sized frames encode/decode correctly (existing codec tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)