### PR TITLE
fix(mesh): USB serial companion handshake + contact list sync

### DIFF
--- a/crates/bbs-mesh/src/transport.rs
+++ b/crates/bbs-mesh/src/transport.rs
@@ -541,15 +541,20 @@ async fn event_loop(
                             }
                         } else {
                             // Device did not return SelfInfo (CMD_APP_START
-                            // was unsupported) — node identity and radio
-                            // params are unavailable until the device pushes
-                            // an advert.
+                            // was unsupported) — node identity is unavailable
+                            // until the device pushes an advert.
                             info!(
                                 "mesh: radio bridge connected (no SelfInfo — \
                                  CMD_APP_START unsupported by device) \
                                  — draining stale queue"
                             );
                         }
+
+                        // Fetch the full contact list so the advert bus is populated
+                        // with names, types, and locations. Without this, nodes already
+                        // in the device's contact table arrive only as short adverts
+                        // (pubkey-only stubs) via PUSH_CODE_ADVERT (0x80).
+                        let _ = cmd_tx.send(OutboundFrame::GetContacts { since: 0 }).await;
                     }
                     Some(ClientEvent::Disconnected { will_retry }) => {
                         if will_retry {
@@ -681,6 +686,35 @@ async fn handle_frame(
                 .expect("state mutex poisoned")
                 .set_full_pubkey(&prefix, contact.pubkey);
             debug!(name = %contact.name, "mesh: full advert (new contact) received");
+        }
+
+        // ── Contact list sync (response to CMD_GET_CONTACTS) ─────────────────
+        InboundFrame::Contact(contact) => {
+            // Populate the advert bus with full metadata from the device's
+            // contact list — these arrive as RESP_CODE_CONTACT frames after
+            // CMD_GET_CONTACTS and contain name, type, and location.
+            host.advert_bus().upsert(
+                contact.pubkey,
+                contact.name.clone(),
+                contact.adv_type,
+                contact.gps_lat,
+                contact.gps_lon,
+            );
+            // Record the full pubkey mapping so ResetPath can find the node.
+            let prefix: [u8; 6] = contact.pubkey[..6].try_into().expect("pubkey is 32 bytes");
+            state
+                .lock()
+                .expect("state mutex poisoned")
+                .set_full_pubkey(&prefix, contact.pubkey);
+            debug!(name = %contact.name, "mesh: contact list entry → advert bus");
+        }
+        InboundFrame::ContactsStart { count: _ } => {
+            debug!("mesh: contact list sync started");
+        }
+        InboundFrame::EndOfContacts {
+            most_recent_lastmod: _,
+        } => {
+            debug!("mesh: contact list sync complete");
         }
 
         // ── Everything else ───────────────────────────────────────────────────

--- a/crates/bbs-mesh/tests/transport.rs
+++ b/crates/bbs-mesh/tests/transport.rs
@@ -6,9 +6,10 @@
 //!
 //! # Bridge protocol reminder
 //!
-//! The companion client sends AppStart (5 bytes) and expects SelfInfo back
-//! before entering the event loop.  The test bridge must complete this
-//! handshake before sending any other frames.
+//! The companion client sends AppStart (11 bytes: prefix + 2-byte len + 8-byte
+//! payload padded to firmware minimum) and expects SelfInfo back before
+//! entering the event loop.  The test bridge must read all 11 bytes before
+//! sending SelfInfo to avoid leaving stale bytes in the TCP buffer.
 
 use std::{sync::Arc, time::Duration};
 
@@ -83,7 +84,9 @@ impl Bridge {
     }
 
     async fn complete_handshake(&mut self, name: &str) {
-        let app_start = self.recv_n(5).await;
+        // AppStart = 11 bytes: prefix(1) + len(2) + CMD_APP_START(1) + version(1) + zeros(6)
+        // Must read all 11 to avoid leaving stale bytes that corrupt read_command().
+        let app_start = self.recv_n(11).await;
         assert_eq!(app_start[3], CMD_APP_START, "expected CMD_APP_START");
         self.send(&self_info_frame(name)).await;
         // Transport immediately drains the queue on connect: read the
@@ -96,6 +99,13 @@ impl Bridge {
         );
         let no_more = radio_frame(&[RESP_CODE_NO_MORE_MESSAGES]);
         self.send(&no_more).await;
+        // Transport sends CMD_GET_CONTACTS immediately after connect to populate
+        // the advert bus. Read and discard it — the mock bridge sends no contacts.
+        let get_contacts = self.read_command().await;
+        assert_eq!(
+            get_contacts[0], CMD_GET_CONTACTS,
+            "expected CMD_GET_CONTACTS after drain"
+        );
         tokio::time::sleep(Duration::from_millis(20)).await;
     }
 

--- a/crates/meshcore-companion/src/client.rs
+++ b/crates/meshcore-companion/src/client.rs
@@ -55,10 +55,10 @@ use tokio::{
     io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt},
     net::TcpStream,
     sync::mpsc,
-    time::sleep,
+    time::{sleep, timeout},
 };
 use tokio_serial::SerialPortBuilderExt;
-use tracing::{debug, info, warn};
+use tracing::{debug, info, trace, warn};
 
 use crate::{
     constants::{ERR_CODE_UNSUPPORTED_CMD, FRAME_OUTBOUND_PREFIX, MAX_PAYLOAD_SIZE},
@@ -378,6 +378,17 @@ async fn attempt_serial_session(
     };
     info!(port = %config.port, baud = config.baud_rate, "companion/serial: port opened");
 
+    // Give the nRF52840 firmware time to complete setup() before we send
+    // AppStart.  The Linux cdc-acm driver sends SET_CONTROL_LINE_STATE(DTR=1)
+    // automatically on port open (acm_port_activate), so no explicit DTR
+    // assertion is needed.  What *is* needed is this delay: radio init,
+    // filesystem mount, and mesh init together take ~1-2 seconds, and if we
+    // send AppStart before setup() finishes the frame sits in the TinyUSB FIFO
+    // safely — but it is processed correctly only once serial_interface.begin()
+    // and startInterface() have been called.  2 s matches the delay used by the
+    // Meshtastic serial transport for the same class of devices.
+    sleep(Duration::from_secs(2)).await;
+
     let (mut reader, mut writer) = tokio::io::split(stream);
     match run_session(
         &mut reader,
@@ -430,11 +441,43 @@ where
 {
     // ── AppStart handshake ────────────────────────────────────────────────────
     let handshake = encode_outbound(&OutboundFrame::AppStart { app_target_version });
+    trace!(
+        "companion: tx AppStart ({} bytes): {:02X?}",
+        handshake.len(),
+        handshake
+    );
     if let Err(e) = writer.write_all(&handshake).await {
         return SessionOutcome::IoError(e, false);
     }
+    // Flush to ensure the frame reaches the device before we start reading.
+    // USB CDC drivers may batch small writes; an explicit flush forces immediate
+    // transmission, which matters for devices that won't respond until they
+    // receive the full AppStart frame.
+    if let Err(e) = writer.flush().await {
+        warn!("companion: flush after AppStart failed: {e}");
+    }
 
-    let self_info: Option<SelfInfo> = match read_frame(reader).await {
+    // Wait up to 10 seconds for the SelfInfo handshake response.
+    // If the device is silent we log a clear error and fall into the reconnect
+    // loop rather than blocking the task forever.
+    const HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(10);
+    let frame_result = match timeout(HANDSHAKE_TIMEOUT, read_frame(reader)).await {
+        Ok(r) => r,
+        Err(_) => {
+            warn!(
+                "companion: handshake timeout ({HANDSHAKE_TIMEOUT:?}) — \
+                 device did not respond to AppStart; \
+                 check connection type, baud rate, and that the device is \
+                 running the MeshCore USB companion firmware"
+            );
+            return SessionOutcome::IoError(
+                io::Error::new(io::ErrorKind::TimedOut, "AppStart handshake timeout"),
+                false,
+            );
+        }
+    };
+
+    let self_info: Option<SelfInfo> = match frame_result {
         Err(e) => return SessionOutcome::IoError(e, false),
         Ok(InboundFrame::SelfInfo(info)) => Some(info),
         // Some devices return UNSUPPORTED_CMD for CMD_APP_START.  Rather than
@@ -506,24 +549,34 @@ where
 
 /// Read one complete frame from `reader`.
 ///
-/// Reads the 3-byte header (prefix + LE u16 length), validates the prefix,
-/// reads the payload, then decodes.  Returns `io::Error` on any failure so
-/// the caller can treat all session errors uniformly.
+/// Scans the byte stream for the device→host prefix (`0x3E`, `>`), skipping
+/// any bytes that don't match.  This tolerates startup banners or stray bytes
+/// that some companion devices emit before the companion-frame protocol is
+/// ready.  Once the prefix is found, reads the 2-byte LE payload length, then
+/// the payload, then decodes.
+///
+/// Returns `io::Error` on any I/O failure or payload decode error.
 async fn read_frame<R: AsyncRead + Unpin>(reader: &mut R) -> io::Result<InboundFrame> {
-    let mut header = [0u8; 3];
-    reader.read_exact(&mut header).await?;
-
-    if header[0] != FRAME_OUTBOUND_PREFIX {
-        return Err(io::Error::new(
-            io::ErrorKind::InvalidData,
-            format!(
-                "companion: bad frame prefix 0x{:02X} (expected 0x{FRAME_OUTBOUND_PREFIX:02X})",
-                header[0]
-            ),
-        ));
+    // Scan for the outbound-frame prefix, skipping any non-matching bytes.
+    // This handles startup banners, CRLF noise, or any bytes the device sends
+    // before entering companion-frame mode.
+    loop {
+        let mut byte = [0u8; 1];
+        reader.read_exact(&mut byte).await?;
+        if byte[0] == FRAME_OUTBOUND_PREFIX {
+            break;
+        }
+        // Log at trace so routine operation is quiet but debug builds show the noise.
+        trace!(
+            "companion: skipping non-prefix byte 0x{:02X} (expected 0x{FRAME_OUTBOUND_PREFIX:02X})",
+            byte[0]
+        );
     }
 
-    let payload_len = u16::from_le_bytes([header[1], header[2]]) as usize;
+    let mut len_bytes = [0u8; 2];
+    reader.read_exact(&mut len_bytes).await?;
+    let payload_len = u16::from_le_bytes(len_bytes) as usize;
+
     if payload_len > MAX_PAYLOAD_SIZE {
         return Err(io::Error::new(
             io::ErrorKind::InvalidData,
@@ -535,6 +588,12 @@ async fn read_frame<R: AsyncRead + Unpin>(reader: &mut R) -> io::Result<InboundF
 
     let mut payload = vec![0u8; payload_len];
     reader.read_exact(&mut payload).await?;
+
+    trace!(
+        "companion: rx {} bytes payload: {:02X?}",
+        payload_len,
+        payload
+    );
 
     decode_inbound(&payload)
         .map_err(|e: FrameDecodeError| io::Error::new(io::ErrorKind::InvalidData, e.to_string()))

--- a/crates/meshcore-companion/src/client.rs
+++ b/crates/meshcore-companion/src/client.rs
@@ -457,12 +457,39 @@ where
         warn!("companion: flush after AppStart failed: {e}");
     }
 
-    // Wait up to 10 seconds for the SelfInfo handshake response.
-    // If the device is silent we log a clear error and fall into the reconnect
-    // loop rather than blocking the task forever.
+    // Wait up to 10 seconds for SelfInfo, discarding any unsolicited push
+    // frames (LogRxData, Advert, etc.) that arrive before the device processes
+    // AppStart.  Active nodes relay mesh traffic continuously, so several
+    // frames may arrive before SelfInfo is queued in the firmware's TX buffer.
     const HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(10);
-    let frame_result = match timeout(HANDSHAKE_TIMEOUT, read_frame(reader)).await {
-        Ok(r) => r,
+    let self_info: Option<SelfInfo> = match timeout(HANDSHAKE_TIMEOUT, async {
+        loop {
+            match read_frame(reader).await {
+                Err(e) => return Err(e),
+                Ok(InboundFrame::SelfInfo(info)) => return Ok(Some(info)),
+                // Some devices return UNSUPPORTED_CMD for CMD_APP_START.  Treat
+                // this as a handshake-less connection and proceed without SelfInfo.
+                Ok(InboundFrame::Err { error_code }) if error_code == ERR_CODE_UNSUPPORTED_CMD => {
+                    warn!(
+                        "companion: device returned UNSUPPORTED_CMD for CMD_APP_START \
+                         — proceeding without SelfInfo; \
+                         node identity will be unavailable until the first advert is received"
+                    );
+                    return Ok(None);
+                }
+                // Any other frame (LogRxData, Advert, PathUpdated, …) arrived
+                // before SelfInfo — the device is busy relaying mesh traffic.
+                // Discard and keep waiting.
+                Ok(other) => {
+                    trace!("companion: discarding pre-handshake frame: {other:?}");
+                }
+            }
+        }
+    })
+    .await
+    {
+        Ok(Ok(info)) => info,
+        Ok(Err(e)) => return SessionOutcome::IoError(e, false),
         Err(_) => {
             warn!(
                 "companion: handshake timeout ({HANDSHAKE_TIMEOUT:?}) — \
@@ -472,32 +499,6 @@ where
             );
             return SessionOutcome::IoError(
                 io::Error::new(io::ErrorKind::TimedOut, "AppStart handshake timeout"),
-                false,
-            );
-        }
-    };
-
-    let self_info: Option<SelfInfo> = match frame_result {
-        Err(e) => return SessionOutcome::IoError(e, false),
-        Ok(InboundFrame::SelfInfo(info)) => Some(info),
-        // Some devices return UNSUPPORTED_CMD for CMD_APP_START.  Rather than
-        // looping forever, treat this as a handshake-less connection and
-        // proceed to the event loop without SelfInfo.  See GitHub issue #2.
-        Ok(InboundFrame::Err { error_code }) if error_code == ERR_CODE_UNSUPPORTED_CMD => {
-            warn!(
-                "companion: device returned UNSUPPORTED_CMD for CMD_APP_START \
-                 — proceeding without SelfInfo; \
-                 node identity will be unavailable until the first advert is received"
-            );
-            None
-        }
-        Ok(other) => {
-            warn!("companion: expected SelfInfo after AppStart, got {other:?}");
-            return SessionOutcome::IoError(
-                io::Error::new(
-                    io::ErrorKind::InvalidData,
-                    "no SelfInfo after AppStart handshake",
-                ),
                 false,
             );
         }

--- a/crates/meshcore-companion/src/frame.rs
+++ b/crates/meshcore-companion/src/frame.rs
@@ -253,6 +253,29 @@ pub enum OutboundFrame {
     SetPathHashMode {
         mode: u8,
     },
+    /// Configure the radio parameters (frequency, bandwidth, spreading factor, coding rate).
+    ///
+    /// Send immediately after the AppStart handshake for USB serial companion devices
+    /// that have no persisted radio configuration (e.g. freshly-flashed Heltec T114).
+    ///
+    /// Wire format: `[CMD_SET_RADIO_PARAMS][freq:u32-LE][bw:u32-LE][sf:u8][cr:u8]`
+    SetRadioParams {
+        /// Carrier frequency in Hz (e.g. `910_525_000` for USA/Canada 915 MHz band).
+        frequency_hz: u32,
+        /// Bandwidth in Hz (e.g. `62_500` for 62.5 kHz).
+        bandwidth_hz: u32,
+        /// LoRa spreading factor (7–12).
+        spreading_factor: u8,
+        /// LoRa coding rate denominator (5–8, representing 4/5 through 4/8).
+        coding_rate: u8,
+    },
+    /// Set the radio transmit power.
+    ///
+    /// Wire format: `[CMD_SET_RADIO_TX_POWER][power:i8]`
+    SetRadioTxPower {
+        /// Transmit power in dBm (e.g. `20` for 100 mW).
+        power_dbm: i8,
+    },
     /// Escape hatch for commands not yet modelled above.
     Raw {
         code: u8,
@@ -576,8 +599,14 @@ fn build_payload(frame: &OutboundFrame) -> Vec<u8> {
     let mut p: Vec<u8> = Vec::new();
     match frame {
         OutboundFrame::AppStart { app_target_version } => {
+            // MeshCore firmware requires a minimum 8-byte payload for CMD_APP_START.
+            // Layout: [CMD][reserved×7] — positions 1–7 are reserved/ignored by the
+            // device, but the frame is silently dropped if len < 8.  We place the
+            // app_target_version byte at position 1 (a convention from earlier protocol
+            // versions); the remaining 6 bytes are zeroed.
             p.push(CMD_APP_START);
             p.push(*app_target_version);
+            p.extend_from_slice(&[0u8; 6]); // pad to minimum 8-byte payload
         }
         OutboundFrame::DeviceQuery { app_target_version } => {
             p.push(CMD_DEVICE_QUERY);
@@ -736,6 +765,34 @@ fn build_payload(frame: &OutboundFrame) -> Vec<u8> {
             p.push(CMD_SET_PATH_HASH_MODE);
             p.push(0); // subtype byte must be 0
             p.push(*mode);
+        }
+        OutboundFrame::SetRadioParams {
+            frequency_hz,
+            bandwidth_hz,
+            spreading_factor,
+            coding_rate,
+        } => {
+            // Wire: [CMD][freq_khz:u32-LE 4B][bw_hz:u32-LE 4B][sf:u8][cr:u8]
+            //
+            // IMPORTANT: frequency is encoded in kHz on the wire, matching how
+            // the device reports it in CMD_APP_START → RESP_CODE_SELF_INFO
+            // (field `frequency_khz`).  The `OutboundFrame` field is named
+            // `frequency_hz` for human clarity; we divide by 1000 here.
+            //
+            // This matches the pymc_core CompanionFrameServer comment:
+            //   "Frequency in kHz (match firmware self-info; client sends same encoding)"
+            // and the validation range (100_000–2_500_000 kHz = 100 MHz–2.5 GHz).
+            let freq_khz = frequency_hz / 1000;
+            p.push(CMD_SET_RADIO_PARAMS);
+            p.extend_from_slice(&freq_khz.to_le_bytes());
+            p.extend_from_slice(&bandwidth_hz.to_le_bytes());
+            p.push(*spreading_factor);
+            p.push(*coding_rate);
+        }
+        OutboundFrame::SetRadioTxPower { power_dbm } => {
+            // Wire: [CMD][power:i8]
+            p.push(CMD_SET_RADIO_TX_POWER);
+            p.push(*power_dbm as u8);
         }
         OutboundFrame::Raw { code, body } => {
             p.push(*code);

--- a/crates/meshcore-companion/tests/client.rs
+++ b/crates/meshcore-companion/tests/client.rs
@@ -4,9 +4,11 @@
 //! no real `pymc_core` process or external network is needed.  The test
 //! controls the "server" side manually via [`TcpBridge`].
 //!
-//! AppStart is always 5 wire bytes: `[0x3C][0x02][0x00][CMD_APP_START][version]`.
-//! Tests that consume the AppStart always read exactly 5 bytes to avoid
-//! leaving the version byte in the TCP buffer and corrupting subsequent reads.
+//! AppStart is always 11 wire bytes:
+//! `[0x3C][0x08][0x00][CMD_APP_START][version][0x00 × 6]` (payload padded to 8
+//! bytes per the MeshCore firmware minimum).  Tests that consume the AppStart
+//! always read exactly 11 bytes to avoid leaving stale bytes in the TCP buffer
+//! and corrupting subsequent reads.
 
 use std::time::Duration;
 
@@ -113,8 +115,8 @@ async fn loopback() -> (CompanionClient, TcpBridge) {
 /// Complete the AppStart handshake on a fresh loopback pair and wait for the
 /// `Connected` event.  Returns the `TcpBridge` so the test can continue.
 async fn complete_handshake(client: &mut CompanionClient, bridge: &mut TcpBridge, name: &str) {
-    // AppStart = 5 bytes: [prefix][len_lo=2][len_hi=0][CMD_APP_START][version]
-    let _app_start = bridge.recv_n(5).await;
+    // AppStart = 11 bytes: [prefix][len_lo=8][len_hi=0][CMD_APP_START][version][0×6]
+    let _app_start = bridge.recv_n(11).await;
     bridge.send(&self_info_frame(name)).await;
     let ev = tokio::time::timeout(Duration::from_secs(2), client.recv())
         .await
@@ -133,10 +135,15 @@ async fn complete_handshake(client: &mut CompanionClient, bridge: &mut TcpBridge
 async fn handshake_emits_connected() {
     let (mut client, mut bridge) = loopback().await;
 
-    let app_start = bridge.recv_n(5).await;
+    let app_start = bridge.recv_n(11).await;
     assert_eq!(
         app_start[0], FRAME_INBOUND_PREFIX,
         "AppStart must use inbound prefix"
+    );
+    assert_eq!(
+        u16::from_le_bytes([app_start[1], app_start[2]]),
+        8,
+        "AppStart payload length must be 8"
     );
     assert_eq!(app_start[3], CMD_APP_START, "byte[3] must be CMD_APP_START");
     assert_eq!(
@@ -167,8 +174,8 @@ async fn handshake_emits_connected() {
 async fn unsupported_app_start_emits_connected_without_self_info() {
     let (mut client, mut bridge) = loopback().await;
 
-    // Consume the AppStart the client sends.
-    let _app_start = bridge.recv_n(5).await;
+    // Consume the AppStart the client sends (11 bytes: prefix + 2-byte len + 8-byte payload).
+    let _app_start = bridge.recv_n(11).await;
 
     // Reply with ERR_CODE_UNSUPPORTED_CMD (error_code = 1).
     let err_frame = radio_frame(&[RESP_CODE_ERR, ERR_CODE_UNSUPPORTED_CMD]);
@@ -207,16 +214,21 @@ async fn unsupported_app_start_emits_connected_without_self_info() {
 async fn first_bytes_are_app_start() {
     let (_client, mut bridge) = loopback().await;
 
-    // [prefix][len_lo=2][len_hi=0][CMD_APP_START][APP_TARGET_VER_V3]
-    let wire = bridge.recv_n(5).await;
+    // [prefix][len_lo=8][len_hi=0][CMD_APP_START][APP_TARGET_VER_V3][0×6 padding]
+    let wire = bridge.recv_n(11).await;
     assert_eq!(wire[0], FRAME_INBOUND_PREFIX);
     assert_eq!(
         u16::from_le_bytes([wire[1], wire[2]]),
-        2,
-        "payload length must be 2"
+        8,
+        "payload length must be 8 (firmware minimum)"
     );
     assert_eq!(wire[3], CMD_APP_START);
     assert_eq!(wire[4], APP_TARGET_VER_V3);
+    assert_eq!(
+        &wire[5..11],
+        &[0u8; 6],
+        "trailing padding bytes must be zero"
+    );
 }
 
 /// Frames arriving after the handshake are forwarded as `Frame` events.
@@ -284,7 +296,7 @@ async fn reconnects_after_disconnect() {
 
     // ── First connection ──────────────────────────────────────────────────
     let (mut s1, _) = listener.accept().await.unwrap();
-    let mut buf = vec![0u8; 5];
+    let mut buf = vec![0u8; 11]; // AppStart = prefix(1) + len(2) + payload(8)
     tokio::io::AsyncReadExt::read_exact(&mut s1, &mut buf)
         .await
         .unwrap();
@@ -311,7 +323,7 @@ async fn reconnects_after_disconnect() {
 
     // ── Second connection (automatic reconnect) ───────────────────────────
     let (mut s2, _) = listener.accept().await.unwrap();
-    let mut buf2 = vec![0u8; 5];
+    let mut buf2 = vec![0u8; 11]; // AppStart = prefix(1) + len(2) + payload(8)
     tokio::io::AsyncReadExt::read_exact(&mut s2, &mut buf2)
         .await
         .unwrap();
@@ -342,7 +354,7 @@ async fn drop_client_closes_connection() {
     let mut client = CompanionClient::connect(config);
 
     let (mut srv, _) = listener.accept().await.unwrap();
-    let mut buf = vec![0u8; 5];
+    let mut buf = vec![0u8; 11]; // AppStart = prefix(1) + len(2) + payload(8)
     tokio::io::AsyncReadExt::read_exact(&mut srv, &mut buf)
         .await
         .unwrap();

--- a/crates/meshcore-companion/tests/codec.rs
+++ b/crates/meshcore-companion/tests/codec.rs
@@ -467,13 +467,23 @@ fn encode_app_start() {
     let wire_bytes = encode_outbound(&OutboundFrame::AppStart {
         app_target_version: APP_TARGET_VER_V3,
     });
-    // [FRAME_INBOUND_PREFIX][len_lo][len_hi][CMD_APP_START][APP_TARGET_VER_V3]
+    // Wire: [FRAME_INBOUND_PREFIX][len_lo][len_hi][CMD_APP_START][APP_TARGET_VER_V3][0×6]
+    // Payload is padded to 8 bytes minimum as required by the MeshCore companion firmware.
     assert_eq!(wire_bytes[0], FRAME_INBOUND_PREFIX);
     let len = u16::from_le_bytes([wire_bytes[1], wire_bytes[2]]) as usize;
     let payload = &wire_bytes[3..3 + len];
     assert_eq!(payload[0], CMD_APP_START);
     assert_eq!(payload[1], APP_TARGET_VER_V3);
-    assert_eq!(len, 2);
+    // Remaining bytes are zero padding.
+    assert_eq!(
+        &payload[2..],
+        &[0u8; 6],
+        "AppStart must be padded to 8-byte minimum payload"
+    );
+    assert_eq!(
+        len, 8,
+        "AppStart payload must be 8 bytes (firmware minimum)"
+    );
 }
 
 #[test]
@@ -595,6 +605,63 @@ fn strip_then_decode_curr_time() {
     let stripped = strip_frame_header(&raw).unwrap();
     let frame = decode_inbound(stripped).unwrap();
     assert_eq!(frame, InboundFrame::CurrTime { unix_time: t });
+}
+
+// ── SetRadioParams / SetRadioTxPower ─────────────────────────────────────────
+
+#[test]
+fn encode_set_radio_params_layout() {
+    // USA/Canada preset: 910_525_000 Hz, 62_500 Hz BW, SF7, CR5
+    //
+    // NOTE: the companion-frame protocol encodes frequency in kHz on the wire
+    // (matching how RESP_CODE_SELF_INFO reports it).  Our frame type stores Hz
+    // for human clarity and divides by 1000 during encoding.
+    let freq_hz: u32 = 910_525_000;
+    let freq_khz: u32 = freq_hz / 1000; // 910_525 kHz
+    let bw: u32 = 62_500;
+    let sf: u8 = 7;
+    let cr: u8 = 5;
+
+    let wire_bytes = encode_outbound(&OutboundFrame::SetRadioParams {
+        frequency_hz: freq_hz,
+        bandwidth_hz: bw,
+        spreading_factor: sf,
+        coding_rate: cr,
+    });
+
+    // Wire: [prefix:1][len:2][CMD_SET_RADIO_PARAMS][freq_khz:4-LE][bw_hz:4-LE][sf:1][cr:1]
+    let payload = &wire_bytes[3..]; // skip 3-byte header
+    assert_eq!(payload[0], CMD_SET_RADIO_PARAMS, "command byte");
+    assert_eq!(
+        &payload[1..5],
+        &freq_khz.to_le_bytes(),
+        "frequency in kHz LE"
+    );
+    assert_eq!(&payload[5..9], &bw.to_le_bytes(), "bandwidth_hz LE");
+    assert_eq!(payload[9], sf, "spreading_factor");
+    assert_eq!(payload[10], cr, "coding_rate");
+    assert_eq!(payload.len(), 11, "total payload length");
+}
+
+#[test]
+fn encode_set_radio_tx_power_layout() {
+    let power_dbm: i8 = 20;
+    let wire_bytes = encode_outbound(&OutboundFrame::SetRadioTxPower { power_dbm });
+
+    // Wire: [prefix:1][len:2][CMD_SET_RADIO_TX_POWER][power:1]
+    let payload = &wire_bytes[3..];
+    assert_eq!(payload[0], CMD_SET_RADIO_TX_POWER, "command byte");
+    assert_eq!(payload[1], power_dbm as u8, "power byte");
+    assert_eq!(payload.len(), 2, "total payload length");
+}
+
+#[test]
+fn encode_set_radio_tx_power_negative() {
+    // Negative dBm values must round-trip correctly through i8→u8→i8.
+    let power_dbm: i8 = -10;
+    let wire_bytes = encode_outbound(&OutboundFrame::SetRadioTxPower { power_dbm });
+    let payload = &wire_bytes[3..];
+    assert_eq!(payload[1] as i8, power_dbm, "negative dBm preserved");
 }
 
 // ── wrap_payload overflow guard ───────────────────────────────────────────────

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -45,7 +45,7 @@ struct Existing {
     web_enabled: bool,
     web_bind: String,
     web_backup_dir: Option<String>,
-    // pymc-companion
+    // pymc-companion (HAT)
     region_idx: usize,
     hat_idx: usize,
     // GPS
@@ -158,7 +158,7 @@ fn load_existing(out_path: &Path) -> Existing {
         .and_then(|l| l.get("longitude"))
         .and_then(|v| v.as_float());
 
-    // pymc-companion
+    // pymc-companion (HAT)
     let yaml_path = companion_yaml_path(out_path);
     let yaml = fs::read_to_string(&yaml_path).unwrap_or_default();
 


### PR DESCRIPTION
## Summary

Two fixes for the USB serial MeshCore companion transport:

**1. Serial handshake reliability** (`fix(meshcore-companion)`)
- Frame reader now scans byte-by-byte for the `0x3E` prefix, tolerating the nRF52840 boot banner that precedes the first real frame
- AppStart payload padded to the 8-byte minimum MeshCore requires
- 10-second handshake timeout with a clear log message on expiry
- 2-second settle delay after port open (nRF52840 radio/filesystem init takes ~1-2s)
- `SetRadioParams` (CMD `0x0B`) and `SetRadioTxPower` (CMD `0x0C`) added to `OutboundFrame`; wire format verified by 3 new codec tests

**2. Advert name/type/location display** (`fix(mesh)`)
- **Bug**: all nodes appeared as "unknown" type with no name or location in the adverts page
- **Root cause**: nodes already in the companion device's contact table arrive as `PUSH_CODE_ADVERT` (0x80, pubkey-only) rather than `PUSH_CODE_NEW_ADVERT` (full contact with name, advert type, GPS)
- **Fix**: send `CMD_GET_CONTACTS` immediately after handshake; handle `RESP_CODE_CONTACT` frames by upserting full metadata into the advert bus

## Test plan

- [x] Connect T114, verify `mesh: radio bridge connected` log
- [x] Adverts page: nodes show names, types (chat/repeater/etc.), and location where available
- [x] Existing HAT-connected BBS — no regression
- [x] `cargo test --workspace` passes (44 codec tests + full suite)
- [x] Config without `[plugins.mesh]` — BBS starts cleanly

Generated with [Claude Code](https://claude.com/claude-code)