### PR TITLE
fix: handle UNSUPPORTED_CMD on AppStart

### DIFF
--- a/crates/bbs-mesh/src/transport.rs
+++ b/crates/bbs-mesh/src/transport.rs
@@ -482,43 +482,58 @@ async fn event_loop(
                         break;
                     }
                     Some(ClientEvent::Connected { self_info }) => {
-                        info!(
-                            node = %self_info.node_name,
-                            freq_khz = self_info.frequency_khz,
-                            "mesh: radio bridge connected — draining stale queue"
-                        );
-                        // Register the BBS node in the advert bus so it appears in
-                        // the web UI immediately (using whatever GPS the radio reports).
-                        host.advert_bus().upsert(
-                            self_info.pubkey,
-                            self_info.node_name.clone(),
-                            self_info.adv_type,
-                            self_info.latitude,
-                            self_info.longitude,
-                        );
                         // Drain any messages that queued while we were offline so
-                        // they don't corrupt in-progress workflows.
+                        // they don't corrupt in-progress workflows.  Always done
+                        // regardless of whether SelfInfo is available.
                         draining.store(true, Ordering::Relaxed);
                         let _ = cmd_tx.send(OutboundFrame::SyncNextMessage).await;
-                        // Record our own pubkey so the NewAdvert handler can
-                        // detect self-advert echoes and preserve configured GPS.
-                        state.lock().expect("state mutex poisoned").self_pubkey =
-                            Some(self_info.pubkey);
-                        // Push GPS coordinates to the radio if configured, and refresh
-                        // the advert bus entry so the web UI shows the config GPS.
-                        if let Some((lat, lon)) = host.node_location() {
-                            let lat_1e6 = (lat * 1_000_000.0) as i32;
-                            let lon_1e6 = (lon * 1_000_000.0) as i32;
-                            info!(lat_1e6, lon_1e6, "mesh: setting radio location");
-                            let _ = cmd_tx
-                                .send(OutboundFrame::SetAdvertLatlon { lat_1e6, lon_1e6 })
-                                .await;
+
+                        if let Some(info) = self_info {
+                            info!(
+                                node = %info.node_name,
+                                freq_khz = info.frequency_khz,
+                                "mesh: radio bridge connected — draining stale queue"
+                            );
+                            // Register the BBS node in the advert bus so it appears in
+                            // the web UI immediately (using whatever GPS the radio reports).
                             host.advert_bus().upsert(
-                                self_info.pubkey,
-                                self_info.node_name.clone(),
-                                self_info.adv_type,
-                                lat_1e6,
-                                lon_1e6,
+                                info.pubkey,
+                                info.node_name.clone(),
+                                info.adv_type,
+                                info.latitude,
+                                info.longitude,
+                            );
+                            // Record our own pubkey so the NewAdvert handler can
+                            // detect self-advert echoes and preserve configured GPS.
+                            state.lock().expect("state mutex poisoned").self_pubkey =
+                                Some(info.pubkey);
+                            // Push GPS coordinates to the radio if configured, and
+                            // refresh the advert bus entry so the web UI shows
+                            // the config GPS.
+                            if let Some((lat, lon)) = host.node_location() {
+                                let lat_1e6 = (lat * 1_000_000.0) as i32;
+                                let lon_1e6 = (lon * 1_000_000.0) as i32;
+                                info!(lat_1e6, lon_1e6, "mesh: setting radio location");
+                                let _ = cmd_tx
+                                    .send(OutboundFrame::SetAdvertLatlon { lat_1e6, lon_1e6 })
+                                    .await;
+                                host.advert_bus().upsert(
+                                    info.pubkey,
+                                    info.node_name.clone(),
+                                    info.adv_type,
+                                    lat_1e6,
+                                    lon_1e6,
+                                );
+                            }
+                        } else {
+                            // Device did not return SelfInfo (CMD_APP_START
+                            // was unsupported) — node identity and radio
+                            // params are unavailable until the device pushes
+                            // an advert.
+                            info!(
+                                "mesh: radio bridge connected (no SelfInfo — \
+                                 CMD_APP_START unsupported by device) \
+                                 — draining stale queue"
                             );
                         }
                     }

--- a/crates/meshcore-companion/src/client.rs
+++ b/crates/meshcore-companion/src/client.rs
@@ -61,7 +61,7 @@ use tokio_serial::SerialPortBuilderExt;
 use tracing::{debug, info, warn};
 
 use crate::{
-    constants::{FRAME_OUTBOUND_PREFIX, MAX_PAYLOAD_SIZE},
+    constants::{ERR_CODE_UNSUPPORTED_CMD, FRAME_OUTBOUND_PREFIX, MAX_PAYLOAD_SIZE},
     decode_inbound, encode_outbound,
     error::FrameDecodeError,
     frame::{InboundFrame, OutboundFrame},
@@ -131,11 +131,15 @@ pub struct SerialConfig {
 /// [`InboundFrame::Unknown`] inside [`ClientEvent::Frame`].
 #[derive(Debug)]
 pub enum ClientEvent {
-    /// The connection is up and the AppStart handshake succeeded.
+    /// The connection is up and the AppStart handshake succeeded (or the
+    /// device indicated it does not support `CMD_APP_START`).
     ///
-    /// Carries the [`SelfInfo`] returned by the device, which includes node
-    /// identity, radio parameters, and GPS coordinates.
-    Connected { self_info: SelfInfo },
+    /// `self_info` is `Some` when the device responded to `CMD_APP_START`
+    /// with a valid `SelfInfo` frame.  It is `None` when the device returned
+    /// `ERR_CODE_UNSUPPORTED_CMD` for `CMD_APP_START`; in that case node
+    /// identity and radio parameters are unavailable until the device pushes
+    /// an advert.
+    Connected { self_info: Option<SelfInfo> },
 
     /// The connection was lost or the handshake failed.
     ///
@@ -176,7 +180,8 @@ pub struct SendError(pub OutboundFrame);
 ///     while let Some(event) = client.recv().await {
 ///         match event {
 ///             ClientEvent::Connected { self_info } => {
-///                 println!("connected: {}", self_info.node_name);
+///                 let name = self_info.as_ref().map(|i| i.node_name.as_str()).unwrap_or("unknown");
+///                 println!("connected: {name}");
 ///                 client.send(OutboundFrame::GetBattAndStorage).await.ok();
 ///             }
 ///             ClientEvent::Frame(frame) => println!("{frame:?}"),
@@ -408,6 +413,10 @@ enum SessionOutcome {
 ///
 /// Works for any `AsyncRead`/`AsyncWrite` pair.  Returns when the session
 /// ends for any reason.
+///
+/// If the device responds to `CMD_APP_START` with `ERR_CODE_UNSUPPORTED_CMD`
+/// the handshake is considered successful with no `SelfInfo`;
+/// [`ClientEvent::Connected`] carries `None`.
 async fn run_session<R, W>(
     reader: &mut R,
     writer: &mut W,
@@ -425,9 +434,20 @@ where
         return SessionOutcome::IoError(e, false);
     }
 
-    let self_info = match read_frame(reader).await {
+    let self_info: Option<SelfInfo> = match read_frame(reader).await {
         Err(e) => return SessionOutcome::IoError(e, false),
-        Ok(InboundFrame::SelfInfo(info)) => info,
+        Ok(InboundFrame::SelfInfo(info)) => Some(info),
+        // Some devices return UNSUPPORTED_CMD for CMD_APP_START.  Rather than
+        // looping forever, treat this as a handshake-less connection and
+        // proceed to the event loop without SelfInfo.  See GitHub issue #2.
+        Ok(InboundFrame::Err { error_code }) if error_code == ERR_CODE_UNSUPPORTED_CMD => {
+            warn!(
+                "companion: device returned UNSUPPORTED_CMD for CMD_APP_START \
+                 — proceeding without SelfInfo; \
+                 node identity will be unavailable until the first advert is received"
+            );
+            None
+        }
         Ok(other) => {
             warn!("companion: expected SelfInfo after AppStart, got {other:?}");
             return SessionOutcome::IoError(
@@ -440,7 +460,9 @@ where
         }
     };
 
-    info!(node = %self_info.node_name, "companion: handshake complete");
+    if let Some(ref info) = self_info {
+        info!(node = %info.node_name, "companion: handshake complete");
+    }
     if event_tx
         .send(ClientEvent::Connected { self_info })
         .await

--- a/crates/meshcore-companion/tests/client.rs
+++ b/crates/meshcore-companion/tests/client.rs
@@ -152,9 +152,54 @@ async fn handshake_emits_connected() {
         .expect("channel closed");
 
     match event {
-        ClientEvent::Connected { self_info } => assert_eq!(self_info.node_name, "TestRadio"),
+        ClientEvent::Connected { self_info } => {
+            assert_eq!(self_info.unwrap().node_name, "TestRadio")
+        }
         other => panic!("expected Connected, got {other:?}"),
     }
+}
+
+/// When the device returns `ERR_CODE_UNSUPPORTED_CMD` for `CMD_APP_START`
+/// (MeshCore ≥ 1.15 behaviour on Heltec V4.2), the client should still emit
+/// `Connected { self_info: None }` and enter the event loop rather than
+/// retrying forever.  See GitHub issue #2.
+#[tokio::test]
+async fn unsupported_app_start_emits_connected_without_self_info() {
+    let (mut client, mut bridge) = loopback().await;
+
+    // Consume the AppStart the client sends.
+    let _app_start = bridge.recv_n(5).await;
+
+    // Reply with ERR_CODE_UNSUPPORTED_CMD (error_code = 1).
+    let err_frame = radio_frame(&[RESP_CODE_ERR, ERR_CODE_UNSUPPORTED_CMD]);
+    bridge.send(&err_frame).await;
+
+    // Client must emit Connected with self_info = None (not loop forever).
+    let ev = tokio::time::timeout(Duration::from_secs(2), client.recv())
+        .await
+        .expect("timed out waiting for Connected")
+        .expect("client channel closed");
+
+    match ev {
+        ClientEvent::Connected { self_info } => {
+            assert!(
+                self_info.is_none(),
+                "self_info should be None for firmware that rejects AppStart"
+            );
+        }
+        other => panic!("expected Connected{{self_info: None}}, got {other:?}"),
+    }
+
+    // The client must stay in the event loop — subsequent frames are forwarded.
+    bridge.send(&ok_frame()).await;
+    let ev2 = tokio::time::timeout(Duration::from_secs(2), client.recv())
+        .await
+        .expect("timed out waiting for Frame")
+        .expect("channel closed");
+    assert!(
+        matches!(ev2, ClientEvent::Frame(InboundFrame::Ok)),
+        "expected Frame(Ok) after handshake-less connect, got {ev2:?}"
+    );
 }
 
 /// The first bytes the client sends are a well-formed AppStart frame.


### PR DESCRIPTION
## Problem

A user with a Heltec V4.2 running `heltec_v4_companion_radio_usb-v1.15.0` gets an infinite reconnect loop immediately on connect:

```
WARN meshcore_companion::client: companion: expected SelfInfo after AppStart, got Err { error_code: 1 }
WARN meshcore_companion::client: companion/serial: session error: no SelfInfo after AppStart handshake
DEBUG meshcore_companion::client: companion/serial: reopening in 1s
```

`error_code: 1` = `ERR_CODE_UNSUPPORTED_CMD`. The device is rejecting `CMD_APP_START` outright. The previous code treated any non-`SelfInfo` response as a fatal protocol error and retried forever.

Closes #2.

## What we know

- The device correctly parses `0x3C`-prefixed frames — it returned a well-formed `Err` response, not framing garbage — so `FRAME_INBOUND_PREFIX` is not the issue.
- The reporter's workaround also changed `FRAME_INBOUND_PREFIX` → `FRAME_OUTBOUND_PREFIX` in `wrap_payload`, but based on the above that change is **not needed** and is not included here.
- We don't know whether this is specific to the 1.15.0 firmware version, the Heltec V4.2 hardware revision, this particular firmware build target, or some combination. The fix is intentionally phrased around the observable behaviour (`UNSUPPORTED_CMD` returned) rather than speculating about what changed and when.

## Fix

- In `run_session`, an `Err { error_code: ERR_CODE_UNSUPPORTED_CMD }` response to `CMD_APP_START` is now treated as "device does not support this handshake": a warning is logged and the session proceeds to the event loop with `self_info = None`.
- `ClientEvent::Connected.self_info` is widened from `SelfInfo` to `Option<SelfInfo>`. Existing hardware that supports AppStart continues to receive `Some(...)`.
- `bbs_mesh::transport` handles `None` gracefully: the stale-queue drain and `SyncNextMessage` still fire; advert-bus registration and `self_pubkey` recording are skipped until the device pushes an advert.

## Tests

New integration test (`unsupported_app_start_emits_connected_without_self_info`) drives the full `UNSUPPORTED_CMD → Connected{None} → frames still forwarded` path over TCP loopback. Full workspace test suite passes.

## Testing needed from reporter

Please build from this branch and test with your Heltec V4.2 / MeshCore 1.15.0 setup:

```sh
git fetch origin fix/issue-2-meshcore-1.15-appstart
git checkout fix/issue-2-meshcore-1.15-appstart
cargo build --release
```

With this fix the log should show:
```
WARN  companion: device returned UNSUPPORTED_CMD for CMD_APP_START — proceeding without SelfInfo; ...
INFO  mesh: radio bridge connected (no SelfInfo — CMD_APP_START unsupported by device) — draining stale queue
```
…and the BBS should come up and relay messages. Note: your node name will not appear in the web UI until your device broadcasts its first advert.