### PR TITLE
fix(mesh): populate timestamp in SendTxtMsg frame

### DIFF
--- a/crates/bbs-mesh/src/transport.rs
+++ b/crates/bbs-mesh/src/transport.rs
@@ -27,6 +27,7 @@
 
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
+use std::time::{SystemTime, UNIX_EPOCH};
 
 use async_trait::async_trait;
 use bbs_plugin_api::{
@@ -45,7 +46,7 @@ use meshcore_companion::{
 
 /// Maximum bytes of plain text that fit in one `SendTxtMsg` companion frame.
 ///
-/// Wire layout: `[prefix:1][len:2][CMD:1][txt_type:1][attempt:1][reserved:4][prefix:6][text:N]`
+/// Wire layout: `[prefix:1][len:2][CMD:1][txt_type:1][attempt:1][timestamp:4][prefix:6][text:N]`
 /// = 16 bytes of overhead.  Total frame must not exceed `MAX_FRAME_SIZE`.
 const MAX_REPLY_BYTES: usize = MAX_FRAME_SIZE - 16;
 use tokio::sync::{mpsc, watch};
@@ -56,6 +57,16 @@ use crate::{
     config::{ConnectionType, MeshConfig},
     session::SessionState,
 };
+
+/// Current Unix time in seconds, truncated to u32 (the wire format's field width).
+/// Returns 0 if the system clock is before the epoch, which should never happen
+/// on a configured host.
+pub fn now_unix_secs() -> u32 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs() as u32)
+        .unwrap_or(0)
+}
 
 // ── MeshTransport ─────────────────────────────────────────────────────────────
 
@@ -335,6 +346,7 @@ impl TransportEngine for MeshTransport {
             .send(OutboundFrame::SendTxtMsg {
                 txt_type: TXT_TYPE_PLAIN,
                 attempt: 0,
+                timestamp: now_unix_secs(),
                 pubkey_prefix,
                 text,
             })
@@ -397,6 +409,7 @@ async fn push_domain_notification(
                         .send(OutboundFrame::SendTxtMsg {
                             txt_type: TXT_TYPE_PLAIN,
                             attempt: 0,
+                            timestamp: now_unix_secs(),
                             pubkey_prefix: prefix,
                             text: "Your account has been validated. \
                                    You now have full access. Type 'H'."
@@ -434,6 +447,7 @@ async fn push_domain_notification(
                         .send(OutboundFrame::SendTxtMsg {
                             txt_type: TXT_TYPE_PLAIN,
                             attempt: 0,
+                            timestamp: now_unix_secs(),
                             pubkey_prefix: prefix,
                             text: format!(
                                 "New registration: {} — type PENDING to review.",
@@ -727,6 +741,7 @@ async fn dispatch_message(
                 .send(OutboundFrame::SendTxtMsg {
                     txt_type: TXT_TYPE_PLAIN,
                     attempt: 0,
+                    timestamp: now_unix_secs(),
                     pubkey_prefix: sender_prefix,
                     text: greeting,
                 })
@@ -923,6 +938,7 @@ async fn dispatch_message(
             .send(OutboundFrame::SendTxtMsg {
                 txt_type: TXT_TYPE_PLAIN,
                 attempt: 0,
+                timestamp: now_unix_secs(),
                 pubkey_prefix: sender_prefix,
                 text: reply_text,
             })

--- a/crates/meshcore-companion/src/frame.rs
+++ b/crates/meshcore-companion/src/frame.rs
@@ -172,6 +172,7 @@ pub enum OutboundFrame {
     SendTxtMsg {
         txt_type: u8,
         attempt: u8,
+        timestamp: u32,
         pubkey_prefix: [u8; 6],
         text: String,
     },
@@ -592,15 +593,16 @@ fn build_payload(frame: &OutboundFrame) -> Vec<u8> {
         OutboundFrame::SendTxtMsg {
             txt_type,
             attempt,
+            timestamp,
             pubkey_prefix,
             text,
         } => {
             // Layout confirmed from frame_server._cmd_send_txt_msg:
-            // data[0]=txt_type, data[1]=attempt, data[2..6]=reserved(4), data[6..12]=prefix, data[12..]=text
+            // data[0]=txt_type, data[1]=attempt, data[2..6]=timestamp(4), data[6..12]=prefix, data[12..]=text
             p.push(CMD_SEND_TXT_MSG);
             p.push(*txt_type);
             p.push(*attempt);
-            p.extend_from_slice(&[0u8; 4]); // reserved
+            p.extend_from_slice(&timestamp.to_le_bytes());
             p.extend_from_slice(pubkey_prefix);
             p.extend_from_slice(text.as_bytes());
         }

--- a/crates/meshcore-companion/tests/codec.rs
+++ b/crates/meshcore-companion/tests/codec.rs
@@ -498,12 +498,14 @@ fn encode_get_contacts() {
 
 #[test]
 fn encode_send_txt_msg_layout() {
-    // Confirm 4 reserved bytes at positions 2-5 (after txt_type and attempt).
-    // Wire payload: [CMD][txt_type][attempt][0x00×4][prefix×6][text…]
+    // Confirm timestamp bytes at positions 2-5 (after txt_type and attempt).
+    // Wire payload: [CMD][txt_type][attempt][timestamp×4][prefix×6][text…]
     let prefix = [0x01, 0x02, 0x03, 0x04, 0x05, 0x06];
+    let ts: u32 = 0x1234_5678;
     let wire_bytes = encode_outbound(&OutboundFrame::SendTxtMsg {
         txt_type: TXT_TYPE_PLAIN,
         attempt: 1,
+        timestamp: ts,
         pubkey_prefix: prefix,
         text: "hi".to_owned(),
     });
@@ -511,8 +513,8 @@ fn encode_send_txt_msg_layout() {
     assert_eq!(payload[0], CMD_SEND_TXT_MSG);
     assert_eq!(payload[1], TXT_TYPE_PLAIN); // txt_type
     assert_eq!(payload[2], 1u8); // attempt
-    assert_eq!(&payload[3..7], &[0u8; 4]); // 4 reserved bytes
-    assert_eq!(&payload[7..13], &prefix); // pubkey_prefix at data[6:12] (relative to CMD byte = index 0)
+    assert_eq!(&payload[3..7], &ts.to_le_bytes()); // timestamp (little-endian)
+    assert_eq!(&payload[7..13], &prefix); // pubkey_prefix
     assert_eq!(&payload[13..15], b"hi");
 }
 


### PR DESCRIPTION
The four bytes at offset 3..7 of the CMD_SEND_TXT_MSG payload are the Unix timestamp per the MeshCore companion protocol, not a reserved field. Sending zeros caused recipients to dedupe identical-content replies (e.g. the help menu) and silently drop them, since the protocol spec recommends dedup by (sender, content, timestamp).

Adds a 'timestamp: u32' field to the SendTxtMsg variant, populated from the host clock at frame construction time via a local now_unix_secs() helper in bbs-mesh's transport.

Protocol reference: https://docs.meshcore.io/companion_protocol/

Verified on Heltec V3 + MeshCore Companion USB v1.15.0: identical-content replies now arrive on the paired MeshCore phone app and surface correctly in the chat UI.