### PR TITLE
fix(host,mesh): N command misrouted during/after room selection

### DIFF
--- a/crates/bbs-core/src/host.rs
+++ b/crates/bbs-core/src/host.rs
@@ -2014,12 +2014,51 @@ impl BbsHost {
                         return self.handle_change_to_room(session, target_id).await;
                     }
                 }
-                // Fall back: treat as room name via the normal change-room path
+                // Fall back: treat as room name via the normal change-room path.
+                //
+                // Guard against out-of-order mesh delivery: if the user typed a
+                // BBS command (e.g. "N") immediately after "K" and the command
+                // arrived while awaiting_reply was still true, it would land
+                // here as a room-selection reply.  Single-letter or short
+                // alphabetic inputs that look like known command keywords are
+                // almost never intended as room names; cancel the room-selection
+                // workflow and tell the user to re-send their command.
+                let is_cmd_keyword = matches!(
+                    trimmed.to_ascii_lowercase().as_str(),
+                    "n" | "f"
+                        | "r"
+                        | "g"
+                        | "k"
+                        | "m"
+                        | "i"
+                        | "e"
+                        | "d"
+                        | "q"
+                        | "w"
+                        | "s"
+                        | "h"
+                        | "?"
+                        | "profile"
+                        | "passwd"
+                        | "pending"
+                        | "whoami"
+                        | ".ff"
+                        | ".c"
+                        | ".dr"
+                        | ".er"
+                );
                 {
                     let mut sessions = self.sessions.write().await;
                     if let Some(r) = sessions.get_mut(&session) {
                         r.workflow = Workflow::None;
                     }
+                }
+                if is_cmd_keyword {
+                    return Ok(Response::Text(format!(
+                        "Room selection cancelled (received '{}' while waiting for room number).\n\
+                         Re-send your command, or type K to list rooms again.",
+                        trimmed.to_uppercase()
+                    )));
                 }
                 self.handle_change_room(session, trimmed).await
             }
@@ -5613,6 +5652,49 @@ mod tests {
         assert!(
             text.to_lowercase().contains("no new messages"),
             "N after pointer reset should say 'no new messages', got: {text:?}"
+        );
+    }
+
+    // ── Bug-03: Workflow::Rooms cancels cleanly for command keywords ──────────
+
+    /// When a single-letter command keyword (e.g. "N") arrives as a workflow
+    /// reply during room selection, the session should cancel cleanly with a
+    /// helpful message rather than reporting "Room 'N' not found".
+    #[tokio::test]
+    async fn rooms_workflow_cancels_for_command_keywords() {
+        let (host, _db) = make_host().await;
+        let sid = host.create_session("test").await.unwrap();
+        let uname = Username::new("alice").unwrap();
+        register_and_login(&host, sid, &uname, "pass1234").await;
+
+        // Enter room-selection workflow.
+        let resp = host.process_command(sid, Command::ListRooms).await.unwrap();
+        assert!(
+            matches!(resp, Response::Prompt { .. }),
+            "K should enter Workflow::Rooms and return Prompt"
+        );
+
+        // "N" arrives as a WorkflowReply (simulating out-of-order mesh delivery).
+        let resp = host
+            .process_command(sid, Command::WorkflowReply { reply: "N".into() })
+            .await
+            .unwrap();
+
+        let text = match resp {
+            Response::Text(t) => t,
+            Response::Error(e) => e,
+            other => panic!("expected Text or Error, got {other:?}"),
+        };
+        // Should mention "cancelled" rather than "Room 'N' not found".
+        assert!(
+            text.to_lowercase().contains("cancel"),
+            "Workflow::Rooms should cancel for command keywords, got: {text:?}"
+        );
+        // Workflow should be cleared — next N should work as ReadNew.
+        let resp2 = host.process_command(sid, Command::ReadNew).await.unwrap();
+        assert!(
+            !matches!(resp2, Response::Error(_)),
+            "ReadNew after cancelled room-selection should not error, got {resp2:?}"
         );
     }
 }

