### PR TITLE
fix(bug-11): use unbounded stdin channel to prevent async send blocking

### DIFF
--- a/crates/bbs-process-transport/src/transport.rs
+++ b/crates/bbs-process-transport/src/transport.rs
@@ -57,7 +57,11 @@ pub struct ProcessTransport {
     config: ProcessPluginConfig,
     host: Arc<dyn Host>,
     /// Sender for JSON lines to the child's stdin.  Set in `start()`.
-    stdin_tx: OnceLock<mpsc::Sender<String>>,
+    ///
+    /// Unbounded so that callers are never blocked waiting for the child's
+    /// stdin writer to drain.  Back-pressure from a slow process manifests as
+    /// growing memory rather than a blocked async task.
+    stdin_tx: OnceLock<mpsc::UnboundedSender<String>>,
     sessions: Arc<Mutex<SessionMap>>,
     /// 0 = unlimited; set from the plugin's `ready` message.
     payload_limit: Arc<AtomicUsize>,
@@ -116,7 +120,7 @@ impl ProcessTransport {
     /// Spawn the child and return it along with the stdin sender channel.
     fn spawn_child(
         config: &ProcessPluginConfig,
-    ) -> Result<(Child, mpsc::Sender<String>), PluginError> {
+    ) -> Result<(Child, mpsc::UnboundedSender<String>), PluginError> {
         let mut cmd = TokioCommand::new(&config.command);
         cmd.args(&config.args)
             .stdin(std::process::Stdio::piped())
@@ -132,7 +136,10 @@ impl ProcessTransport {
         })?;
 
         let stdin = child.stdin.take().expect("stdin piped");
-        let (tx, mut rx) = mpsc::channel::<String>(256);
+        // Use an unbounded channel so the caller is never blocked waiting for
+        // the child's stdin writer to drain (BUG-11).  The writer task owns
+        // the receiver and drains it at the speed of the child process.
+        let (tx, mut rx) = mpsc::unbounded_channel::<String>();
 
         // Dedicated writer task: reads from the channel and writes to stdin.
         tokio::spawn(async move {
@@ -294,7 +301,7 @@ impl Plugin for ProcessTransport {
         let _ = self.shutdown_tx.send(true);
         if let Some(tx) = self.stdin_tx.get() {
             if let Ok(msg) = serde_json::to_string(&HostMsg::Shutdown) {
-                let _ = tx.send(msg).await;
+                let _ = tx.send(msg);
             }
         }
         Ok(())
@@ -327,8 +334,10 @@ impl TransportEngine for ProcessTransport {
             hide_input: false,
         };
         match serde_json::to_string(&msg) {
-            Ok(line) => match tx.try_send(line) {
+            Ok(line) => match tx.send(line) {
                 Ok(()) => Ok(NotifyOutcome::Delivered),
+                // UnboundedSender::send only fails when the receiver is dropped
+                // (i.e. the writer task exited because the process died).
                 Err(_) => Ok(NotifyOutcome::Dropped),
             },
             Err(e) => Ok(NotifyOutcome::PermanentFailure(e.to_string())),
@@ -345,7 +354,7 @@ async fn handle_plugin_msg(
     transport_name: &'static str,
     payload_limit: &Arc<AtomicUsize>,
     plugin_version: &Arc<std::sync::Mutex<Option<String>>>,
-    stdin_tx: &mpsc::Sender<String>,
+    stdin_tx: &mpsc::UnboundedSender<String>,
 ) {
     let msg: PluginMsg = match serde_json::from_str(raw) {
         Ok(m) => m,
@@ -384,7 +393,7 @@ async fn handle_plugin_msg(
                 Err(e) => {
                     warn!(transport = transport_name, conn = %id, "create_session failed: {e}");
                     // Kick the connection so the plugin doesn't expect IPC responses.
-                    send_kick(stdin_tx, &id).await;
+                    send_kick(stdin_tx, &id);
                 }
             }
         }
@@ -420,7 +429,7 @@ async fn handle_plugin_msg(
             if let Some(mut text) = response.render() {
                 let limit = payload_limit.load(Ordering::Relaxed);
                 text = truncate_to_limit(text, limit);
-                send_text(stdin_tx, &id, text, hide_input).await;
+                send_text(stdin_tx, &id, text, hide_input);
             }
         }
 
@@ -442,21 +451,21 @@ async fn handle_plugin_msg(
     }
 }
 
-async fn send_text(tx: &mpsc::Sender<String>, id: &str, text: String, hide_input: bool) {
+fn send_text(tx: &mpsc::UnboundedSender<String>, id: &str, text: String, hide_input: bool) {
     let msg = HostMsg::Send {
         id: id.to_owned(),
         text,
         hide_input,
     };
     if let Ok(line) = serde_json::to_string(&msg) {
-        let _ = tx.send(line).await;
+        let _ = tx.send(line);
     }
 }
 
-async fn send_kick(tx: &mpsc::Sender<String>, id: &str) {
+fn send_kick(tx: &mpsc::UnboundedSender<String>, id: &str) {
     let msg = HostMsg::Kick { id: id.to_owned() };
     if let Ok(line) = serde_json::to_string(&msg) {
-        let _ = tx.send(line).await;
+        let _ = tx.send(line);
     }
 }
 


### PR DESCRIPTION
## Summary

- Replaces `mpsc::channel(256)` with `mpsc::unbounded_channel()` for the stdin writer channel
- Converts `send_text` and `send_kick` from `async fn` (blocking on `.await`) to sync `fn` (non-blocking `.send()`)
- Updates `stop()` and `notify()` to use sync send
- Removes potential task stall: callers were previously blocked waiting for a slow child process to drain the 256-entry buffer

## Root cause

The bounded channel with capacity 256 meant that under broadcast scenarios (many sessions notified at once) or when a child process was slow to consume stdin, any task calling `send_text` or `send_kick` would `.await` on a full channel. This blocked the tokio task running the IPC dispatch loop, stalling all other sessions sharing that executor thread.

## Test plan
- [ ] All process-transport integration tests pass
- [ ] A slow child process no longer stalls the dispatch loop
- [ ] `send_text`/`send_kick` are confirmed sync (no `.await` needed at call sites)

🤖 Generated with [Claude Code](https://claude.com/claude-code)