--- a/crates/bbs-mesh/src/command.rs
+++ b/crates/bbs-mesh/src/command.rs
@@ -48,7 +48,10 @@ use bbs_plugin_api::{event::Notification, identity::Username, Command, Response}
 /// - `None` — the message should be silently dropped (prefix configured,
 ///   message doesn't start with it, and no workflow is active).
 pub fn parse_command(text: &str, prefix: Option<char>, awaiting_reply: bool) -> Option<Command> {
-    let text = text.trim();
+    // Trim standard whitespace and null bytes.  Some MeshCore firmware
+    // null-terminates its text payloads; without this, "N\0" would not match
+    // the "n" keyword and would produce Command::Unknown instead of ReadNew.
+    let text = text.trim().trim_matches('\0');
 
     // ── Cancel / stop always break out of any workflow ───────────────────────
     if matches!(text.to_ascii_lowercase().as_str(), "cancel" | "stop") {

--- a/crates/bbs-mesh/src/transport.rs
+++ b/crates/bbs-mesh/src/transport.rs
@@ -35,7 +35,7 @@ use bbs_plugin_api::{
     identity::SessionId,
     plugin::Plugin,
     transport::TransportEngine,
-    Host, PermissionLevel, Response,
+    Command, Host, PermissionLevel, Response,
 };
 use meshcore_companion::{
     client::{ClientConfig, ClientEvent, CompanionClient, SerialConfig},
@@ -837,7 +837,20 @@ async fn dispatch_message(
                     warn!(?fresh_sid, "mesh: node_restore on refresh error: {e}");
                 }
             }
-            match host.process_command(fresh_sid, cmd).await {
+            // The original command was parsed with the stale transport state
+            // (which may have had `awaiting_reply = true`).  If it became a
+            // WorkflowReply but the fresh session has no active workflow, re-parse
+            // with awaiting_reply = false so the user's intent is honoured.
+            //
+            // Example: user had K's room list open; BBS session expired; user
+            // sends "N" → parsed as WorkflowReply.  After eviction the fresh
+            // session has Workflow::None, so we re-parse "N" as Command::ReadNew.
+            let retry_cmd = if matches!(cmd, Command::WorkflowReply { .. }) {
+                parse_command(text, command_prefix, false).unwrap_or_else(|| cmd.clone())
+            } else {
+                cmd.clone()
+            };
+            match host.process_command(fresh_sid, retry_cmd).await {
                 Ok(r) => r,
                 Err(e) => {
                     warn!(?fresh_sid, "mesh: error after session refresh: {e}");


### PR DESCRIPTION
## Bug

Pressing `N` (Read New) immediately after `K` (List Rooms) would sometimes result in one of:
- "Room 'N' not found" — the command was treated as a room name
- `Command::Unknown` — because the firmware sent `N\0` and the null byte prevented the keyword match

Three root causes were identified, all fixed here.

## Root causes & fixes

### 1. Null-terminated payloads (`crates/bbs-mesh/src/command.rs`)

MeshCore firmware null-terminates its text payloads. `"N\0"` did not match the `"n"` keyword in `parse_command`, so it fell through to `Command::Unknown` instead of `Command::ReadNew`.

Fix: trim null bytes (via `trim_matches('\0')`) alongside the existing whitespace trim.

### 2. WorkflowReply persisted after session eviction (`crates/bbs-mesh/src/transport.rs`)

When a BBS session expired while room selection was active, the transport re-created a fresh session but dispatched the original `Command::WorkflowReply` (parsed with `awaiting_reply=true`). The new session had `Workflow::None`, so the reply landed in the `Workflow::Rooms` fallback and attempted to change to a room named `"N"`.

Fix: after an `UnknownSession` eviction, if the command is a `WorkflowReply`, re-parse the raw text with `awaiting_reply=false` so the user's actual command intent is honoured.

### 3. Out-of-order delivery falling into the room-name path (`crates/bbs-core/src/host.rs`)

Even without session expiry, if `"N"` arrived slightly before the room-selection reply was consumed, the `Workflow::Rooms` fallback would call `handle_change_room("N")`.

Fix: the `Workflow::Rooms` fallback now detects known command keywords before attempting a room-name lookup. If a keyword is detected, the workflow is cleared and the user receives a "Room selection cancelled — re-send your command" message.

## Tests

One new unit test in `host::tests`:

| Test | What it checks |
|------|----------------|
| `rooms_workflow_cancels_for_command_keywords` | `WorkflowReply` of "N" during room selection cancels cleanly; subsequent `ReadNew` succeeds |

## Manual verification

1. Press `K` to enter room-selection workflow.
2. Before responding, press `N`.
3. Expected: "Room selection cancelled (received 'N'…) Re-send your command."
4. Press `N` again. Expected: message list or "No new messages."
5. (Mesh nodes) Verify "N\0" and "n\0" inputs are accepted as Read New.