### PR TITLE
feat(node): companion device key management CLI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2523,6 +2523,7 @@ dependencies = [
  "dialoguer",
  "dirs",
  "figment",
+ "meshcore-companion",
  "serde",
  "sysinfo",
  "thiserror 1.0.69",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ path = "src/main.rs"
 [features]
 default               = ["transport-cli", "transport-mesh", "transport-meshtastic", "admin-web", "transport-process"]
 transport-cli         = ["dep:bbs-cli"]
-transport-mesh        = ["dep:bbs-mesh"]
+transport-mesh        = ["dep:bbs-mesh", "dep:meshcore-companion"]
 transport-meshtastic  = ["dep:bbs-meshtastic"]
 admin-web             = ["dep:bbs-web"]
 transport-process     = ["dep:bbs-process-transport"]
@@ -35,6 +35,7 @@ bbs-mesh             = { workspace = true, optional = true }
 bbs-meshtastic       = { workspace = true, optional = true }
 bbs-web              = { workspace = true, optional = true }
 bbs-process-transport = { workspace = true, optional = true }
+meshcore-companion   = { workspace = true, optional = true }
 clap.workspace            = true
 dirs.workspace            = true
 figment.workspace         = true

--- a/crates/bbs-core/src/host.rs
+++ b/crates/bbs-core/src/host.rs
@@ -212,6 +212,12 @@ pub struct BbsHost {
     /// Absolute path to `config.toml`, used by in-BBS commands that persist
     /// policy changes to disk.  `None` in tests and minimal CLI runs.
     config_path: Option<PathBuf>,
+    /// Current node public key hex — set by the mesh transport on AppStart.
+    node_pubkey: std::sync::RwLock<Option<String>>,
+    /// Sending half of the mesh key-ops admin channel.
+    /// None when the mesh transport has not registered itself.
+    mesh_key_tx:
+        std::sync::RwLock<Option<tokio::sync::mpsc::Sender<bbs_plugin_api::MeshKeyRequest>>>,
 }
 
 impl BbsHost {
@@ -247,6 +253,8 @@ impl BbsHost {
             access_policy: RwLock::new(policy),
             guest_room_id: std::sync::RwLock::new(None),
             config_path,
+            node_pubkey: std::sync::RwLock::new(None),
+            mesh_key_tx: std::sync::RwLock::new(None),
         }
     }
 
@@ -500,6 +508,82 @@ impl Host for BbsHost {
 
     fn set_node_location(&self, location: Option<(f64, f64)>) {
         *self.location.write().unwrap() = location;
+    }
+
+    fn set_node_pubkey(&self, pubkey_hex: String) {
+        *self.node_pubkey.write().expect("node_pubkey poisoned") = Some(pubkey_hex);
+    }
+
+    fn node_pubkey(&self) -> Option<String> {
+        self.node_pubkey
+            .read()
+            .expect("node_pubkey poisoned")
+            .clone()
+    }
+
+    fn register_mesh_key_ops(
+        &self,
+        sender: tokio::sync::mpsc::Sender<bbs_plugin_api::MeshKeyRequest>,
+    ) {
+        *self.mesh_key_tx.write().expect("mesh_key_tx poisoned") = Some(sender);
+    }
+
+    async fn admin_export_node_key(&self) -> Result<String, bbs_plugin_api::HostError> {
+        let tx = self
+            .mesh_key_tx
+            .read()
+            .expect("mesh_key_tx poisoned")
+            .clone()
+            .ok_or_else(|| {
+                bbs_plugin_api::HostError::Internal("mesh transport not connected".into())
+            })?;
+        let (reply_tx, reply_rx) = tokio::sync::oneshot::channel();
+        tx.send(bbs_plugin_api::MeshKeyRequest::ExportKey { reply: reply_tx })
+            .await
+            .map_err(|_| {
+                bbs_plugin_api::HostError::Internal("mesh transport disconnected".into())
+            })?;
+        reply_rx
+            .await
+            .map_err(|_| bbs_plugin_api::HostError::Internal("key op cancelled".into()))?
+            .map_err(bbs_plugin_api::HostError::Internal)
+    }
+
+    async fn admin_import_node_key(&self, hex: String) -> Result<(), bbs_plugin_api::HostError> {
+        // Validate + decode hex -> 32 bytes.
+        if hex.len() != 64 {
+            return Err(bbs_plugin_api::HostError::PreconditionFailed(
+                "private key must be exactly 64 hex characters (32 bytes)".into(),
+            ));
+        }
+        let mut key = [0u8; 32];
+        for (i, chunk) in hex.as_bytes().chunks(2).enumerate() {
+            let s = std::str::from_utf8(chunk).map_err(|_| {
+                bbs_plugin_api::HostError::PreconditionFailed("invalid hex in private key".into())
+            })?;
+            key[i] = u8::from_str_radix(s, 16).map_err(|_| {
+                bbs_plugin_api::HostError::PreconditionFailed("invalid hex in private key".into())
+            })?;
+        }
+        let tx = self
+            .mesh_key_tx
+            .read()
+            .expect("mesh_key_tx poisoned")
+            .clone()
+            .ok_or_else(|| {
+                bbs_plugin_api::HostError::Internal("mesh transport not connected".into())
+            })?;
+        let (reply_tx, reply_rx) = tokio::sync::oneshot::channel();
+        tx.send(bbs_plugin_api::MeshKeyRequest::ImportKey {
+            key,
+            reply: reply_tx,
+        })
+        .await
+        .map_err(|_| bbs_plugin_api::HostError::Internal("mesh transport disconnected".into()))?;
+        reply_rx
+            .await
+            .map_err(|_| bbs_plugin_api::HostError::Internal("key op cancelled".into()))?
+            .map_err(bbs_plugin_api::HostError::Internal)
     }
 
     // ── Admin / web-UI operations ─────────────────────────────────────────────

--- a/crates/bbs-mesh/src/config.rs
+++ b/crates/bbs-mesh/src/config.rs
@@ -47,6 +47,51 @@ pub enum ConnectionType {
     Serial,
 }
 
+/// Radio parameter configuration stored in `[plugins.mesh.radio]`.
+///
+/// These values are **not** pushed to the device automatically on connect.
+/// Apply them explicitly via `supply-drop-bbs node set-radio` or during
+/// the setup wizard. Once applied the device (T114, Heltec V3, etc.)
+/// persists the settings in its own flash.
+///
+/// Either specify a named `preset` (which sets all parameters at once) or
+/// supply individual fields. Individual fields take precedence over the preset.
+#[derive(Debug, Clone, Default, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct RadioConfig {
+    /// Named region preset (e.g. `"USA/Canada"`).
+    ///
+    /// Run `supply-drop-bbs node set-radio --list-presets` to see all names.
+    #[serde(default)]
+    pub preset: Option<String>,
+
+    /// Carrier frequency in Hz (e.g. `910_525_000` for 910.525 MHz).
+    ///
+    /// Overrides the preset value when set.
+    #[serde(default)]
+    pub frequency_hz: Option<u64>,
+
+    /// Channel bandwidth in Hz (e.g. `62_500` for 62.5 kHz).
+    ///
+    /// Overrides the preset value when set.
+    #[serde(default)]
+    pub bandwidth_hz: Option<u32>,
+
+    /// LoRa spreading factor (7–12). Overrides the preset value when set.
+    #[serde(default)]
+    pub spreading_factor: Option<u8>,
+
+    /// LoRa coding rate denominator (5–8, representing 4/5 through 4/8).
+    ///
+    /// Overrides the preset value when set.
+    #[serde(default)]
+    pub coding_rate: Option<u8>,
+
+    /// Transmit power in dBm. Overrides the preset value when set.
+    #[serde(default)]
+    pub tx_power_dbm: Option<i32>,
+}
+
 /// Configuration for [`MeshTransport`](crate::MeshTransport).
 ///
 /// # Minimal TOML examples
@@ -156,6 +201,20 @@ pub struct MeshConfig {
     /// behaviour.  Defaults to `true`.
     #[serde(default = "default_flood_after_send")]
     pub flood_after_send: bool,
+
+    /// Radio parameter configuration.
+    ///
+    /// Stored here for reference and applied on demand via
+    /// `supply-drop-bbs node set-radio`.  **Not** pushed automatically on
+    /// every connect — the device persists radio settings in its own flash.
+    ///
+    /// Example:
+    /// ```toml
+    /// [plugins.mesh.radio]
+    /// preset = "USA/Canada"
+    /// ```
+    #[serde(default)]
+    pub radio: Option<RadioConfig>,
 }
 
 impl MeshConfig {
@@ -185,6 +244,7 @@ impl Default for MeshConfig {
             reconnect_delay_max_ms: default_reconnect_max_ms(),
             node_credential_ttl_days: default_node_credential_ttl_days(),
             flood_after_send: default_flood_after_send(),
+            radio: None,
         }
     }
 }

--- a/crates/bbs-mesh/src/transport.rs
+++ b/crates/bbs-mesh/src/transport.rs
@@ -210,6 +210,10 @@ impl Plugin for MeshTransport {
         let ttl_days = self.node_credential_ttl_days;
         let flood_after_send = self.flood_after_send;
 
+        // Admin channel: web UI → event loop for key operations.
+        let (key_tx, key_rx) = tokio::sync::mpsc::channel::<bbs_plugin_api::MeshKeyRequest>(4);
+        self.host.register_mesh_key_ops(key_tx);
+
         // Watch for advert-send requests from the web UI.
         let mut advert_send_rx = host.advert_bus().subscribe_send();
         let advert_cmd_tx = self.cmd_tx.clone();
@@ -293,6 +297,7 @@ impl Plugin for MeshTransport {
             ttl_days,
             draining,
             flood_after_send,
+            key_rx,
         ));
 
         info!("mesh transport started");
@@ -471,6 +476,16 @@ async fn push_domain_notification(
     }
 }
 
+/// Pending one-shot key operation in the event loop.
+enum PendingKeyOp {
+    Export {
+        reply: tokio::sync::oneshot::Sender<Result<String, String>>,
+    },
+    Import {
+        reply: tokio::sync::oneshot::Sender<Result<(), String>>,
+    },
+}
+
 /// Background task: receive [`ClientEvent`]s and dispatch them.
 ///
 /// Runs until the shutdown watch fires or the companion client channel closes.
@@ -486,7 +501,11 @@ async fn event_loop(
     node_credential_ttl_days: u32,
     draining: Arc<AtomicBool>,
     flood_after_send: bool,
+    mut key_rx: tokio::sync::mpsc::Receiver<bbs_plugin_api::MeshKeyRequest>,
 ) {
+    // Pending one-shot key operation. At most one at a time.
+    let mut pending_key_op: Option<PendingKeyOp> = None;
+
     loop {
         tokio::select! {
             event = client.recv() => {
@@ -521,6 +540,9 @@ async fn event_loop(
                             // detect self-advert echoes and preserve configured GPS.
                             state.lock().expect("state mutex poisoned").self_pubkey =
                                 Some(info.pubkey);
+                            // Publish pubkey to Host so the web UI can display it.
+                            let pubkey_hex: String = info.pubkey.iter().map(|b| format!("{b:02x}")).collect();
+                            host.set_node_pubkey(pubkey_hex);
                             // Push GPS coordinates to the radio if configured, and
                             // refresh the advert bus entry so the web UI shows
                             // the config GPS.
@@ -565,7 +587,52 @@ async fn event_loop(
                         }
                     }
                     Some(ClientEvent::Frame(frame)) => {
-                        handle_frame(frame, &host, &cmd_tx, &state, command_prefix, &welcome_message, node_credential_ttl_days, &draining, flood_after_send).await;
+                        use meshcore_companion::frame::InboundFrame;
+                        // Intercept key op responses before general frame dispatch.
+                        let consumed = match &frame {
+                            InboundFrame::PrivateKey { key } => {
+                                if let Some(PendingKeyOp::Export { reply }) = pending_key_op.take() {
+                                    let hex: String = key.iter().map(|b| format!("{b:02x}")).collect();
+                                    let _ = reply.send(Ok(hex));
+                                    true
+                                } else {
+                                    false
+                                }
+                            }
+                            InboundFrame::Ok => {
+                                if let Some(PendingKeyOp::Import { reply }) = pending_key_op.take() {
+                                    let _ = reply.send(Ok(()));
+                                    true
+                                } else {
+                                    false
+                                }
+                            }
+                            _ => false,
+                        };
+                        if !consumed {
+                            handle_frame(frame, &host, &cmd_tx, &state, command_prefix, &welcome_message, node_credential_ttl_days, &draining, flood_after_send).await;
+                        }
+                    }
+                }
+            }
+            Some(req) = key_rx.recv() => {
+                use bbs_plugin_api::MeshKeyRequest;
+                match req {
+                    MeshKeyRequest::ExportKey { reply } => {
+                        if pending_key_op.is_some() {
+                            let _ = reply.send(Err("another key operation is already in progress".into()));
+                        } else {
+                            let _ = cmd_tx.send(OutboundFrame::ExportPrivateKey).await;
+                            pending_key_op = Some(PendingKeyOp::Export { reply });
+                        }
+                    }
+                    MeshKeyRequest::ImportKey { key, reply } => {
+                        if pending_key_op.is_some() {
+                            let _ = reply.send(Err("another key operation is already in progress".into()));
+                        } else {
+                            let _ = cmd_tx.send(OutboundFrame::ImportPrivateKey { key }).await;
+                            pending_key_op = Some(PendingKeyOp::Import { reply });
+                        }
                     }
                 }
             }

--- a/crates/bbs-mesh/src/transport.rs
+++ b/crates/bbs-mesh/src/transport.rs
@@ -760,12 +760,18 @@ async fn handle_frame(
             // Populate the advert bus with full metadata from the device's
             // contact list — these arrive as RESP_CODE_CONTACT frames after
             // CMD_GET_CONTACTS and contain name, type, and location.
-            host.advert_bus().upsert(
+            //
+            // Use upsert_with_timestamp so the "Last Seen" column reflects the
+            // real last-advert time stored on the device rather than the moment
+            // we happened to run GetContacts (which would make every row show
+            // the same timestamp).
+            host.advert_bus().upsert_with_timestamp(
                 contact.pubkey,
                 contact.name.clone(),
                 contact.adv_type,
                 contact.gps_lat,
                 contact.gps_lon,
+                contact.last_advert_timestamp as i64,
             );
             // Record the full pubkey mapping so ResetPath can find the node.
             let prefix: [u8; 6] = contact.pubkey[..6].try_into().expect("pubkey is 32 bytes");

--- a/crates/bbs-mesh/src/transport.rs
+++ b/crates/bbs-mesh/src/transport.rs
@@ -696,7 +696,7 @@ async fn handle_frame(
             // While draining, discard queued messages and request the next one
             // so we flush the entire backlog before serving live traffic.
             if draining.load(Ordering::Relaxed) {
-                info!(
+                debug!(
                     prefix = msg.sender_key_prefix[0],
                     "mesh: discarding stale queued message (draining)"
                 );
@@ -707,14 +707,14 @@ async fn handle_frame(
             // Only handle plain-text messages; CLI data and signed frames are
             // not BBS commands.
             if msg.txt_type != meshcore_companion::constants::TXT_TYPE_PLAIN {
-                info!(
+                debug!(
                     txt_type = msg.txt_type,
                     "mesh: ignoring non-plain-text ContactMsg"
                 );
                 return;
             }
 
-            info!(
+            debug!(
                 prefix = msg.sender_key_prefix[0],
                 txt_type = msg.txt_type,
                 len = msg.text.len(),
@@ -737,7 +737,7 @@ async fn handle_frame(
         // ── Queued message notification ───────────────────────────────────────
         // The bridge has a message waiting; fetch it with SyncNextMessage.
         InboundFrame::MsgWaiting => {
-            info!("mesh: MsgWaiting — fetching next queued message");
+            debug!("mesh: MsgWaiting — fetching next queued message");
             if cmd_tx.send(OutboundFrame::SyncNextMessage).await.is_err() {
                 warn!("mesh: could not enqueue SyncNextMessage — cmd channel closed");
             }
@@ -942,7 +942,7 @@ async fn dispatch_message(
             .set_last_workflow_reply(&sender_prefix, text.to_owned());
     }
 
-    info!(?session, ?cmd, "mesh: dispatching command");
+    debug!(?session, ?cmd, "mesh: dispatching command");
 
     // ── Process through the host ──────────────────────────────────────────────
     // On UnknownSession (e.g. server restarted while the transport retained a
@@ -1070,7 +1070,7 @@ async fn dispatch_message(
             reply_text
         };
 
-        info!(
+        debug!(
             ?session,
             len = reply_text.len(),
             frame = i + 1,

--- a/crates/bbs-mesh/src/transport.rs
+++ b/crates/bbs-mesh/src/transport.rs
@@ -579,6 +579,16 @@ async fn event_loop(
                         let _ = cmd_tx.send(OutboundFrame::GetContacts { since: 0 }).await;
                     }
                     Some(ClientEvent::Disconnected { will_retry }) => {
+                        // If a key operation is in flight, fail it immediately so
+                        // the caller's oneshot receiver is not left hanging
+                        // indefinitely waiting for a reply that will never come.
+                        if let Some(op) = pending_key_op.take() {
+                            let err = "device disconnected".to_owned();
+                            match op {
+                                PendingKeyOp::Export { reply } => { let _ = reply.send(Err(err)); }
+                                PendingKeyOp::Import { reply } => { let _ = reply.send(Err(err)); }
+                            }
+                        }
                         if will_retry {
                             info!("mesh: radio bridge disconnected, will retry");
                         } else {
@@ -602,6 +612,20 @@ async fn event_loop(
                             InboundFrame::Ok => {
                                 if let Some(PendingKeyOp::Import { reply }) = pending_key_op.take() {
                                     let _ = reply.send(Ok(()));
+                                    true
+                                } else {
+                                    false
+                                }
+                            }
+                            // Device returned an error frame while a key op was in
+                            // flight — propagate it so the caller doesn't hang.
+                            InboundFrame::Err { error_code } => {
+                                if let Some(op) = pending_key_op.take() {
+                                    let msg = format!("device error (code {error_code:#04x})");
+                                    match op {
+                                        PendingKeyOp::Export { reply } => { let _ = reply.send(Err(msg)); }
+                                        PendingKeyOp::Import { reply } => { let _ = reply.send(Err(msg)); }
+                                    }
                                     true
                                 } else {
                                     false

--- a/crates/bbs-plugin-api/src/advert.rs
+++ b/crates/bbs-plugin-api/src/advert.rs
@@ -108,6 +108,51 @@ impl AdvertBus {
         entry.last_seen_secs = now;
     }
 
+    /// Insert or update a full advertisement with an explicit `last_seen` timestamp.
+    ///
+    /// Use this when the timestamp comes from the device (e.g. the
+    /// `last_advert_timestamp` field in a `RESP_CODE_CONTACT` frame) rather than
+    /// the current wall clock. A `device_last_seen` of `0` falls back to `now`.
+    ///
+    /// Updates all fields for an existing record; preserves `first_seen_secs`.
+    pub fn upsert_with_timestamp(
+        &self,
+        pubkey: [u8; 32],
+        name: String,
+        adv_type: u8,
+        gps_lat: i32,
+        gps_lon: i32,
+        device_last_seen: i64,
+    ) {
+        let now = unix_now();
+        let last_seen = if device_last_seen > 0 {
+            device_last_seen
+        } else {
+            now
+        };
+        let lat = gps_lat as f64 / 1_000_000.0;
+        let lon = gps_lon as f64 / 1_000_000.0;
+        let mut records = self.records.lock().expect("advert bus poisoned");
+        let entry = records.entry(pubkey).or_insert_with(|| AdvertRecord {
+            pubkey_hex: hex_encode(&pubkey),
+            name: String::new(),
+            adv_type: 0,
+            lat: 0.0,
+            lon: 0.0,
+            first_seen_secs: now,
+            last_seen_secs: last_seen,
+        });
+        entry.name = name;
+        entry.adv_type = adv_type;
+        entry.lat = lat;
+        entry.lon = lon;
+        // Only advance last_seen — never move it backwards. A live advert
+        // arriving later will always have a wall-clock time ≥ the stored value.
+        if last_seen > entry.last_seen_secs {
+            entry.last_seen_secs = last_seen;
+        }
+    }
+
     /// Insert or update a short advertisement (pubkey only).
     ///
     /// Updates `last_seen_secs` on an existing record without overwriting

--- a/crates/bbs-plugin-api/src/host.rs
+++ b/crates/bbs-plugin-api/src/host.rs
@@ -24,6 +24,22 @@
 
 use std::sync::Arc;
 
+/// Request sent from [`Host`] to the mesh transport's admin channel.
+pub enum MeshKeyRequest {
+    /// Fetch the device's private key hex (64 chars).
+    ExportKey {
+        /// One-shot channel to deliver the result back to the caller.
+        reply: tokio::sync::oneshot::Sender<Result<String, String>>,
+    },
+    /// Push a new private key (32 raw bytes) to the device.
+    ImportKey {
+        /// Raw 32-byte private key to install on the device.
+        key: [u8; 32],
+        /// One-shot channel to deliver the result back to the caller.
+        reply: tokio::sync::oneshot::Sender<Result<(), String>>,
+    },
+}
+
 use crate::admin::{
     AdminAccessPolicy, AdminAuditEntry, AdminBackupRecord, AdminMessageRecord, AdminReports,
     AdminRoomSummary, AdminSessionInfo, AdminStats, AdminUserInfo,
@@ -386,6 +402,33 @@ pub trait Host: Send + Sync {
     /// Called by the web admin after saving a `[location]` config change.
     /// The mesh transport reads this on the next reconnect.
     fn set_node_location(&self, _location: Option<(f64, f64)>) {}
+
+    /// Called by the mesh transport when AppStart SelfInfo is received.
+    /// Stores the node's public key hex so it can be displayed in the web UI.
+    fn set_node_pubkey(&self, _pubkey_hex: String) {}
+
+    /// Return the current node public key hex (set by the mesh transport on connect).
+    fn node_pubkey(&self) -> Option<String> {
+        None
+    }
+
+    /// Register the mesh transport's admin command channel.
+    /// Called by MeshTransport on start; the sender is stored so Host methods
+    /// can route key operations through the live transport.
+    fn register_mesh_key_ops(&self, _sender: tokio::sync::mpsc::Sender<MeshKeyRequest>) {}
+
+    /// Export the device's private key as a 64-char hex string.
+    /// Requires the mesh transport to be connected.
+    async fn admin_export_node_key(&self) -> Result<String, HostError> {
+        Err(HostError::NotSupported("admin_export_node_key".into()))
+    }
+
+    /// Import a new private key from a 64-char hex string.
+    /// Requires the mesh transport to be connected.
+    async fn admin_import_node_key(&self, hex: String) -> Result<(), HostError> {
+        let _ = hex;
+        Err(HostError::NotSupported("admin_import_node_key".into()))
+    }
 
     // ── Mesh node credentials ────────────────────────────────────────────────────
     //

--- a/crates/bbs-plugin-api/src/lib.rs
+++ b/crates/bbs-plugin-api/src/lib.rs
@@ -58,7 +58,7 @@ pub use advert::{AdvertBus, AdvertRecord};
 pub use command::{Command, Response};
 pub use error::{HostError, PluginError, TransportError};
 pub use event::{DomainEvent, MessageRecipient, Notification, NotifyOutcome};
-pub use host::Host;
+pub use host::{Host, MeshKeyRequest};
 pub use identity::{SessionId, Username};
 pub use permissions::{PermissionCtx, PermissionLevel};
 pub use plugin::Plugin;

--- a/crates/bbs-web/src/lib.rs
+++ b/crates/bbs-web/src/lib.rs
@@ -34,6 +34,8 @@
 //! │  │  PATCH /api/v1/config              (auth)       │    │
 //! │  │  GET  /api/v1/access-policy        (auth)       │    │
 //! │  │  PATCH /api/v1/access-policy       (auth)       │    │
+//! │  │  GET  /api/v1/radio-config         (auth)       │    │
+//! │  │  PATCH /api/v1/radio-config        (auth)       │    │
 //! │  │  GET  /api/v1/errors               (auth)       │    │
 //! │  │  GET  /api/v1/metrics              (auth)       │    │
 //! │  │  GET  /api/v1/sse/logs             (auth)       │    │
@@ -550,6 +552,10 @@ fn build_router(state: Arc<AppState>) -> Router {
         .route(
             "/access-policy",
             get(api_get_access_policy).patch(api_patch_access_policy),
+        )
+        .route(
+            "/radio-config",
+            get(api_get_radio_config).patch(api_patch_radio_config),
         )
         .route("/restart", post(api_restart))
         .route("/logs", get(api_logs))
@@ -1544,6 +1550,37 @@ async fn api_settings(State(state): State<Arc<AppState>>) -> impl IntoResponse {
 
 // ── Config read / write ───────────────────────────────────────────────────────
 
+/// Response body for `GET /api/v1/radio-config`.
+#[derive(Debug, Serialize)]
+struct RadioConfigResponse {
+    preset: Option<String>,
+    frequency_hz: Option<u64>,
+    bandwidth_hz: Option<u32>,
+    spreading_factor: Option<u8>,
+    coding_rate: Option<u8>,
+    tx_power_dbm: Option<i32>,
+    /// All available preset names, for populating the UI dropdown.
+    presets: Vec<&'static str>,
+}
+
+/// Patch body for `PATCH /api/v1/radio-config`.
+/// `None` means "leave unchanged"; for optional fields, JSON `null` clears the value.
+#[derive(Debug, Deserialize)]
+struct RadioConfigPatch {
+    /// Named preset. JSON null clears it; a string sets it.
+    preset: Option<serde_json::Value>,
+    /// Carrier frequency in Hz. JSON null clears it.
+    frequency_hz: Option<serde_json::Value>,
+    /// Channel bandwidth in Hz. JSON null clears it.
+    bandwidth_hz: Option<serde_json::Value>,
+    /// LoRa spreading factor (7–12). JSON null clears it.
+    spreading_factor: Option<serde_json::Value>,
+    /// Coding rate denominator (5–8). JSON null clears it.
+    coding_rate: Option<serde_json::Value>,
+    /// TX power in dBm. JSON null clears it.
+    tx_power_dbm: Option<serde_json::Value>,
+}
+
 /// Editable subset of the BBS configuration, returned by GET /api/v1/config.
 ///
 /// Only fields that are safe to change via the web UI are included.
@@ -1656,6 +1693,30 @@ fn system_timezone() -> String {
     "UTC".to_owned()
 }
 
+/// Preset names mirrored from `src/mesh_presets.rs`.
+/// Duplicated here because `bbs-web` does not depend on the main binary.
+const RADIO_PRESET_NAMES: &[&str] = &[
+    "Australia",
+    "Australia (Narrow)",
+    "Australia SA, WA, QLD",
+    "Czech Republic",
+    "EU 433MHz",
+    "EU/UK (Long Range)",
+    "EU/UK (Medium Range)",
+    "EU/UK (Narrow)",
+    "New Zealand",
+    "New Zealand (Narrow)",
+    "Portugal 433",
+    "Portugal 869",
+    "Switzerland",
+    "USA Arizona",
+    "USA/Canada",
+    "Vietnam",
+    "Off-Grid 433",
+    "Off-Grid 869",
+    "Off-Grid 918",
+];
+
 fn read_config_toml(path: &str) -> Result<toml::Value, String> {
     let raw =
         std::fs::read_to_string(path).map_err(|e| format!("could not read config file: {e}"))?;
@@ -1681,6 +1742,73 @@ fn toml_u64_field(val: &toml::Value, section: &str, key: &str) -> Option<u64> {
 
 fn toml_f64_field(val: &toml::Value, section: &str, key: &str) -> Option<f64> {
     val.get(section)?.get(key)?.as_float()
+}
+
+fn toml_radio_str(val: &toml::Value, key: &str) -> Option<String> {
+    val.get("plugins")?
+        .get("mesh")?
+        .get("radio")?
+        .get(key)?
+        .as_str()
+        .map(str::to_owned)
+}
+
+fn toml_radio_u64(val: &toml::Value, key: &str) -> Option<u64> {
+    val.get("plugins")?
+        .get("mesh")?
+        .get("radio")?
+        .get(key)?
+        .as_integer()
+        .map(|i| i as u64)
+}
+
+fn toml_radio_u32(val: &toml::Value, key: &str) -> Option<u32> {
+    val.get("plugins")?
+        .get("mesh")?
+        .get("radio")?
+        .get(key)?
+        .as_integer()
+        .map(|i| i as u32)
+}
+
+fn toml_radio_i32(val: &toml::Value, key: &str) -> Option<i32> {
+    val.get("plugins")?
+        .get("mesh")?
+        .get("radio")?
+        .get(key)?
+        .as_integer()
+        .map(|i| i as i32)
+}
+
+/// Set a scalar key in `[plugins.mesh.radio]`, creating the table path as needed.
+fn doc_set_radio_field(doc: &mut toml_edit::DocumentMut, key: &str, val: toml_edit::Value) {
+    // Ensure [plugins] exists as a table
+    if doc.get("plugins").is_none() {
+        doc["plugins"] = toml_edit::Item::Table(toml_edit::Table::new());
+    }
+    let plugins = doc["plugins"].as_table_mut().unwrap();
+    if plugins.get("mesh").is_none() {
+        plugins.insert("mesh", toml_edit::Item::Table(toml_edit::Table::new()));
+    }
+    let mesh = plugins.get_mut("mesh").unwrap().as_table_mut().unwrap();
+    if mesh.get("radio").is_none() {
+        mesh.insert("radio", toml_edit::Item::Table(toml_edit::Table::new()));
+    }
+    let radio = mesh.get_mut("radio").unwrap().as_table_mut().unwrap();
+    radio.insert(key, toml_edit::Item::Value(val));
+}
+
+/// Remove a key from `[plugins.mesh.radio]` if the table path exists.
+fn doc_remove_radio_field(doc: &mut toml_edit::DocumentMut, key: &str) {
+    if let Some(plugins) = doc.get_mut("plugins") {
+        if let Some(mesh) = plugins.as_table_mut().and_then(|t| t.get_mut("mesh")) {
+            if let Some(radio) = mesh.as_table_mut().and_then(|t| t.get_mut("radio")) {
+                if let Some(t) = radio.as_table_mut() {
+                    t.remove(key);
+                }
+            }
+        }
+    }
 }
 
 /// Remove a key from a section in a [`toml_edit::DocumentMut`], if it exists.
@@ -2048,6 +2176,173 @@ async fn api_patch_access_policy(
         )
             .into_response(),
     }
+}
+
+// ── Radio config ──────────────────────────────────────────────────────────────
+
+async fn api_get_radio_config(
+    State(state): State<Arc<AppState>>,
+    Extension(user): Extension<CurrentUser>,
+) -> Response {
+    if user.permission_level < 100 {
+        return (StatusCode::FORBIDDEN, Json(json_error("sysop required"))).into_response();
+    }
+
+    let path = match &state.config.config_path {
+        Some(p) if !p.is_empty() => p.clone(),
+        _ => {
+            return (
+                StatusCode::NOT_FOUND,
+                Json(json_error(
+                    "config_path not set in [plugins.web] — cannot read config",
+                )),
+            )
+                .into_response()
+        }
+    };
+
+    let val = match read_config_toml(&path) {
+        Ok(v) => v,
+        Err(e) => return (StatusCode::INTERNAL_SERVER_ERROR, Json(json_error(&e))).into_response(),
+    };
+
+    Json(RadioConfigResponse {
+        preset: toml_radio_str(&val, "preset"),
+        frequency_hz: toml_radio_u64(&val, "frequency_hz"),
+        bandwidth_hz: toml_radio_u32(&val, "bandwidth_hz"),
+        spreading_factor: toml_radio_u32(&val, "spreading_factor").map(|v| v as u8),
+        coding_rate: toml_radio_u32(&val, "coding_rate").map(|v| v as u8),
+        tx_power_dbm: toml_radio_i32(&val, "tx_power_dbm"),
+        presets: RADIO_PRESET_NAMES.to_vec(),
+    })
+    .into_response()
+}
+
+async fn api_patch_radio_config(
+    State(state): State<Arc<AppState>>,
+    Extension(user): Extension<CurrentUser>,
+    Json(patch): Json<RadioConfigPatch>,
+) -> Response {
+    if user.permission_level < 100 {
+        return (StatusCode::FORBIDDEN, Json(json_error("sysop required"))).into_response();
+    }
+
+    let path = match &state.config.config_path {
+        Some(p) if !p.is_empty() => p.clone(),
+        _ => {
+            return (
+                StatusCode::NOT_FOUND,
+                Json(json_error(
+                    "config_path not set in [plugins.web] — cannot write config",
+                )),
+            )
+                .into_response()
+        }
+    };
+
+    let raw = match std::fs::read_to_string(&path) {
+        Ok(s) => s,
+        Err(e) => {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json_error(&format!("could not read config file: {e}"))),
+            )
+                .into_response()
+        }
+    };
+    let mut doc = match raw.parse::<toml_edit::DocumentMut>() {
+        Ok(d) => d,
+        Err(e) => {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json_error(&format!("could not parse config file: {e}"))),
+            )
+                .into_response()
+        }
+    };
+
+    // Apply patches — null clears the key; a value sets it.
+    if let Some(v) = patch.preset {
+        if v.is_null() {
+            doc_remove_radio_field(&mut doc, "preset");
+        } else if let Some(s) = v.as_str() {
+            doc_set_radio_field(&mut doc, "preset", toml_edit::Value::from(s));
+        }
+    }
+    if let Some(v) = patch.frequency_hz {
+        if v.is_null() {
+            doc_remove_radio_field(&mut doc, "frequency_hz");
+        } else if let Some(n) = v.as_u64() {
+            doc_set_radio_field(&mut doc, "frequency_hz", toml_edit::Value::from(n as i64));
+        }
+    }
+    if let Some(v) = patch.bandwidth_hz {
+        if v.is_null() {
+            doc_remove_radio_field(&mut doc, "bandwidth_hz");
+        } else if let Some(n) = v.as_u64() {
+            doc_set_radio_field(&mut doc, "bandwidth_hz", toml_edit::Value::from(n as i64));
+        }
+    }
+    if let Some(v) = patch.spreading_factor {
+        if v.is_null() {
+            doc_remove_radio_field(&mut doc, "spreading_factor");
+        } else if let Some(n) = v.as_u64() {
+            doc_set_radio_field(
+                &mut doc,
+                "spreading_factor",
+                toml_edit::Value::from(n as i64),
+            );
+        }
+    }
+    if let Some(v) = patch.coding_rate {
+        if v.is_null() {
+            doc_remove_radio_field(&mut doc, "coding_rate");
+        } else if let Some(n) = v.as_u64() {
+            doc_set_radio_field(&mut doc, "coding_rate", toml_edit::Value::from(n as i64));
+        }
+    }
+    if let Some(v) = patch.tx_power_dbm {
+        if v.is_null() {
+            doc_remove_radio_field(&mut doc, "tx_power_dbm");
+        } else if let Some(n) = v.as_i64() {
+            doc_set_radio_field(&mut doc, "tx_power_dbm", toml_edit::Value::from(n));
+        }
+    }
+
+    if let Err(e) = std::fs::write(&path, doc.to_string()) {
+        return (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(json_error(&format!("could not write config file: {e}"))),
+        )
+            .into_response();
+    }
+
+    // Audit log — best-effort.
+    let _ = state
+        .host
+        .admin_write_audit(
+            &format!("web:{}", user.username),
+            "radio_config_change",
+            None,
+            None,
+        )
+        .await;
+
+    // Return updated config.
+    let val = match read_config_toml(&path) {
+        Ok(v) => v,
+        Err(e) => return (StatusCode::INTERNAL_SERVER_ERROR, Json(json_error(&e))).into_response(),
+    };
+    Json(RadioConfigResponse {
+        preset: toml_radio_str(&val, "preset"),
+        frequency_hz: toml_radio_u64(&val, "frequency_hz"),
+        bandwidth_hz: toml_radio_u32(&val, "bandwidth_hz"),
+        spreading_factor: toml_radio_u32(&val, "spreading_factor").map(|v| v as u8),
+        coding_rate: toml_radio_u32(&val, "coding_rate").map(|v| v as u8),
+        tx_power_dbm: toml_radio_i32(&val, "tx_power_dbm"),
+        presets: RADIO_PRESET_NAMES.to_vec(),
+    })
+    .into_response()
 }
 
 // ── HTTP log poll ─────────────────────────────────────────────────────────────

--- a/crates/bbs-web/src/lib.rs
+++ b/crates/bbs-web/src/lib.rs
@@ -2559,7 +2559,16 @@ async fn api_import_node_key(
     }
     match state.host.admin_import_node_key(body.key).await {
         Ok(()) => Json(serde_json::json!({ "ok": true })).into_response(),
-        Err(e) => (StatusCode::BAD_REQUEST, Json(json_error(&format!("{e}")))).into_response(),
+        Err(e) => {
+            // PreconditionFailed = bad key from the client (400).
+            // Internal / NotSupported = transport unavailable or server fault (503/500).
+            let status = match &e {
+                HostError::PreconditionFailed(_) => StatusCode::BAD_REQUEST,
+                HostError::Internal(_) => StatusCode::SERVICE_UNAVAILABLE,
+                _ => StatusCode::INTERNAL_SERVER_ERROR,
+            };
+            (status, Json(json_error(&format!("{e}")))).into_response()
+        }
     }
 }
 

--- a/crates/bbs-web/src/lib.rs
+++ b/crates/bbs-web/src/lib.rs
@@ -557,6 +557,9 @@ fn build_router(state: Arc<AppState>) -> Router {
             "/radio-config",
             get(api_get_radio_config).patch(api_patch_radio_config),
         )
+        .route("/node-identity", get(api_get_node_identity))
+        .route("/node-identity/export-key", post(api_export_node_key))
+        .route("/node-identity/import-key", post(api_import_node_key))
         .route("/restart", post(api_restart))
         .route("/logs", get(api_logs))
         .route("/sse/logs", get(api_sse_logs))
@@ -2343,6 +2346,64 @@ async fn api_patch_radio_config(
         presets: RADIO_PRESET_NAMES.to_vec(),
     })
     .into_response()
+}
+
+// ── Node identity ─────────────────────────────────────────────────────────────
+
+#[derive(Debug, Serialize)]
+struct NodeIdentityResponse {
+    /// Current node public key hex (64 chars), or null if not yet connected.
+    pubkey: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ImportKeyBody {
+    /// 64-char hex private key.
+    key: String,
+}
+
+async fn api_get_node_identity(
+    State(state): State<Arc<AppState>>,
+    Extension(user): Extension<CurrentUser>,
+) -> Response {
+    if user.permission_level < 100 {
+        return (StatusCode::FORBIDDEN, Json(json_error("sysop required"))).into_response();
+    }
+    Json(NodeIdentityResponse {
+        pubkey: state.host.node_pubkey(),
+    })
+    .into_response()
+}
+
+async fn api_export_node_key(
+    State(state): State<Arc<AppState>>,
+    Extension(user): Extension<CurrentUser>,
+) -> Response {
+    if user.permission_level < 100 {
+        return (StatusCode::FORBIDDEN, Json(json_error("sysop required"))).into_response();
+    }
+    match state.host.admin_export_node_key().await {
+        Ok(hex) => Json(serde_json::json!({ "key": hex })).into_response(),
+        Err(e) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(json_error(&format!("{e}"))),
+        )
+            .into_response(),
+    }
+}
+
+async fn api_import_node_key(
+    State(state): State<Arc<AppState>>,
+    Extension(user): Extension<CurrentUser>,
+    Json(body): Json<ImportKeyBody>,
+) -> Response {
+    if user.permission_level < 100 {
+        return (StatusCode::FORBIDDEN, Json(json_error("sysop required"))).into_response();
+    }
+    match state.host.admin_import_node_key(body.key).await {
+        Ok(()) => Json(serde_json::json!({ "ok": true })).into_response(),
+        Err(e) => (StatusCode::BAD_REQUEST, Json(json_error(&format!("{e}")))).into_response(),
+    }
 }
 
 // ── HTTP log poll ─────────────────────────────────────────────────────────────

--- a/crates/bbs-web/src/lib.rs
+++ b/crates/bbs-web/src/lib.rs
@@ -1553,6 +1553,17 @@ async fn api_settings(State(state): State<Arc<AppState>>) -> impl IntoResponse {
 
 // ── Config read / write ───────────────────────────────────────────────────────
 
+/// One entry in the `presets` list returned by `GET /api/v1/radio-config`.
+#[derive(Debug, Clone, Serialize)]
+struct RadioPresetDetail {
+    name: &'static str,
+    frequency_hz: u64,
+    bandwidth_hz: u32,
+    spreading_factor: u8,
+    coding_rate: u8,
+    tx_power_dbm: i32,
+}
+
 /// Response body for `GET /api/v1/radio-config`.
 #[derive(Debug, Serialize)]
 struct RadioConfigResponse {
@@ -1562,8 +1573,12 @@ struct RadioConfigResponse {
     spreading_factor: Option<u8>,
     coding_rate: Option<u8>,
     tx_power_dbm: Option<i32>,
-    /// All available preset names, for populating the UI dropdown.
-    presets: Vec<&'static str>,
+    /// MeshCore connection type: `"serial"`, `"tcp"`, or `"hat"`.
+    connection_type: Option<String>,
+    /// Serial port path (only set when `connection_type` is `"serial"`).
+    serial_port: Option<String>,
+    /// Full preset details for populating the UI dropdown and auto-filling fields.
+    presets: Vec<RadioPresetDetail>,
 }
 
 /// Patch body for `PATCH /api/v1/radio-config`.
@@ -1698,26 +1713,161 @@ fn system_timezone() -> String {
 
 /// Preset names mirrored from `src/mesh_presets.rs`.
 /// Duplicated here because `bbs-web` does not depend on the main binary.
-const RADIO_PRESET_NAMES: &[&str] = &[
-    "Australia",
-    "Australia (Narrow)",
-    "Australia SA, WA, QLD",
-    "Czech Republic",
-    "EU 433MHz",
-    "EU/UK (Long Range)",
-    "EU/UK (Medium Range)",
-    "EU/UK (Narrow)",
-    "New Zealand",
-    "New Zealand (Narrow)",
-    "Portugal 433",
-    "Portugal 869",
-    "Switzerland",
-    "USA Arizona",
-    "USA/Canada",
-    "Vietnam",
-    "Off-Grid 433",
-    "Off-Grid 869",
-    "Off-Grid 918",
+/// Full preset data mirrored from `src/mesh_presets.rs`.
+/// Duplicated here because `bbs-web` does not depend on the main binary.
+const RADIO_PRESETS: &[RadioPresetDetail] = &[
+    RadioPresetDetail {
+        name: "Australia",
+        frequency_hz: 915_800_000,
+        bandwidth_hz: 250_000,
+        spreading_factor: 10,
+        coding_rate: 5,
+        tx_power_dbm: 20,
+    },
+    RadioPresetDetail {
+        name: "Australia (Narrow)",
+        frequency_hz: 916_575_000,
+        bandwidth_hz: 62_500,
+        spreading_factor: 7,
+        coding_rate: 5,
+        tx_power_dbm: 20,
+    },
+    RadioPresetDetail {
+        name: "Australia SA, WA, QLD",
+        frequency_hz: 923_125_000,
+        bandwidth_hz: 62_500,
+        spreading_factor: 8,
+        coding_rate: 5,
+        tx_power_dbm: 20,
+    },
+    RadioPresetDetail {
+        name: "Czech Republic",
+        frequency_hz: 869_432_000,
+        bandwidth_hz: 62_500,
+        spreading_factor: 7,
+        coding_rate: 5,
+        tx_power_dbm: 14,
+    },
+    RadioPresetDetail {
+        name: "EU 433MHz",
+        frequency_hz: 433_650_000,
+        bandwidth_hz: 250_000,
+        spreading_factor: 11,
+        coding_rate: 5,
+        tx_power_dbm: 20,
+    },
+    RadioPresetDetail {
+        name: "EU/UK (Long Range)",
+        frequency_hz: 869_525_000,
+        bandwidth_hz: 250_000,
+        spreading_factor: 11,
+        coding_rate: 5,
+        tx_power_dbm: 14,
+    },
+    RadioPresetDetail {
+        name: "EU/UK (Medium Range)",
+        frequency_hz: 869_525_000,
+        bandwidth_hz: 250_000,
+        spreading_factor: 10,
+        coding_rate: 5,
+        tx_power_dbm: 14,
+    },
+    RadioPresetDetail {
+        name: "EU/UK (Narrow)",
+        frequency_hz: 869_618_000,
+        bandwidth_hz: 62_500,
+        spreading_factor: 8,
+        coding_rate: 5,
+        tx_power_dbm: 14,
+    },
+    RadioPresetDetail {
+        name: "New Zealand",
+        frequency_hz: 917_375_000,
+        bandwidth_hz: 250_000,
+        spreading_factor: 11,
+        coding_rate: 5,
+        tx_power_dbm: 20,
+    },
+    RadioPresetDetail {
+        name: "New Zealand (Narrow)",
+        frequency_hz: 917_375_000,
+        bandwidth_hz: 62_500,
+        spreading_factor: 7,
+        coding_rate: 5,
+        tx_power_dbm: 20,
+    },
+    RadioPresetDetail {
+        name: "Portugal 433",
+        frequency_hz: 433_375_000,
+        bandwidth_hz: 62_500,
+        spreading_factor: 9,
+        coding_rate: 5,
+        tx_power_dbm: 20,
+    },
+    RadioPresetDetail {
+        name: "Portugal 869",
+        frequency_hz: 869_618_000,
+        bandwidth_hz: 62_500,
+        spreading_factor: 7,
+        coding_rate: 5,
+        tx_power_dbm: 14,
+    },
+    RadioPresetDetail {
+        name: "Switzerland",
+        frequency_hz: 869_618_000,
+        bandwidth_hz: 62_500,
+        spreading_factor: 8,
+        coding_rate: 5,
+        tx_power_dbm: 14,
+    },
+    RadioPresetDetail {
+        name: "USA Arizona",
+        frequency_hz: 908_205_000,
+        bandwidth_hz: 62_500,
+        spreading_factor: 10,
+        coding_rate: 5,
+        tx_power_dbm: 20,
+    },
+    RadioPresetDetail {
+        name: "USA/Canada",
+        frequency_hz: 910_525_000,
+        bandwidth_hz: 62_500,
+        spreading_factor: 7,
+        coding_rate: 5,
+        tx_power_dbm: 20,
+    },
+    RadioPresetDetail {
+        name: "Vietnam",
+        frequency_hz: 920_250_000,
+        bandwidth_hz: 250_000,
+        spreading_factor: 11,
+        coding_rate: 5,
+        tx_power_dbm: 20,
+    },
+    RadioPresetDetail {
+        name: "Off-Grid 433",
+        frequency_hz: 433_000_000,
+        bandwidth_hz: 250_000,
+        spreading_factor: 11,
+        coding_rate: 8,
+        tx_power_dbm: 20,
+    },
+    RadioPresetDetail {
+        name: "Off-Grid 869",
+        frequency_hz: 869_000_000,
+        bandwidth_hz: 250_000,
+        spreading_factor: 11,
+        coding_rate: 8,
+        tx_power_dbm: 14,
+    },
+    RadioPresetDetail {
+        name: "Off-Grid 918",
+        frequency_hz: 918_000_000,
+        bandwidth_hz: 250_000,
+        spreading_factor: 11,
+        coding_rate: 8,
+        tx_power_dbm: 20,
+    },
 ];
 
 fn read_config_toml(path: &str) -> Result<toml::Value, String> {
@@ -2209,6 +2359,9 @@ async fn api_get_radio_config(
         Err(e) => return (StatusCode::INTERNAL_SERVER_ERROR, Json(json_error(&e))).into_response(),
     };
 
+    let connection_type = toml_plugin_str(&val, "mesh", "connection_type");
+    let serial_port = toml_plugin_str(&val, "mesh", "serial_port");
+
     Json(RadioConfigResponse {
         preset: toml_radio_str(&val, "preset"),
         frequency_hz: toml_radio_u64(&val, "frequency_hz"),
@@ -2216,7 +2369,9 @@ async fn api_get_radio_config(
         spreading_factor: toml_radio_u32(&val, "spreading_factor").map(|v| v as u8),
         coding_rate: toml_radio_u32(&val, "coding_rate").map(|v| v as u8),
         tx_power_dbm: toml_radio_i32(&val, "tx_power_dbm"),
-        presets: RADIO_PRESET_NAMES.to_vec(),
+        connection_type,
+        serial_port,
+        presets: RADIO_PRESETS.to_vec(),
     })
     .into_response()
 }
@@ -2343,7 +2498,9 @@ async fn api_patch_radio_config(
         spreading_factor: toml_radio_u32(&val, "spreading_factor").map(|v| v as u8),
         coding_rate: toml_radio_u32(&val, "coding_rate").map(|v| v as u8),
         tx_power_dbm: toml_radio_i32(&val, "tx_power_dbm"),
-        presets: RADIO_PRESET_NAMES.to_vec(),
+        connection_type: toml_plugin_str(&val, "mesh", "connection_type"),
+        serial_port: toml_plugin_str(&val, "mesh", "serial_port"),
+        presets: RADIO_PRESETS.to_vec(),
     })
     .into_response()
 }

--- a/crates/bbs-web/web/src/pages/SettingsPage.vue
+++ b/crates/bbs-web/web/src/pages/SettingsPage.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, computed, onMounted } from 'vue'
+import { ref, computed, watch, onMounted } from 'vue'
 import { api, ApiError } from '../api/client'
 
 interface ConfigData {
@@ -338,6 +338,15 @@ async function saveAccessPolicy() {
   }
 }
 
+interface RadioPresetDetail {
+  name: string
+  frequency_hz: number
+  bandwidth_hz: number
+  spreading_factor: number
+  coding_rate: number
+  tx_power_dbm: number
+}
+
 interface RadioConfigData {
   preset: string | null
   frequency_hz: number | null
@@ -345,25 +354,40 @@ interface RadioConfigData {
   spreading_factor: number | null
   coding_rate: number | null
   tx_power_dbm: number | null
-  presets: string[]
+  connection_type: string | null
+  serial_port: string | null
+  presets: RadioPresetDetail[]
 }
 
 const radioConfig = ref<RadioConfigData | null>(null)
-const radioPresets = ref<string[]>([])
+const radioPresets = ref<RadioPresetDetail[]>([])
 const radioLoading = ref(false)
 const radioError = ref<string | null>(null)
 const radioSaving = ref(false)
 const radioSaveOk = ref<string | null>(null)
 const radioSaveError = ref<string | null>(null)
 
-// Working copy
-const radioPreset = ref<string>('')          // '' means none/cleared
-const radioCustomEnabled = ref(false)        // whether to show/save individual overrides
+// Working copy — always show all fields; preset just fills them in
+const radioPreset = ref<string>('')  // '' means no preset selected
 const radioFrequencyHz = ref<string>('')
 const radioBandwidthHz = ref<string>('')
 const radioSpreadingFactor = ref<string>('')
 const radioCodingRate = ref<string>('')
 const radioTxPowerDbm = ref<string>('')
+
+function applyPreset(name: string) {
+  const p = radioPresets.value.find(p => p.name === name)
+  if (!p) return
+  radioFrequencyHz.value     = String(p.frequency_hz)
+  radioBandwidthHz.value     = String(p.bandwidth_hz)
+  radioSpreadingFactor.value = String(p.spreading_factor)
+  radioCodingRate.value      = String(p.coding_rate)
+  radioTxPowerDbm.value      = String(p.tx_power_dbm)
+}
+
+watch(radioPreset, (name) => {
+  if (name) applyPreset(name)
+})
 
 async function loadRadioConfig() {
   radioLoading.value = true
@@ -373,15 +397,17 @@ async function loadRadioConfig() {
     radioConfig.value = r
     radioPresets.value = r.presets
     radioPreset.value = r.preset ?? ''
-    const hasCustom = r.frequency_hz != null || r.bandwidth_hz != null ||
-                      r.spreading_factor != null || r.coding_rate != null ||
-                      r.tx_power_dbm != null
-    radioCustomEnabled.value = hasCustom
-    radioFrequencyHz.value     = r.frequency_hz     != null ? String(r.frequency_hz)     : ''
-    radioBandwidthHz.value     = r.bandwidth_hz     != null ? String(r.bandwidth_hz)     : ''
-    radioSpreadingFactor.value = r.spreading_factor != null ? String(r.spreading_factor) : ''
-    radioCodingRate.value      = r.coding_rate      != null ? String(r.coding_rate)      : ''
-    radioTxPowerDbm.value      = r.tx_power_dbm     != null ? String(r.tx_power_dbm)     : ''
+    // Prefer stored individual values; if none, fall back to preset values
+    if (r.frequency_hz != null || r.bandwidth_hz != null || r.spreading_factor != null ||
+        r.coding_rate != null || r.tx_power_dbm != null) {
+      radioFrequencyHz.value     = r.frequency_hz     != null ? String(r.frequency_hz)     : ''
+      radioBandwidthHz.value     = r.bandwidth_hz     != null ? String(r.bandwidth_hz)     : ''
+      radioSpreadingFactor.value = r.spreading_factor != null ? String(r.spreading_factor) : ''
+      radioCodingRate.value      = r.coding_rate      != null ? String(r.coding_rate)      : ''
+      radioTxPowerDbm.value      = r.tx_power_dbm     != null ? String(r.tx_power_dbm)     : ''
+    } else if (r.preset) {
+      applyPreset(r.preset)
+    }
   } catch (e: any) {
     radioError.value = e?.message ?? 'failed to load radio config'
   } finally {
@@ -390,30 +416,21 @@ async function loadRadioConfig() {
 }
 
 async function saveRadioConfig() {
-  radioSaving.value   = true
-  radioSaveOk.value   = null
+  radioSaving.value    = true
+  radioSaveOk.value    = null
   radioSaveError.value = null
   try {
     const patch: Record<string, unknown> = {
-      preset: radioPreset.value || null,
-    }
-    if (radioCustomEnabled.value) {
-      patch.frequency_hz     = radioFrequencyHz.value     ? parseInt(radioFrequencyHz.value, 10)     : null
-      patch.bandwidth_hz     = radioBandwidthHz.value     ? parseInt(radioBandwidthHz.value, 10)     : null
-      patch.spreading_factor = radioSpreadingFactor.value ? parseInt(radioSpreadingFactor.value, 10) : null
-      patch.coding_rate      = radioCodingRate.value      ? parseInt(radioCodingRate.value, 10)      : null
-      patch.tx_power_dbm     = radioTxPowerDbm.value      ? parseInt(radioTxPowerDbm.value, 10)      : null
-    } else {
-      // Clear all individual fields
-      patch.frequency_hz = null
-      patch.bandwidth_hz = null
-      patch.spreading_factor = null
-      patch.coding_rate = null
-      patch.tx_power_dbm = null
+      preset:           radioPreset.value || null,
+      frequency_hz:     radioFrequencyHz.value     ? parseInt(radioFrequencyHz.value, 10)     : null,
+      bandwidth_hz:     radioBandwidthHz.value     ? parseInt(radioBandwidthHz.value, 10)     : null,
+      spreading_factor: radioSpreadingFactor.value ? parseInt(radioSpreadingFactor.value, 10) : null,
+      coding_rate:      radioCodingRate.value      ? parseInt(radioCodingRate.value, 10)      : null,
+      tx_power_dbm:     radioTxPowerDbm.value      ? parseInt(radioTxPowerDbm.value, 10)      : null,
     }
     const updated = await api.patch<RadioConfigData>('/api/v1/radio-config', patch)
     radioConfig.value = updated
-    radioSaveOk.value = 'Radio config saved to config.toml. Restart the service or run `supply-drop-bbs node set-radio` to apply to device.'
+    radioSaveOk.value = 'Radio config saved. Apply to device with: sudo supply-drop-bbs node set-radio'
   } catch (e: any) {
     radioSaveError.value = e?.message ?? 'failed to save radio config'
   } finally {
@@ -759,15 +776,26 @@ chmod g+w {{ configFile }}</pre>
         </div>
       </section>
 
-      <!-- Radio -->
+      <!-- MeshCore Radio -->
       <section class="card">
-        <h2>Radio</h2>
+        <h2>MeshCore radio</h2>
         <p class="hint">
+          LoRa parameters for the MeshCore companion device
+          <span v-if="radioConfig?.connection_type === 'serial' && radioConfig?.serial_port">
+            (<code>{{ radioConfig.serial_port }}</code>)
+          </span>
+          <span v-else-if="radioConfig?.connection_type === 'hat'">
+            (Pi HAT via pymc-companion)
+          </span>
+          <span v-else-if="radioConfig?.connection_type === 'tcp'">
+            (TCP — pymc-companion)
+          </span>.
           Saved to <code>[plugins.mesh.radio]</code> in config.toml.
-          Settings stored here are <strong>not</strong> pushed to the device automatically.
-          After saving, apply them with:
+          Settings are <strong>not</strong> applied automatically — after saving, run:
           <code>sudo supply-drop-bbs node set-radio</code>
-          (or restart the service, which applies them on reconnect when using USB serial).
+        </p>
+        <p class="hint" style="margin-top: 0.3rem">
+          Using Meshtastic? Radio parameters are configured in the Meshtastic app — they are not managed here.
         </p>
 
         <div v-if="radioError" class="notice error-notice">{{ radioError }}</div>
@@ -777,23 +805,13 @@ chmod g+w {{ configFile }}</pre>
         <div class="field">
           <label>Region preset</label>
           <select v-model="radioPreset" :disabled="radioLoading" style="max-width: 320px">
-            <option value="">(none — use custom parameters below)</option>
-            <option v-for="p in radioPresets" :key="p" :value="p">{{ p }}</option>
+            <option value="">(select a preset to fill values below)</option>
+            <option v-for="p in radioPresets" :key="p.name" :value="p.name">{{ p.name }}</option>
           </select>
-          <p class="hint">Selects a predefined set of LoRa parameters for your region.</p>
+          <p class="hint">Selecting a preset fills in the parameters below. You can then adjust individual values.</p>
         </div>
 
-        <div class="field checkbox-field">
-          <label>
-            <input type="checkbox" v-model="radioCustomEnabled" :disabled="radioLoading" />
-            Override individual radio parameters
-          </label>
-          <p class="hint">
-            Override specific values from the preset, or set all parameters manually when no preset is selected.
-          </p>
-        </div>
-
-        <div v-if="radioCustomEnabled" class="field-row">
+        <div class="field-row">
           <div class="field">
             <label>Frequency (Hz)</label>
             <input v-model="radioFrequencyHz" type="number" min="1" placeholder="e.g. 910525000" :disabled="radioLoading" />
@@ -802,9 +820,10 @@ chmod g+w {{ configFile }}</pre>
           <div class="field">
             <label>Bandwidth (Hz)</label>
             <input v-model="radioBandwidthHz" type="number" min="1" placeholder="e.g. 62500" :disabled="radioLoading" />
+            <p class="hint">e.g. 62500 for 62.5 kHz</p>
           </div>
         </div>
-        <div v-if="radioCustomEnabled" class="field-row">
+        <div class="field-row">
           <div class="field">
             <label>Spreading factor (7–12)</label>
             <input v-model="radioSpreadingFactor" type="number" min="7" max="12" :disabled="radioLoading" />

--- a/crates/bbs-web/web/src/pages/SettingsPage.vue
+++ b/crates/bbs-web/web/src/pages/SettingsPage.vue
@@ -454,12 +454,38 @@ const exportKeyLoading = ref(false)
 const exportKeyError = ref<string | null>(null)
 const exportKeyVisible = ref(false)
 
-// Import state
-const importKeyInput = ref('')
-const importKeyLoading = ref(false)
-const importKeyOk = ref<string | null>(null)
-const importKeyError = ref<string | null>(null)
-const showImportForm = ref(false)
+// Inline node-key edit state (replaces the old separate import form)
+const editingNodeKey = ref(false)
+const nodeKeyInput = ref('')
+const nodeKeyLoading = ref(false)
+const nodeKeyOk = ref<string | null>(null)
+const nodeKeyError = ref<string | null>(null)
+
+function startEditNodeKey() {
+  nodeKeyInput.value = ''
+  nodeKeyOk.value = null
+  nodeKeyError.value = null
+  editingNodeKey.value = true
+}
+
+function cancelEditNodeKey() {
+  editingNodeKey.value = false
+  nodeKeyInput.value = ''
+  nodeKeyOk.value = null
+  nodeKeyError.value = null
+}
+
+function validateHex64(value: string): string | null {
+  const h = value.trim()
+  if (h.length !== 64) return `Must be exactly 64 hex characters (${h.length} given).`
+  if (!/^[0-9a-fA-F]+$/.test(h)) return 'Contains invalid characters — only 0-9 and a-f are allowed.'
+  return null
+}
+
+const nodeKeyInputError = computed(() => {
+  if (!nodeKeyInput.value.trim()) return null
+  return validateHex64(nodeKeyInput.value)
+})
 
 async function loadNodeIdentity() {
   nodeIdentityLoading.value = true
@@ -489,26 +515,23 @@ async function exportNodeKey() {
   }
 }
 
-async function importNodeKey() {
-  importKeyOk.value = null
-  importKeyError.value = null
-  const hex = importKeyInput.value.trim()
-  if (hex.length !== 64 || !/^[0-9a-fA-F]+$/.test(hex)) {
-    importKeyError.value = 'Private key must be exactly 64 hex characters (32 bytes).'
-    return
-  }
-  importKeyLoading.value = true
+async function saveNodeKey() {
+  nodeKeyOk.value = null
+  nodeKeyError.value = null
+  const err = validateHex64(nodeKeyInput.value)
+  if (err) { nodeKeyError.value = err; return }
+  const hex = nodeKeyInput.value.trim()
+  nodeKeyLoading.value = true
   try {
     await api.post('/api/v1/node-identity/import-key', { key: hex })
-    importKeyOk.value = 'Private key imported successfully. The node\'s public key will update on the next connection.'
-    importKeyInput.value = ''
-    showImportForm.value = false
-    // Reload identity so pubkey refreshes.
+    nodeKeyOk.value = 'Node key saved. The public key will update on the next mesh connection.'
+    nodeKeyInput.value = ''
+    editingNodeKey.value = false
     await loadNodeIdentity()
   } catch (e: any) {
-    importKeyError.value = e?.message ?? 'failed to import key'
+    nodeKeyError.value = e?.message ?? 'failed to save node key'
   } finally {
-    importKeyLoading.value = false
+    nodeKeyLoading.value = false
   }
 }
 
@@ -851,17 +874,19 @@ chmod g+w {{ configFile }}</pre>
       <section class="card">
         <h2>Node identity</h2>
         <p class="hint">
-          The companion device's identity keypair. The public key identifies your
-          node on the mesh. Export the private key for backup before a firmware
-          flash; import it to restore your identity on a new device.
-          <strong>Keep the private key secret.</strong>
+          The MeshCore companion device's identity keypair. The public key identifies
+          your node on the mesh network and is shared with other stations to contact you.
+          Use <strong>Set node key</strong> to paste a known 64-character hex key (e.g. when
+          migrating to new hardware). Export the private key for backup before a firmware
+          flash. <strong>Keep the private key secret.</strong>
         </p>
 
         <div v-if="nodeIdentityError" class="notice error-notice">{{ nodeIdentityError }}</div>
 
+        <!-- Public key display + inline edit -->
         <div class="field">
           <label>Public key</label>
-          <div class="key-display">
+          <div v-if="!editingNodeKey" class="key-display">
             <code v-if="nodeIdentity?.pubkey" class="key-hex">{{ nodeIdentity.pubkey }}</code>
             <span v-else-if="nodeIdentityLoading" class="muted">loading…</span>
             <span v-else class="muted">not connected — start the mesh transport to read the device key</span>
@@ -872,12 +897,48 @@ chmod g+w {{ configFile }}</pre>
               title="Copy public key"
               @click="copyToClipboard(nodeIdentity!.pubkey!)"
             >⎘</button>
+            <button
+              type="button"
+              class="icon-btn"
+              title="Set node key"
+              style="margin-left: 0.25rem"
+              @click="startEditNodeKey"
+            >✏️</button>
           </div>
+
+          <!-- Inline edit form -->
+          <div v-if="editingNodeKey" style="display: flex; flex-direction: column; gap: 0.5rem; margin-top: 0.25rem">
+            <div class="notice warn-notice" style="font-size: 0.85em">
+              ⚠ Setting a new node key replaces the device's current identity on the mesh.
+              Back up the current private key first if you may need to restore it.
+            </div>
+            <input
+              v-model="nodeKeyInput"
+              type="text"
+              placeholder="paste 64-character hex node key"
+              style="max-width: 480px; font-family: monospace; font-size: 0.85em"
+              autocomplete="off"
+              spellcheck="false"
+              autofocus
+            />
+            <div v-if="nodeKeyInputError" class="notice error-notice" style="font-size: 0.85em">{{ nodeKeyInputError }}</div>
+            <div v-if="nodeKeyError" class="notice error-notice">{{ nodeKeyError }}</div>
+            <div class="actions" style="padding-top: 0">
+              <button
+                type="button"
+                :disabled="nodeKeyLoading || !nodeKeyInput.trim() || !!nodeKeyInputError"
+                @click="saveNodeKey"
+              >{{ nodeKeyLoading ? 'saving…' : 'set node key' }}</button>
+              <button type="button" class="secondary" :disabled="nodeKeyLoading" @click="cancelEditNodeKey">cancel</button>
+            </div>
+          </div>
+
+          <div v-if="nodeKeyOk" class="notice ok-notice" style="margin-top: 0.5rem">{{ nodeKeyOk }}</div>
         </div>
 
-        <!-- Export -->
+        <!-- Export private key -->
         <div class="field">
-          <label>Private key</label>
+          <label>Private key backup</label>
           <div v-if="exportedKey" class="key-display">
             <code v-if="exportKeyVisible" class="key-hex">{{ exportedKey }}</code>
             <span v-else class="muted key-hex">••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••</span>
@@ -891,35 +952,6 @@ chmod g+w {{ configFile }}</pre>
             <button type="button" class="secondary" :disabled="exportKeyLoading" @click="exportNodeKey">
               {{ exportKeyLoading ? 'exporting…' : 'export private key' }}
             </button>
-          </div>
-        </div>
-
-        <!-- Import -->
-        <div class="field">
-          <div class="actions" style="padding-top: 0">
-            <button type="button" class="secondary" @click="showImportForm = !showImportForm">
-              {{ showImportForm ? 'cancel import' : 'import private key' }}
-            </button>
-          </div>
-          <div v-if="showImportForm" style="margin-top: 0.6rem; display: flex; flex-direction: column; gap: 0.5rem">
-            <div class="notice warn-notice" style="font-size: 0.85em">
-              ⚠ Importing a private key replaces the current keypair. Back up the current key first.
-            </div>
-            <input
-              v-model="importKeyInput"
-              type="password"
-              placeholder="paste 64-char hex private key"
-              style="max-width: 480px; font-family: monospace"
-              autocomplete="off"
-              spellcheck="false"
-            />
-            <div v-if="importKeyError" class="notice error-notice">{{ importKeyError }}</div>
-            <div v-if="importKeyOk" class="notice ok-notice">{{ importKeyOk }}</div>
-            <div class="actions" style="padding-top: 0">
-              <button type="button" :disabled="importKeyLoading || !importKeyInput.trim()" @click="importNodeKey">
-                {{ importKeyLoading ? 'importing…' : 'confirm import' }}
-              </button>
-            </div>
           </div>
         </div>
       </section>

--- a/crates/bbs-web/web/src/pages/SettingsPage.vue
+++ b/crates/bbs-web/web/src/pages/SettingsPage.vue
@@ -421,11 +421,90 @@ async function saveRadioConfig() {
   }
 }
 
+// ── Node identity ─────────────────────────────────────────────────────────────
+
+interface NodeIdentityData {
+  pubkey: string | null
+}
+
+const nodeIdentity = ref<NodeIdentityData | null>(null)
+const nodeIdentityLoading = ref(false)
+const nodeIdentityError = ref<string | null>(null)
+
+// Export state
+const exportedKey = ref<string | null>(null)
+const exportKeyLoading = ref(false)
+const exportKeyError = ref<string | null>(null)
+const exportKeyVisible = ref(false)
+
+// Import state
+const importKeyInput = ref('')
+const importKeyLoading = ref(false)
+const importKeyOk = ref<string | null>(null)
+const importKeyError = ref<string | null>(null)
+const showImportForm = ref(false)
+
+async function loadNodeIdentity() {
+  nodeIdentityLoading.value = true
+  nodeIdentityError.value = null
+  try {
+    const r = await api.get<NodeIdentityData>('/api/v1/node-identity')
+    nodeIdentity.value = r
+  } catch (e: any) {
+    nodeIdentityError.value = e?.message ?? 'failed to load node identity'
+  } finally {
+    nodeIdentityLoading.value = false
+  }
+}
+
+async function exportNodeKey() {
+  exportKeyLoading.value = true
+  exportKeyError.value = null
+  exportedKey.value = null
+  try {
+    const r = await api.post<{ key: string }>('/api/v1/node-identity/export-key', {})
+    exportedKey.value = r.key
+    exportKeyVisible.value = false
+  } catch (e: any) {
+    exportKeyError.value = e?.message ?? 'failed to export key'
+  } finally {
+    exportKeyLoading.value = false
+  }
+}
+
+async function importNodeKey() {
+  importKeyOk.value = null
+  importKeyError.value = null
+  const hex = importKeyInput.value.trim()
+  if (hex.length !== 64 || !/^[0-9a-fA-F]+$/.test(hex)) {
+    importKeyError.value = 'Private key must be exactly 64 hex characters (32 bytes).'
+    return
+  }
+  importKeyLoading.value = true
+  try {
+    await api.post('/api/v1/node-identity/import-key', { key: hex })
+    importKeyOk.value = 'Private key imported successfully. The node\'s public key will update on the next connection.'
+    importKeyInput.value = ''
+    showImportForm.value = false
+    // Reload identity so pubkey refreshes.
+    await loadNodeIdentity()
+  } catch (e: any) {
+    importKeyError.value = e?.message ?? 'failed to import key'
+  } finally {
+    importKeyLoading.value = false
+  }
+}
+
+function copyToClipboard(text: string) {
+  navigator.clipboard.writeText(text).catch(() => {})
+}
+
 onMounted(() => {
   load()
   loadRooms()
   loadAccessPolicy()
   loadRadioConfig()
+  loadNodeIdentity()
 })
 </script>
 
@@ -749,6 +828,83 @@ chmod g+w {{ configFile }}</pre>
         </div>
       </section>
 
+      <!-- Node identity -->
+      <section class="card">
+        <h2>Node identity</h2>
+        <p class="hint">
+          The companion device's identity keypair. The public key identifies your
+          node on the mesh. Export the private key for backup before a firmware
+          flash; import it to restore your identity on a new device.
+          <strong>Keep the private key secret.</strong>
+        </p>
+
+        <div v-if="nodeIdentityError" class="notice error-notice">{{ nodeIdentityError }}</div>
+
+        <div class="field">
+          <label>Public key</label>
+          <div class="key-display">
+            <code v-if="nodeIdentity?.pubkey" class="key-hex">{{ nodeIdentity.pubkey }}</code>
+            <span v-else-if="nodeIdentityLoading" class="muted">loading…</span>
+            <span v-else class="muted">not connected — start the mesh transport to read the device key</span>
+            <button
+              v-if="nodeIdentity?.pubkey"
+              type="button"
+              class="icon-btn"
+              title="Copy public key"
+              @click="copyToClipboard(nodeIdentity!.pubkey!)"
+            >⎘</button>
+          </div>
+        </div>
+
+        <!-- Export -->
+        <div class="field">
+          <label>Private key</label>
+          <div v-if="exportedKey" class="key-display">
+            <code v-if="exportKeyVisible" class="key-hex">{{ exportedKey }}</code>
+            <span v-else class="muted key-hex">••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••</span>
+            <button type="button" class="icon-btn" :title="exportKeyVisible ? 'Hide' : 'Reveal'" @click="exportKeyVisible = !exportKeyVisible">
+              {{ exportKeyVisible ? '🙈' : '👁' }}
+            </button>
+            <button v-if="exportKeyVisible" type="button" class="icon-btn" title="Copy private key" @click="copyToClipboard(exportedKey!)">⎘</button>
+          </div>
+          <div v-if="exportKeyError" class="notice error-notice" style="margin-top: 0.4rem">{{ exportKeyError }}</div>
+          <div class="actions" style="padding-top: 0.4rem">
+            <button type="button" class="secondary" :disabled="exportKeyLoading" @click="exportNodeKey">
+              {{ exportKeyLoading ? 'exporting…' : 'export private key' }}
+            </button>
+          </div>
+        </div>
+
+        <!-- Import -->
+        <div class="field">
+          <div class="actions" style="padding-top: 0">
+            <button type="button" class="secondary" @click="showImportForm = !showImportForm">
+              {{ showImportForm ? 'cancel import' : 'import private key' }}
+            </button>
+          </div>
+          <div v-if="showImportForm" style="margin-top: 0.6rem; display: flex; flex-direction: column; gap: 0.5rem">
+            <div class="notice warn-notice" style="font-size: 0.85em">
+              ⚠ Importing a private key replaces the current keypair. Back up the current key first.
+            </div>
+            <input
+              v-model="importKeyInput"
+              type="password"
+              placeholder="paste 64-char hex private key"
+              style="max-width: 480px; font-family: monospace"
+              autocomplete="off"
+              spellcheck="false"
+            />
+            <div v-if="importKeyError" class="notice error-notice">{{ importKeyError }}</div>
+            <div v-if="importKeyOk" class="notice ok-notice">{{ importKeyOk }}</div>
+            <div class="actions" style="padding-top: 0">
+              <button type="button" :disabled="importKeyLoading || !importKeyInput.trim()" @click="importNodeKey">
+                {{ importKeyLoading ? 'importing…' : 'confirm import' }}
+              </button>
+            </div>
+          </div>
+        </div>
+      </section>
+
       <!-- Service restart -->
       <section class="card">
         <h2>Service</h2>
@@ -854,4 +1010,26 @@ p { margin: 0; }
 .field-row .field { flex: 1; min-width: 160px; }
 
 .actions { display: flex; align-items: center; gap: 1rem; padding-top: 0.4rem; }
+
+.key-display {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  flex-wrap: wrap;
+}
+.key-hex {
+  font-family: monospace;
+  font-size: 0.82em;
+  word-break: break-all;
+  color: var(--fg);
+}
+.icon-btn {
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-size: 1em;
+  padding: 0.1rem 0.3rem;
+  color: var(--muted);
+}
+.icon-btn:hover { color: var(--fg); }
 </style>

--- a/crates/bbs-web/web/src/pages/SettingsPage.vue
+++ b/crates/bbs-web/web/src/pages/SettingsPage.vue
@@ -338,10 +338,94 @@ async function saveAccessPolicy() {
   }
 }
 
+interface RadioConfigData {
+  preset: string | null
+  frequency_hz: number | null
+  bandwidth_hz: number | null
+  spreading_factor: number | null
+  coding_rate: number | null
+  tx_power_dbm: number | null
+  presets: string[]
+}
+
+const radioConfig = ref<RadioConfigData | null>(null)
+const radioPresets = ref<string[]>([])
+const radioLoading = ref(false)
+const radioError = ref<string | null>(null)
+const radioSaving = ref(false)
+const radioSaveOk = ref<string | null>(null)
+const radioSaveError = ref<string | null>(null)
+
+// Working copy
+const radioPreset = ref<string>('')          // '' means none/cleared
+const radioCustomEnabled = ref(false)        // whether to show/save individual overrides
+const radioFrequencyHz = ref<string>('')
+const radioBandwidthHz = ref<string>('')
+const radioSpreadingFactor = ref<string>('')
+const radioCodingRate = ref<string>('')
+const radioTxPowerDbm = ref<string>('')
+
+async function loadRadioConfig() {
+  radioLoading.value = true
+  radioError.value = null
+  try {
+    const r = await api.get<RadioConfigData>('/api/v1/radio-config')
+    radioConfig.value = r
+    radioPresets.value = r.presets
+    radioPreset.value = r.preset ?? ''
+    const hasCustom = r.frequency_hz != null || r.bandwidth_hz != null ||
+                      r.spreading_factor != null || r.coding_rate != null ||
+                      r.tx_power_dbm != null
+    radioCustomEnabled.value = hasCustom
+    radioFrequencyHz.value     = r.frequency_hz     != null ? String(r.frequency_hz)     : ''
+    radioBandwidthHz.value     = r.bandwidth_hz     != null ? String(r.bandwidth_hz)     : ''
+    radioSpreadingFactor.value = r.spreading_factor != null ? String(r.spreading_factor) : ''
+    radioCodingRate.value      = r.coding_rate      != null ? String(r.coding_rate)      : ''
+    radioTxPowerDbm.value      = r.tx_power_dbm     != null ? String(r.tx_power_dbm)     : ''
+  } catch (e: any) {
+    radioError.value = e?.message ?? 'failed to load radio config'
+  } finally {
+    radioLoading.value = false
+  }
+}
+
+async function saveRadioConfig() {
+  radioSaving.value   = true
+  radioSaveOk.value   = null
+  radioSaveError.value = null
+  try {
+    const patch: Record<string, unknown> = {
+      preset: radioPreset.value || null,
+    }
+    if (radioCustomEnabled.value) {
+      patch.frequency_hz     = radioFrequencyHz.value     ? parseInt(radioFrequencyHz.value, 10)     : null
+      patch.bandwidth_hz     = radioBandwidthHz.value     ? parseInt(radioBandwidthHz.value, 10)     : null
+      patch.spreading_factor = radioSpreadingFactor.value ? parseInt(radioSpreadingFactor.value, 10) : null
+      patch.coding_rate      = radioCodingRate.value      ? parseInt(radioCodingRate.value, 10)      : null
+      patch.tx_power_dbm     = radioTxPowerDbm.value      ? parseInt(radioTxPowerDbm.value, 10)      : null
+    } else {
+      // Clear all individual fields
+      patch.frequency_hz = null
+      patch.bandwidth_hz = null
+      patch.spreading_factor = null
+      patch.coding_rate = null
+      patch.tx_power_dbm = null
+    }
+    const updated = await api.patch<RadioConfigData>('/api/v1/radio-config', patch)
+    radioConfig.value = updated
+    radioSaveOk.value = 'Radio config saved to config.toml. Restart the service or run `supply-drop-bbs node set-radio` to apply to device.'
+  } catch (e: any) {
+    radioSaveError.value = e?.message ?? 'failed to save radio config'
+  } finally {
+    radioSaving.value = false
+  }
+}
+
 onMounted(() => {
   load()
   loadRooms()
   loadAccessPolicy()
+  loadRadioConfig()
 })
 </script>
 
@@ -593,6 +677,75 @@ chmod g+w {{ configFile }}</pre>
           >
             {{ accessPolicySaving ? 'saving…' : 'save access policy' }}
           </button>
+        </div>
+      </section>
+
+      <!-- Radio -->
+      <section class="card">
+        <h2>Radio</h2>
+        <p class="hint">
+          Saved to <code>[plugins.mesh.radio]</code> in config.toml.
+          Settings stored here are <strong>not</strong> pushed to the device automatically.
+          After saving, apply them with:
+          <code>sudo supply-drop-bbs node set-radio</code>
+          (or restart the service, which applies them on reconnect when using USB serial).
+        </p>
+
+        <div v-if="radioError" class="notice error-notice">{{ radioError }}</div>
+        <div v-if="radioSaveOk" class="notice ok-notice">{{ radioSaveOk }}</div>
+        <div v-if="radioSaveError" class="notice error-notice">{{ radioSaveError }}</div>
+
+        <div class="field">
+          <label>Region preset</label>
+          <select v-model="radioPreset" :disabled="radioLoading" style="max-width: 320px">
+            <option value="">(none — use custom parameters below)</option>
+            <option v-for="p in radioPresets" :key="p" :value="p">{{ p }}</option>
+          </select>
+          <p class="hint">Selects a predefined set of LoRa parameters for your region.</p>
+        </div>
+
+        <div class="field checkbox-field">
+          <label>
+            <input type="checkbox" v-model="radioCustomEnabled" :disabled="radioLoading" />
+            Override individual radio parameters
+          </label>
+          <p class="hint">
+            Override specific values from the preset, or set all parameters manually when no preset is selected.
+          </p>
+        </div>
+
+        <div v-if="radioCustomEnabled" class="field-row">
+          <div class="field">
+            <label>Frequency (Hz)</label>
+            <input v-model="radioFrequencyHz" type="number" min="1" placeholder="e.g. 910525000" :disabled="radioLoading" />
+            <p class="hint">e.g. 910525000 for 910.525 MHz</p>
+          </div>
+          <div class="field">
+            <label>Bandwidth (Hz)</label>
+            <input v-model="radioBandwidthHz" type="number" min="1" placeholder="e.g. 62500" :disabled="radioLoading" />
+          </div>
+        </div>
+        <div v-if="radioCustomEnabled" class="field-row">
+          <div class="field">
+            <label>Spreading factor (7–12)</label>
+            <input v-model="radioSpreadingFactor" type="number" min="7" max="12" :disabled="radioLoading" />
+          </div>
+          <div class="field">
+            <label>Coding rate (5–8)</label>
+            <input v-model="radioCodingRate" type="number" min="5" max="8" :disabled="radioLoading" />
+            <p class="hint">Denominator: 5 = 4/5, 8 = 4/8</p>
+          </div>
+          <div class="field">
+            <label>TX power (dBm)</label>
+            <input v-model="radioTxPowerDbm" type="number" min="-10" max="30" :disabled="radioLoading" />
+          </div>
+        </div>
+
+        <div class="actions">
+          <button type="button" :disabled="radioSaving || radioLoading || !writable" @click="saveRadioConfig">
+            {{ radioSaving ? 'saving…' : 'save radio config' }}
+          </button>
+          <span v-if="!writable" class="hint">config file is not writable</span>
         </div>
       </section>
 

--- a/crates/meshcore-companion/src/client.rs
+++ b/crates/meshcore-companion/src/client.rs
@@ -521,7 +521,7 @@ where
             result = read_frame(reader) => {
                 match result {
                     Ok(frame) => {
-                        debug!("companion: rx {frame:?}");
+                        trace!("companion: rx {frame:?}");
                         if event_tx.send(ClientEvent::Frame(frame)).await.is_err() {
                             return SessionOutcome::Shutdown;
                         }
@@ -533,7 +533,7 @@ where
             cmd = cmd_rx.recv() => {
                 match cmd {
                     Some(frame) => {
-                        debug!("companion: tx {frame:?}");
+                        trace!("companion: tx {frame:?}");
                         let wire = encode_outbound(&frame);
                         if let Err(e) = writer.write_all(&wire).await {
                             return SessionOutcome::IoError(e, false);

--- a/crates/meshcore-companion/src/frame.rs
+++ b/crates/meshcore-companion/src/frame.rs
@@ -465,8 +465,10 @@ pub fn decode_inbound(payload: &[u8]) -> Result<InboundFrame, FrameDecodeError> 
         RESP_CODE_ADVERT_PATH => Ok(InboundFrame::AdvertPath { raw: body.to_vec() }),
         RESP_CODE_TUNING_PARAMS => Ok(InboundFrame::TuningParams { raw: body.to_vec() }),
         RESP_CODE_CUSTOM_VARS => {
-            let s = std::str::from_utf8(body).map_err(|_| FrameDecodeError::InvalidUtf8)?;
-            Ok(InboundFrame::CustomVars { csv: s.to_owned() })
+            // Lossy conversion: same reasoning as read_cstr — bad bytes become U+FFFD.
+            Ok(InboundFrame::CustomVars {
+                csv: String::from_utf8_lossy(body).into_owned(),
+            })
         }
 
         PUSH_CODE_ADVERT => {
@@ -846,9 +848,11 @@ fn copy32(b: &[u8]) -> [u8; 32] {
 
 fn read_cstr(b: &[u8]) -> Result<String, FrameDecodeError> {
     let end = b.iter().position(|&x| x == 0).unwrap_or(b.len());
-    std::str::from_utf8(&b[..end])
-        .map(|s| s.to_owned())
-        .map_err(|_| FrameDecodeError::InvalidUtf8)
+    // Use lossy UTF-8 so that node/contact names containing non-UTF-8 bytes
+    // (e.g. truncated emoji, Latin-1 characters, or zero-padded fields with
+    // stray high bytes) don't kill the session. Invalid bytes are replaced with
+    // the Unicode replacement character U+FFFD.
+    Ok(String::from_utf8_lossy(&b[..end]).into_owned())
 }
 
 fn parse_contact(body: &[u8]) -> Result<Contact, FrameDecodeError> {

--- a/crates/meshcore-companion/src/frame.rs
+++ b/crates/meshcore-companion/src/frame.rs
@@ -276,6 +276,21 @@ pub enum OutboundFrame {
         /// Transmit power in dBm (e.g. `20` for 100 mW).
         power_dbm: i8,
     },
+    /// Export the companion device's private key.
+    ///
+    /// The device responds with [`InboundFrame::PrivateKey`].
+    /// Wire format: `[CMD_EXPORT_PRIVATE_KEY]` (no body).
+    ExportPrivateKey,
+    /// Import a 32-byte private key into the companion device.
+    ///
+    /// The device responds with [`InboundFrame::Ok`] on success or
+    /// [`InboundFrame::Err`] on failure. This replaces the device's current
+    /// keypair — back up the old key with [`OutboundFrame::ExportPrivateKey`] first.
+    ///
+    /// Wire format: `[CMD_IMPORT_PRIVATE_KEY][key:32]`
+    ImportPrivateKey {
+        key: [u8; 32],
+    },
     /// Escape hatch for commands not yet modelled above.
     Raw {
         code: u8,
@@ -793,6 +808,13 @@ fn build_payload(frame: &OutboundFrame) -> Vec<u8> {
             // Wire: [CMD][power:i8]
             p.push(CMD_SET_RADIO_TX_POWER);
             p.push(*power_dbm as u8);
+        }
+        OutboundFrame::ExportPrivateKey => {
+            p.push(CMD_EXPORT_PRIVATE_KEY);
+        }
+        OutboundFrame::ImportPrivateKey { key } => {
+            p.push(CMD_IMPORT_PRIVATE_KEY);
+            p.extend_from_slice(key);
         }
         OutboundFrame::Raw { code, body } => {
             p.push(*code);

--- a/crates/meshcore-companion/tests/codec.rs
+++ b/crates/meshcore-companion/tests/codec.rs
@@ -664,6 +664,28 @@ fn encode_set_radio_tx_power_negative() {
     assert_eq!(payload[1] as i8, power_dbm, "negative dBm preserved");
 }
 
+// ── ExportPrivateKey / ImportPrivateKey ──────────────────────────────────────
+
+#[test]
+fn encode_export_private_key_layout() {
+    let bytes = encode_outbound(&OutboundFrame::ExportPrivateKey);
+    // Header: 0x3C + u16-LE payload length (1 byte for the CMD byte)
+    assert_eq!(bytes[0], FRAME_INBOUND_PREFIX);
+    assert_eq!(u16::from_le_bytes([bytes[1], bytes[2]]), 1);
+    assert_eq!(bytes[3], CMD_EXPORT_PRIVATE_KEY);
+    assert_eq!(bytes.len(), 4);
+}
+
+#[test]
+fn encode_import_private_key_layout() {
+    let key = [0xABu8; 32];
+    let bytes = encode_outbound(&OutboundFrame::ImportPrivateKey { key });
+    assert_eq!(bytes[0], FRAME_INBOUND_PREFIX);
+    assert_eq!(u16::from_le_bytes([bytes[1], bytes[2]]), 33); // 1 CMD + 32 key
+    assert_eq!(bytes[3], CMD_IMPORT_PRIVATE_KEY);
+    assert_eq!(&bytes[4..], &[0xABu8; 32]);
+}
+
 // ── wrap_payload overflow guard ───────────────────────────────────────────────
 
 /// `encode_outbound` (via `wrap_payload`) must panic with a clear message when

--- a/crates/meshcore-companion/tests/codec.rs
+++ b/crates/meshcore-companion/tests/codec.rs
@@ -382,16 +382,23 @@ fn decode_body_too_short_for_type() {
 }
 
 #[test]
-fn decode_invalid_utf8_errors() {
+fn decode_tolerates_invalid_utf8() {
     // RESP_CODE_CHANNEL_MSG_RECV: [chan_idx][path_len][txt_type][ts×4][invalid utf8]
+    // read_cstr now uses from_utf8_lossy so invalid bytes become U+FFFD rather
+    // than returning an error and killing the session.
     let mut payload = vec![RESP_CODE_CHANNEL_MSG_RECV];
     payload.push(0); // channel_idx
     payload.push(0); // path_len
     payload.push(0); // txt_type
     payload.extend_from_slice(&0u32.to_le_bytes()); // timestamp
-    payload.push(0xFF); // invalid UTF-8 byte
-    let err = decode_inbound(&payload).unwrap_err();
-    assert_eq!(err, FrameDecodeError::InvalidUtf8);
+    payload.push(0xFF); // invalid UTF-8 byte → replaced with U+FFFD
+    let frame = decode_inbound(&payload).unwrap();
+    match frame {
+        InboundFrame::ChannelMsgRecv(msg) => {
+            assert_eq!(msg.text, "\u{FFFD}", "invalid byte should become U+FFFD");
+        }
+        other => panic!("expected ChannelMsgRecv, got {other:?}"),
+    }
 }
 
 // ── decode_inbound — contact struct ──────────────────────────────────────────

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -245,6 +245,77 @@ Backup created: backup_20260511_142301.db
 
 ---
 
+### `node show-key`
+
+```
+supply-drop-bbs node show-key [OPTIONS]
+```
+
+Connect to the MeshCore companion device via USB serial, perform the handshake, and print the node's 32-byte **public key** as a 64-character hex string. This is the key other mesh nodes use to contact your BBS.
+
+The BBS service must **not** be running on the same serial port when you run this.
+
+```sh
+supply-drop-bbs node show-key
+# ab12cd34ef56...  (64 hex chars)
+
+supply-drop-bbs node show-key --port /dev/ttyACM0
+```
+
+| Flag | Description |
+|------|-------------|
+| `--port <PATH>` | Serial port (e.g. `/dev/ttyACM0`, `COM3`). Defaults to the port in `config.toml`. |
+| `--baud <N>` | Baud rate. Defaults to `config.toml` value or `115200`. |
+
+---
+
+### `node export-key`
+
+```
+supply-drop-bbs node export-key [OPTIONS]
+```
+
+Export the companion device's 32-byte **private key** as a 64-character hex string. Back up this value before a firmware flash or hardware migration — it is the only way to restore your node's mesh identity.
+
+**Keep the output secret.** Anyone with the private key can impersonate your node.
+
+The BBS service must **not** be running on the same serial port.
+
+```sh
+supply-drop-bbs node export-key
+# 7f3a1b... (64 hex chars — keep secret)
+```
+
+---
+
+### `node import-key`
+
+```
+supply-drop-bbs node import-key <KEY> [OPTIONS]
+```
+
+Import a 64-character hex key into the companion device as its new private key. The device's mesh identity changes immediately. The corresponding public key (shown by `node show-key`) will change to match.
+
+Use this to:
+- Restore a backed-up key after a firmware flash
+- Migrate an identity from one device to another
+- Set a specific node key when deploying pre-provisioned hardware
+
+| Argument | Description |
+|----------|-------------|
+| `<KEY>` | 64 hex characters (32 bytes). Must be valid hexadecimal. |
+
+```sh
+supply-drop-bbs node import-key ab12cd34ef56...
+# key imported — node identity updated
+```
+
+**Exit codes:** `0` on success; `1` if the key is invalid, the port cannot be opened, or the device does not confirm the import.
+
+> **Web admin:** The same operation is available in the Settings page → **Node identity** → click the ✏️ icon next to the public key.
+
+---
+
 ### `user promote`
 
 ```

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -91,11 +91,12 @@ Run the interactive first-run setup wizard. Detects your radio device, asks conf
 
 The wizard asks:
 
-1. Radio connection type - USB serial or Pi HAT
-2. Serial port *(USB only)* - auto-detected; you confirm or enter manually
-3. BBS name - shown to users on connect
-4. Data directory - defaults to `/var/lib/supply-drop-bbs`
-5. Web admin UI - whether to enable it, bind address, and password
+1. Radio connection type — USB serial or Pi HAT
+2. Serial port *(USB only)* — auto-detected; you confirm or enter manually
+3. Radio parameters *(USB serial only)* — choose a named region preset or enter custom values (frequency, bandwidth, spreading factor, coding rate, TX power); stored in `[plugins.mesh.radio]` and applied to the device; can be re-applied later with `node set-radio`
+4. BBS name — shown to users on connect
+5. Data directory — defaults to `/var/lib/supply-drop-bbs`
+6. Web admin UI — whether to enable it, bind address, and backup directory
 
 After the wizard completes, restart the service to apply:
 
@@ -313,6 +314,64 @@ supply-drop-bbs node import-key ab12cd34ef56...
 **Exit codes:** `0` on success; `1` if the key is invalid, the port cannot be opened, or the device does not confirm the import.
 
 > **Web admin:** The same operation is available in the Settings page → **Node identity** → click the ✏️ icon next to the public key.
+
+---
+
+### `node set-radio`
+
+```
+supply-drop-bbs node set-radio [OPTIONS]
+```
+
+Push radio parameters (frequency, bandwidth, spreading factor, coding rate, TX
+power) to the companion device over USB serial. The device persists these
+settings in its own flash; you only need to run this command when you want to
+change them.
+
+The BBS service must **not** be running on the same serial port when you run
+this command.
+
+| Flag | Description |
+|------|-------------|
+| `--preset <NAME>` | Named region preset (e.g. `"USA/Canada"`). Overrides `config.toml` preset. |
+| `--frequency-hz <N>` | Carrier frequency in Hz. Overrides preset. |
+| `--bandwidth-hz <N>` | Channel bandwidth in Hz. Overrides preset. |
+| `--spreading-factor <N>` | LoRa spreading factor 7–12. Overrides preset. |
+| `--coding-rate <N>` | Coding rate denominator 5–8. Overrides preset. |
+| `--tx-power-dbm <N>` | Transmit power in dBm. Overrides preset. |
+| `--save` | Write the resolved parameters back to `config.toml`. |
+| `--list-presets` | Print all available preset names and exit (does not open the port). |
+| `--port <PATH>` | Serial port (e.g. `/dev/ttyACM0`, `COM3`). Defaults to the port in `config.toml`. |
+| `--baud <N>` | Baud rate. Defaults to `config.toml` value or `115200`. |
+
+**Examples:**
+
+```sh
+# List available region presets
+supply-drop-bbs node set-radio --list-presets
+
+# Apply the preset stored in config.toml (no flags needed)
+supply-drop-bbs node set-radio \
+  --config /etc/supply-drop-bbs/config.toml
+
+# Apply a specific preset and save it to config.toml
+supply-drop-bbs node set-radio --preset "USA/Canada" --save \
+  --config /etc/supply-drop-bbs/config.toml
+
+# Apply fully custom parameters without using a preset
+supply-drop-bbs node set-radio \
+  --frequency-hz 910525000 --bandwidth-hz 62500 \
+  --spreading-factor 7 --coding-rate 5 --tx-power-dbm 20 \
+  --save --config /etc/supply-drop-bbs/config.toml
+```
+
+**Exit codes:** `0` on success; `1` if a parameter is out of range, the port
+cannot be opened, or the device does not confirm the command.
+
+> **Config reference:** Radio parameters are stored in
+> [`[plugins.mesh.radio]`](CONFIG.md#radio-parameter-configuration-pluginsmeshradio)
+> in `config.toml`. Saving them there allows `node set-radio` (with no flags)
+> to re-apply the same settings after a firmware flash.
 
 ---
 

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -310,6 +310,127 @@ your wiring differs from the standard layout):
 | `waveshare`   | 21 | 18    | 20   | 16  | TXEN=13, RXEN=12             |
 | `uconsole`    | -1 | 25    | 24   | 26  | bus_id=1, hardware CS        |
 
+### Radio parameter configuration (`[plugins.mesh.radio]`)
+
+Stores the LoRa parameters that will be pushed to the companion device when you
+run `supply-drop-bbs node set-radio`. **Not applied automatically on every
+connect** — the device persists radio settings in its own flash after they are
+applied once.
+
+Either specify a named `preset` (which fills all five parameters at once) or
+supply individual fields. Individual fields take precedence over the preset; you
+can mix them to override a single value while keeping the rest of the preset.
+
+| Key                | Type    | Default  | Required | Description                                                  |
+|--------------------|---------|----------|----------|--------------------------------------------------------------|
+| `preset`           | string  | (unset)  | no       | Named region preset. Run `node set-radio --list-presets` to see all names. |
+| `frequency_hz`     | integer | (unset)  | no       | Carrier frequency in Hz. Overrides the preset value when set. Example: `910_525_000` for 910.525 MHz. |
+| `bandwidth_hz`     | integer | (unset)  | no       | Channel bandwidth in Hz. Overrides the preset value. Example: `62_500` for 62.5 kHz. |
+| `spreading_factor` | integer | (unset)  | no       | LoRa spreading factor, `7`–`12`. Higher values = longer range, lower data rate. |
+| `coding_rate`      | integer | (unset)  | no       | LoRa coding rate denominator, `5`–`8` (representing 4/5 through 4/8). |
+| `tx_power_dbm`     | integer | (unset)  | no       | Transmit power in dBm. Overrides the preset value.           |
+
+#### Available presets
+
+Run `supply-drop-bbs node set-radio --list-presets` for the current list. At the
+time of writing the built-in presets are:
+
+| Preset name           | Frequency    | Bandwidth | SF | CR | TX power |
+|-----------------------|--------------|-----------|----|----|----------|
+| `Australia`           | 915.800 MHz  | 250 kHz   | 10 | 5  | 20 dBm   |
+| `Australia (Narrow)`  | 916.575 MHz  | 62.5 kHz  | 7  | 5  | 20 dBm   |
+| `Australia SA, WA, QLD` | 923.125 MHz | 62.5 kHz | 8  | 5  | 20 dBm   |
+| `Czech Republic`      | 869.432 MHz  | 62.5 kHz  | 7  | 5  | 14 dBm   |
+| `EU 433MHz`           | 433.650 MHz  | 250 kHz   | 11 | 5  | 20 dBm   |
+| `EU/UK (Long Range)`  | 869.525 MHz  | 250 kHz   | 11 | 5  | 14 dBm   |
+| `EU/UK (Medium Range)`| 869.525 MHz  | 250 kHz   | 10 | 5  | 14 dBm   |
+| `EU/UK (Narrow)`      | 869.618 MHz  | 62.5 kHz  | 8  | 5  | 14 dBm   |
+| `New Zealand`         | 917.375 MHz  | 250 kHz   | 11 | 5  | 20 dBm   |
+| `New Zealand (Narrow)`| 917.375 MHz  | 62.5 kHz  | 7  | 5  | 20 dBm   |
+| `Portugal 433`        | 433.375 MHz  | 62.5 kHz  | 9  | 5  | 20 dBm   |
+| `Portugal 869`        | 869.618 MHz  | 62.5 kHz  | 7  | 5  | 14 dBm   |
+| `Switzerland`         | 869.618 MHz  | 62.5 kHz  | 8  | 5  | 14 dBm   |
+| `USA Arizona`         | 908.205 MHz  | 62.5 kHz  | 10 | 5  | 20 dBm   |
+| `USA/Canada`          | 910.525 MHz  | 62.5 kHz  | 7  | 5  | 20 dBm   |
+| `Vietnam`             | 920.250 MHz  | 250 kHz   | 11 | 5  | 20 dBm   |
+| `Off-Grid 433`        | 433.000 MHz  | 250 kHz   | 11 | 8  | 20 dBm   |
+| `Off-Grid 869`        | 869.000 MHz  | 250 kHz   | 11 | 8  | 14 dBm   |
+| `Off-Grid 918`        | 918.000 MHz  | 250 kHz   | 11 | 8  | 20 dBm   |
+
+#### Examples
+
+**Using a preset (recommended for most deployments):**
+
+```toml
+[plugins.mesh.radio]
+preset = "USA/Canada"
+```
+
+**Custom parameters (all fields required when no preset is given):**
+
+```toml
+[plugins.mesh.radio]
+frequency_hz     = 910_525_000
+bandwidth_hz     = 62_500
+spreading_factor = 7
+coding_rate      = 5
+tx_power_dbm     = 20
+```
+
+**Preset with one override (increase TX power beyond the preset default):**
+
+```toml
+[plugins.mesh.radio]
+preset       = "EU/UK (Long Range)"
+tx_power_dbm = 17
+```
+
+#### Applying radio parameters
+
+Saving a `[plugins.mesh.radio]` section **does not push the settings to the
+device**. The device persists its own radio parameters in flash; the config
+section is just a record of the intended configuration. To apply or re-apply:
+
+```sh
+# BBS must not be running — it holds the serial port open.
+sudo systemctl stop supply-drop-bbs
+
+# Apply using the preset stored in config.toml:
+supply-drop-bbs node set-radio \
+  --config /etc/supply-drop-bbs/config.toml
+
+# Apply a one-off preset without changing config.toml:
+supply-drop-bbs node set-radio --preset "EU/UK (Narrow)"
+
+# Apply fully custom parameters and save them to config.toml:
+supply-drop-bbs node set-radio \
+  --frequency-hz 910525000 --bandwidth-hz 62500 \
+  --spreading-factor 7 --coding-rate 5 --tx-power-dbm 20 \
+  --save --config /etc/supply-drop-bbs/config.toml
+
+sudo systemctl start supply-drop-bbs
+```
+
+The setup wizard (`supply-drop-bbs setup`) also offers radio configuration and
+writes the chosen settings to both `config.toml` and the device in one step.
+
+#### Node identity (`[plugins.mesh]` — node key)
+
+The BBS's mesh identity is a 32-byte Ed25519 key pair stored on the companion
+device. The public key is what other MeshCore nodes use to address messages to
+your BBS.
+
+| Operation | How |
+|-----------|-----|
+| **View public key** | `supply-drop-bbs node show-key` or web admin **Settings** → Node identity |
+| **Back up private key** | `supply-drop-bbs node export-key` (keep the output secret) |
+| **Restore / migrate private key** | `supply-drop-bbs node import-key <64-hex-chars>` or web admin **Settings** → Node identity → ✏️ |
+
+The BBS service must **not** be running when using these commands — it holds
+the serial port open.
+
+See the [CLI Reference](CLI.md#node-show-key) for full flag documentation.
+
 ## `[plugins.meshtastic]` - Meshtastic transport (only if `transport-meshtastic` feature enabled)
 
 Meshtastic is a separate radio protocol from MeshCore. Both can run simultaneously

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,6 +11,7 @@
 #![allow(missing_docs)]
 
 mod config;
+mod mesh_presets;
 mod setup;
 
 use std::{path::PathBuf, sync::Arc};
@@ -302,6 +303,56 @@ enum NodeAction {
         port: Option<String>,
         #[arg(long)]
         baud: Option<u32>,
+    },
+
+    /// Apply radio configuration to the companion device.
+    ///
+    /// Reads parameters from `[plugins.mesh.radio]` in config.toml, with
+    /// optional per-flag overrides. The device persists the settings in its
+    /// own flash — they survive power cycles and reconnects without the BBS
+    /// re-sending them.
+    ///
+    /// The BBS service must not be running on the same port when you run this.
+    ///
+    /// Examples:
+    ///
+    ///   # Apply preset from config.toml and save any flag overrides back
+    ///   supply-drop-bbs node set-radio
+    ///
+    ///   # Apply a specific preset and save it to config.toml
+    ///   supply-drop-bbs node set-radio --preset "USA/Canada" --save
+    ///
+    ///   # List available presets
+    ///   supply-drop-bbs node set-radio --list-presets
+    SetRadio {
+        #[arg(long)]
+        port: Option<String>,
+        #[arg(long)]
+        baud: Option<u32>,
+        /// Named region preset (e.g. "USA/Canada"). Overrides config.toml preset.
+        #[arg(long)]
+        preset: Option<String>,
+        /// Carrier frequency in Hz. Overrides preset.
+        #[arg(long)]
+        frequency_hz: Option<u64>,
+        /// Channel bandwidth in Hz. Overrides preset.
+        #[arg(long)]
+        bandwidth_hz: Option<u32>,
+        /// Spreading factor 7–12. Overrides preset.
+        #[arg(long)]
+        spreading_factor: Option<u8>,
+        /// Coding rate 5–8. Overrides preset.
+        #[arg(long)]
+        coding_rate: Option<u8>,
+        /// TX power in dBm. Overrides preset.
+        #[arg(long)]
+        tx_power_dbm: Option<i32>,
+        /// Also save the resolved settings to config.toml.
+        #[arg(long)]
+        save: bool,
+        /// Print all available region preset names and exit.
+        #[arg(long)]
+        list_presets: bool,
     },
 }
 
@@ -1651,6 +1702,151 @@ async fn cmd_room(config_path: Option<&std::path::Path>, action: RoomAction) {
     }
 }
 
+// ── Radio helpers ─────────────────────────────────────────────────────────────
+
+#[cfg(feature = "transport-mesh")]
+struct ResolvedRadio {
+    frequency_hz: u32,
+    bandwidth_hz: u32,
+    spreading_factor: u8,
+    coding_rate: u8,
+    tx_power_dbm: i32,
+}
+
+/// Resolve final radio parameters by layering: preset → config fields → CLI flags.
+#[cfg(feature = "transport-mesh")]
+fn resolve_radio(
+    cfg_radio: Option<&bbs_mesh::config::RadioConfig>,
+    preset_override: Option<&str>,
+    freq_override: Option<u64>,
+    bw_override: Option<u32>,
+    sf_override: Option<u8>,
+    cr_override: Option<u8>,
+    pwr_override: Option<i32>,
+) -> Result<ResolvedRadio, String> {
+    let mut freq: Option<u32> = None;
+    let mut bw: Option<u32> = None;
+    let mut sf: Option<u8> = None;
+    let mut cr: Option<u8> = None;
+    let mut pwr: Option<i32> = None;
+
+    // 1. Named preset (CLI flag > config.toml preset).
+    let preset_name = preset_override.or_else(|| cfg_radio.and_then(|r| r.preset.as_deref()));
+    if let Some(name) = preset_name {
+        let p = mesh_presets::REGION_PRESETS
+            .iter()
+            .find(|p| p.name.eq_ignore_ascii_case(name))
+            .ok_or_else(|| {
+                format!(
+                    "unknown preset '{name}' — run \
+                     'supply-drop-bbs node set-radio --list-presets' to see valid names"
+                )
+            })?;
+        freq = Some(p.frequency_hz as u32);
+        bw = Some(p.bandwidth_hz);
+        sf = Some(p.spreading_factor);
+        cr = Some(p.coding_rate);
+        pwr = Some(p.tx_power_dbm);
+    }
+
+    // 2. Individual config.toml fields overlay preset.
+    if let Some(r) = cfg_radio {
+        if let Some(v) = r.frequency_hz {
+            freq = Some(v as u32);
+        }
+        if let Some(v) = r.bandwidth_hz {
+            bw = Some(v);
+        }
+        if let Some(v) = r.spreading_factor {
+            sf = Some(v);
+        }
+        if let Some(v) = r.coding_rate {
+            cr = Some(v);
+        }
+        if let Some(v) = r.tx_power_dbm {
+            pwr = Some(v);
+        }
+    }
+
+    // 3. CLI flag overrides take highest precedence.
+    if let Some(v) = freq_override {
+        freq = Some(v as u32);
+    }
+    if let Some(v) = bw_override {
+        bw = Some(v);
+    }
+    if let Some(v) = sf_override {
+        sf = Some(v);
+    }
+    if let Some(v) = cr_override {
+        cr = Some(v);
+    }
+    if let Some(v) = pwr_override {
+        pwr = Some(v);
+    }
+
+    Ok(ResolvedRadio {
+        frequency_hz: freq
+            .ok_or("frequency_hz not set — specify a preset or frequency_hz in config")?,
+        bandwidth_hz: bw.ok_or("bandwidth_hz not set")?,
+        spreading_factor: sf.ok_or("spreading_factor not set")?,
+        coding_rate: cr.ok_or("coding_rate not set")?,
+        tx_power_dbm: pwr.ok_or("tx_power_dbm not set")?,
+    })
+}
+
+/// Write radio settings back to config.toml under `[plugins.mesh.radio]`.
+#[cfg(feature = "transport-mesh")]
+fn save_radio_config(config_path: Option<&std::path::Path>, r: &ResolvedRadio) {
+    #[cfg(feature = "transport-process")]
+    let path_opt = config::resolve_config_path(config_path);
+    #[cfg(not(feature = "transport-process"))]
+    let path_opt = {
+        let explicit = config_path.map(|p| p.to_path_buf());
+        explicit.or_else(|| {
+            [
+                std::path::PathBuf::from("config.toml"),
+                std::path::PathBuf::from("/etc/supply-drop-bbs/config.toml"),
+            ]
+            .iter()
+            .find(|p| p.exists())
+            .cloned()
+        })
+    };
+
+    let path = match path_opt {
+        Some(p) => p,
+        None => {
+            eprintln!("warning: --save: no config file found, skipping write");
+            return;
+        }
+    };
+
+    let content = std::fs::read_to_string(&path).unwrap_or_default();
+    let mut doc: toml_edit::DocumentMut = content.parse().unwrap_or_default();
+
+    // Ensure [plugins] and [plugins.mesh] exist.
+    if doc.get("plugins").is_none() {
+        doc["plugins"] = toml_edit::Item::Table(toml_edit::Table::new());
+    }
+    if doc["plugins"].get("mesh").is_none() {
+        doc["plugins"]["mesh"] = toml_edit::Item::Table(toml_edit::Table::new());
+    }
+    // Write [plugins.mesh.radio] fields.
+    doc["plugins"]["mesh"]["radio"]["frequency_hz"] = toml_edit::value(r.frequency_hz as i64);
+    doc["plugins"]["mesh"]["radio"]["bandwidth_hz"] = toml_edit::value(r.bandwidth_hz as i64);
+    doc["plugins"]["mesh"]["radio"]["spreading_factor"] =
+        toml_edit::value(r.spreading_factor as i64);
+    doc["plugins"]["mesh"]["radio"]["coding_rate"] = toml_edit::value(r.coding_rate as i64);
+    doc["plugins"]["mesh"]["radio"]["tx_power_dbm"] = toml_edit::value(r.tx_power_dbm as i64);
+
+    if let Err(e) = std::fs::write(&path, doc.to_string()) {
+        eprintln!("warning: --save: could not write {}: {e}", path.display());
+    } else {
+        eprintln!("Saved radio config to {}.", path.display());
+    }
+}
+
 async fn cmd_node(config_path: Option<&std::path::Path>, action: NodeAction) {
     #[cfg(feature = "transport-mesh")]
     {
@@ -1666,10 +1862,32 @@ async fn cmd_node(config_path: Option<&std::path::Path>, action: NodeAction) {
         let cfg = config::load(config_path).unwrap_or_default();
         let mesh_cfg = &cfg.plugins.mesh;
 
+        // --list-presets is handled before we even open the port.
+        if let NodeAction::SetRadio {
+            list_presets: true, ..
+        } = &action
+        {
+            println!("{:<28} FREQUENCY   BANDWIDTH  SF  CR  PWR", "PRESET NAME");
+            println!("{}", "-".repeat(72));
+            for p in mesh_presets::REGION_PRESETS {
+                println!(
+                    "{:<28} {:>10.3} MHz  {:>6} kHz  {:>2}  {:>2}  {:>3} dBm",
+                    p.name,
+                    p.frequency_hz as f64 / 1_000_000.0,
+                    p.bandwidth_hz / 1_000,
+                    p.spreading_factor,
+                    p.coding_rate,
+                    p.tx_power_dbm,
+                );
+            }
+            return;
+        }
+
         let (port_flag, baud_flag) = match &action {
             NodeAction::ShowKey { port, baud } => (port.clone(), *baud),
             NodeAction::ExportKey { port, baud } => (port.clone(), *baud),
             NodeAction::ImportKey { port, baud, .. } => (port.clone(), *baud),
+            NodeAction::SetRadio { port, baud, .. } => (port.clone(), *baud),
         };
 
         let port = match port_flag.or_else(|| {
@@ -1692,6 +1910,57 @@ async fn cmd_node(config_path: Option<&std::path::Path>, action: NodeAction) {
         let baud = baud_flag.unwrap_or(mesh_cfg.baud_rate);
 
         eprintln!("Connecting to {port} at {baud} baud...");
+
+        // ── Resolve radio params for set-radio ────────────────────────────
+        // Do this before connecting so we can fail fast on bad config.
+        let resolved_radio: Option<ResolvedRadio> = if let NodeAction::SetRadio {
+            preset,
+            frequency_hz,
+            bandwidth_hz,
+            spreading_factor,
+            coding_rate,
+            tx_power_dbm,
+            save,
+            ..
+        } = &action
+        {
+            match resolve_radio(
+                cfg.plugins.mesh.radio.as_ref(),
+                preset.as_deref(),
+                *frequency_hz,
+                *bandwidth_hz,
+                *spreading_factor,
+                *coding_rate,
+                *tx_power_dbm,
+            ) {
+                Ok(r) => {
+                    eprintln!(
+                        "Radio: {:.3} MHz  BW={} kHz  SF={}  CR={}  PWR={} dBm",
+                        r.frequency_hz as f64 / 1_000_000.0,
+                        r.bandwidth_hz / 1_000,
+                        r.spreading_factor,
+                        r.coding_rate,
+                        r.tx_power_dbm,
+                    );
+                    if *save {
+                        save_radio_config(config_path, &r);
+                    }
+                    Some(r)
+                }
+                Err(e) => {
+                    eprintln!("error: {e}");
+                    eprintln!(
+                        "Tip: add a [plugins.mesh.radio] section to config.toml, or use --preset."
+                    );
+                    eprintln!(
+                        "     Run 'supply-drop-bbs node set-radio --list-presets' for preset names."
+                    );
+                    std::process::exit(1);
+                }
+            }
+        } else {
+            None
+        };
 
         // ── Build the command to send after Connected ─────────────────────
         let cmd_to_send: OutboundFrame = match &action {
@@ -1723,6 +1992,11 @@ async fn cmd_node(config_path: Option<&std::path::Path>, action: NodeAction) {
                 }
                 OutboundFrame::ImportPrivateKey { key: bytes }
             }
+            NodeAction::SetRadio { .. } => {
+                // First frame sent in the event loop after the radio params frame.
+                // Placeholder — the actual send is handled specially below.
+                OutboundFrame::GetBattAndStorage
+            }
         };
 
         let serial_cfg = SerialConfig {
@@ -1739,6 +2013,9 @@ async fn cmd_node(config_path: Option<&std::path::Path>, action: NodeAction) {
         // ── Wait up to 15 s for the whole operation ───────────────────────
         let result = timeout(Duration::from_secs(15), async {
             let mut connected = false;
+            // For set-radio: track how many Ok responses we've received
+            // (one for SetRadioParams, one for SetRadioTxPower).
+            let mut radio_ok_count: u8 = 0;
 
             while let Some(event) = client.recv().await {
                 match event {
@@ -1770,6 +2047,22 @@ async fn cmd_node(config_path: Option<&std::path::Path>, action: NodeAction) {
                             }
                         }
 
+                        // For set-radio, send SetRadioParams first.
+                        if let NodeAction::SetRadio { .. } = &action {
+                            if let Some(ref r) = resolved_radio {
+                                let frame = OutboundFrame::SetRadioParams {
+                                    frequency_hz: r.frequency_hz,
+                                    bandwidth_hz: r.bandwidth_hz,
+                                    spreading_factor: r.spreading_factor,
+                                    coding_rate: r.coding_rate,
+                                };
+                                if let Err(e) = client.send(frame).await {
+                                    return Err(format!("send SetRadioParams failed: {e}"));
+                                }
+                            }
+                            continue;
+                        }
+
                         // For export/import, send the command now.
                         if let Err(e) = client.send(cmd_to_send.clone()).await {
                             return Err(format!("send failed: {e}"));
@@ -1787,6 +2080,26 @@ async fn cmd_node(config_path: Option<&std::path::Path>, action: NodeAction) {
                             if let NodeAction::ImportKey { .. } = &action {
                                 eprintln!("Key imported successfully.");
                                 return Ok(());
+                            }
+                            if let NodeAction::SetRadio { .. } = &action {
+                                radio_ok_count += 1;
+                                if radio_ok_count == 1 {
+                                    // SetRadioParams acknowledged — now send SetRadioTxPower.
+                                    if let Some(ref r) = resolved_radio {
+                                        let frame = OutboundFrame::SetRadioTxPower {
+                                            power_dbm: r.tx_power_dbm as i8,
+                                        };
+                                        if let Err(e) = client.send(frame).await {
+                                            return Err(format!(
+                                                "send SetRadioTxPower failed: {e}"
+                                            ));
+                                        }
+                                    }
+                                } else {
+                                    // Both commands acknowledged — done.
+                                    eprintln!("Radio configured successfully.");
+                                    return Ok(());
+                                }
                             }
                         }
                         InboundFrame::Err { error_code } => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -112,6 +112,15 @@ enum Commands {
 
     /// Print a system metrics snapshot (CPU, memory, disk, network) and exit.
     Metrics,
+
+    /// Manage the USB serial MeshCore companion device's node identity.
+    ///
+    /// These commands open the serial port directly to communicate with the device.
+    /// The BBS service must not be running on the same port when you execute them.
+    Node {
+        #[command(subcommand)]
+        action: NodeAction,
+    },
 }
 
 #[derive(Subcommand)]
@@ -254,6 +263,48 @@ enum ConfigAction {
     },
 }
 
+#[derive(Subcommand)]
+#[allow(clippy::enum_variant_names)] // "Key" postfix is intentional — all actions operate on a key
+enum NodeAction {
+    /// Show the companion device's public key (hex).
+    ///
+    /// Connects to the device, performs the AppStart handshake, and prints the
+    /// 32-byte public key from the SelfInfo response.
+    ShowKey {
+        /// Serial port to connect to (e.g. /dev/ttyACM0, COM3).
+        /// Defaults to the port in config.toml [plugins.mesh].
+        #[arg(long)]
+        port: Option<String>,
+        /// Baud rate. Defaults to the value in config.toml or 115200.
+        #[arg(long)]
+        baud: Option<u32>,
+    },
+    /// Export the companion device's private key as hex.
+    ///
+    /// The private key uniquely identifies the node on the mesh.
+    /// Keep it secret and back it up — you will need it to restore the node's
+    /// identity after a firmware flash or to migrate to new hardware.
+    ExportKey {
+        #[arg(long)]
+        port: Option<String>,
+        #[arg(long)]
+        baud: Option<u32>,
+    },
+    /// Import a private key into the companion device.
+    ///
+    /// The key must be exactly 64 hex characters (32 bytes).
+    /// The device's current key is replaced immediately. Back it up first with
+    /// `export-key` if you may need to restore it.
+    ImportKey {
+        /// 64 hex characters (32 bytes).
+        key: String,
+        #[arg(long)]
+        port: Option<String>,
+        #[arg(long)]
+        baud: Option<u32>,
+    },
+}
+
 // ── Entry point ───────────────────────────────────────────────────────────────
 
 #[tokio::main]
@@ -273,6 +324,7 @@ async fn main() {
         #[cfg(feature = "transport-process")]
         Some(Commands::Plugin { action }) => cmd_plugin(config_path.as_deref(), action),
         Some(Commands::Metrics) => cmd_metrics(),
+        Some(Commands::Node { action }) => cmd_node(config_path.as_deref(), action).await,
     }
 }
 
@@ -1596,6 +1648,190 @@ async fn cmd_room(config_path: Option<&std::path::Path>, action: RoomAction) {
                 }
             }
         }
+    }
+}
+
+async fn cmd_node(config_path: Option<&std::path::Path>, action: NodeAction) {
+    #[cfg(feature = "transport-mesh")]
+    {
+        use meshcore_companion::{
+            client::{ClientEvent, CompanionClient, SerialConfig},
+            constants::APP_TARGET_VER_V3,
+            frame::{InboundFrame, OutboundFrame},
+        };
+        use std::time::Duration;
+        use tokio::time::timeout;
+
+        // ── Resolve port / baud from flags or config ──────────────────────
+        let cfg = config::load(config_path).unwrap_or_default();
+        let mesh_cfg = &cfg.plugins.mesh;
+
+        let (port_flag, baud_flag) = match &action {
+            NodeAction::ShowKey { port, baud } => (port.clone(), *baud),
+            NodeAction::ExportKey { port, baud } => (port.clone(), *baud),
+            NodeAction::ImportKey { port, baud, .. } => (port.clone(), *baud),
+        };
+
+        let port = match port_flag.or_else(|| {
+            if mesh_cfg.connection_type == bbs_mesh::config::ConnectionType::Serial {
+                mesh_cfg.serial_port.clone()
+            } else {
+                None
+            }
+        }) {
+            Some(p) => p,
+            None => {
+                eprintln!(
+                    "error: no serial port specified. Use --port or set [plugins.mesh] \
+                     connection_type = \"serial\" and serial_port in config.toml"
+                );
+                std::process::exit(1);
+            }
+        };
+
+        let baud = baud_flag.unwrap_or(mesh_cfg.baud_rate);
+
+        eprintln!("Connecting to {port} at {baud} baud...");
+
+        // ── Build the command to send after Connected ─────────────────────
+        let cmd_to_send: OutboundFrame = match &action {
+            NodeAction::ShowKey { .. } => {
+                // We only need SelfInfo from the Connected event — no extra command needed.
+                // Send GetBattAndStorage as a no-op to keep the connection alive.
+                OutboundFrame::GetBattAndStorage
+            }
+            NodeAction::ExportKey { .. } => OutboundFrame::ExportPrivateKey,
+            NodeAction::ImportKey { key, .. } => {
+                let hex = key.trim();
+                if hex.len() != 64 {
+                    eprintln!(
+                        "error: key must be exactly 64 hex characters ({} given)",
+                        hex.len()
+                    );
+                    std::process::exit(1);
+                }
+                let mut bytes = [0u8; 32];
+                for (i, chunk) in hex.as_bytes().chunks(2).enumerate() {
+                    let s = std::str::from_utf8(chunk).unwrap_or("??");
+                    bytes[i] = match u8::from_str_radix(s, 16) {
+                        Ok(b) => b,
+                        Err(_) => {
+                            eprintln!("error: invalid hex character in key at position {}", i * 2);
+                            std::process::exit(1);
+                        }
+                    };
+                }
+                OutboundFrame::ImportPrivateKey { key: bytes }
+            }
+        };
+
+        let serial_cfg = SerialConfig {
+            port,
+            baud_rate: baud,
+            app_target_version: APP_TARGET_VER_V3,
+            // Don't retry on CLI — if the port is unavailable, fail fast.
+            reconnect_delay_initial: Duration::from_secs(60),
+            reconnect_delay_max: Duration::from_secs(60),
+        };
+
+        let mut client = CompanionClient::connect_serial(serial_cfg);
+
+        // ── Wait up to 15 s for the whole operation ───────────────────────
+        let result = timeout(Duration::from_secs(15), async {
+            let mut connected = false;
+
+            while let Some(event) = client.recv().await {
+                match event {
+                    ClientEvent::Connected { self_info } => {
+                        connected = true;
+                        if let Some(ref info) = self_info {
+                            let pk_hex: String =
+                                info.pubkey.iter().map(|b| format!("{b:02x}")).collect();
+                            eprintln!("Connected: {} ({})", info.node_name, pk_hex);
+                        } else {
+                            eprintln!("Connected (no SelfInfo)");
+                        }
+
+                        // For show-key we're done once we have SelfInfo.
+                        if let NodeAction::ShowKey { .. } = &action {
+                            match self_info {
+                                Some(info) => {
+                                    let hex: String =
+                                        info.pubkey.iter().map(|b| format!("{b:02x}")).collect();
+                                    println!("{hex}");
+                                    return Ok::<(), String>(());
+                                }
+                                None => {
+                                    return Err(
+                                        "device did not return SelfInfo — public key unavailable"
+                                            .to_owned(),
+                                    );
+                                }
+                            }
+                        }
+
+                        // For export/import, send the command now.
+                        if let Err(e) = client.send(cmd_to_send.clone()).await {
+                            return Err(format!("send failed: {e}"));
+                        }
+                    }
+                    ClientEvent::Frame(frame) => match frame {
+                        InboundFrame::PrivateKey { ref key } => {
+                            if let NodeAction::ExportKey { .. } = &action {
+                                let hex: String = key.iter().map(|b| format!("{b:02x}")).collect();
+                                println!("{hex}");
+                                return Ok(());
+                            }
+                        }
+                        InboundFrame::Ok => {
+                            if let NodeAction::ImportKey { .. } = &action {
+                                eprintln!("Key imported successfully.");
+                                return Ok(());
+                            }
+                        }
+                        InboundFrame::Err { error_code } => {
+                            return Err(format!("device returned error code {error_code}"));
+                        }
+                        _ => {} // ignore other frames
+                    },
+                    ClientEvent::Disconnected { will_retry: false } => {
+                        if !connected {
+                            return Err("connection failed".to_owned());
+                        }
+                        return Err("disconnected before operation completed".to_owned());
+                    }
+                    ClientEvent::Disconnected { will_retry: true } => {
+                        if !connected {
+                            return Err("connection failed".to_owned());
+                        }
+                    }
+                }
+            }
+            Err("connection closed unexpectedly".to_owned())
+        })
+        .await;
+
+        match result {
+            Ok(Ok(())) => {}
+            Ok(Err(e)) => {
+                eprintln!("error: {e}");
+                std::process::exit(1);
+            }
+            Err(_) => {
+                eprintln!("error: timed out waiting for device response (15s)");
+                std::process::exit(1);
+            }
+        }
+    }
+
+    #[cfg(not(feature = "transport-mesh"))]
+    {
+        let _ = (config_path, action);
+        eprintln!(
+            "error: the `node` subcommand requires the `transport-mesh` feature. \
+             Rebuild with --features transport-mesh."
+        );
+        std::process::exit(1);
     }
 }
 

--- a/src/mesh_presets.rs
+++ b/src/mesh_presets.rs
@@ -1,0 +1,173 @@
+//! Region presets for MeshCore radio configuration.
+//!
+//! Shared between the setup wizard (`setup.rs`) and the CLI `node set-radio`
+//! command (`main.rs`).
+
+/// A named radio region preset with default LoRa parameters.
+pub struct RegionPreset {
+    pub name: &'static str,
+    /// Carrier frequency in Hz.
+    pub frequency_hz: u64,
+    /// Channel bandwidth in Hz.
+    pub bandwidth_hz: u32,
+    pub spreading_factor: u8,
+    /// Coding rate denominator (5 = 4/5, 8 = 4/8).
+    pub coding_rate: u8,
+    /// Transmit power in dBm.
+    pub tx_power_dbm: i32,
+}
+
+pub const REGION_PRESETS: &[RegionPreset] = &[
+    RegionPreset {
+        name: "Australia",
+        frequency_hz: 915_800_000,
+        bandwidth_hz: 250_000,
+        spreading_factor: 10,
+        coding_rate: 5,
+        tx_power_dbm: 20,
+    },
+    RegionPreset {
+        name: "Australia (Narrow)",
+        frequency_hz: 916_575_000,
+        bandwidth_hz: 62_500,
+        spreading_factor: 7,
+        coding_rate: 5,
+        tx_power_dbm: 20,
+    },
+    RegionPreset {
+        name: "Australia SA, WA, QLD",
+        frequency_hz: 923_125_000,
+        bandwidth_hz: 62_500,
+        spreading_factor: 8,
+        coding_rate: 5,
+        tx_power_dbm: 20,
+    },
+    RegionPreset {
+        name: "Czech Republic",
+        frequency_hz: 869_432_000,
+        bandwidth_hz: 62_500,
+        spreading_factor: 7,
+        coding_rate: 5,
+        tx_power_dbm: 14,
+    },
+    RegionPreset {
+        name: "EU 433MHz",
+        frequency_hz: 433_650_000,
+        bandwidth_hz: 250_000,
+        spreading_factor: 11,
+        coding_rate: 5,
+        tx_power_dbm: 20,
+    },
+    RegionPreset {
+        name: "EU/UK (Long Range)",
+        frequency_hz: 869_525_000,
+        bandwidth_hz: 250_000,
+        spreading_factor: 11,
+        coding_rate: 5,
+        tx_power_dbm: 14,
+    },
+    RegionPreset {
+        name: "EU/UK (Medium Range)",
+        frequency_hz: 869_525_000,
+        bandwidth_hz: 250_000,
+        spreading_factor: 10,
+        coding_rate: 5,
+        tx_power_dbm: 14,
+    },
+    RegionPreset {
+        name: "EU/UK (Narrow)",
+        frequency_hz: 869_618_000,
+        bandwidth_hz: 62_500,
+        spreading_factor: 8,
+        coding_rate: 5,
+        tx_power_dbm: 14,
+    },
+    RegionPreset {
+        name: "New Zealand",
+        frequency_hz: 917_375_000,
+        bandwidth_hz: 250_000,
+        spreading_factor: 11,
+        coding_rate: 5,
+        tx_power_dbm: 20,
+    },
+    RegionPreset {
+        name: "New Zealand (Narrow)",
+        frequency_hz: 917_375_000,
+        bandwidth_hz: 62_500,
+        spreading_factor: 7,
+        coding_rate: 5,
+        tx_power_dbm: 20,
+    },
+    RegionPreset {
+        name: "Portugal 433",
+        frequency_hz: 433_375_000,
+        bandwidth_hz: 62_500,
+        spreading_factor: 9,
+        coding_rate: 5,
+        tx_power_dbm: 20,
+    },
+    RegionPreset {
+        name: "Portugal 869",
+        frequency_hz: 869_618_000,
+        bandwidth_hz: 62_500,
+        spreading_factor: 7,
+        coding_rate: 5,
+        tx_power_dbm: 14,
+    },
+    RegionPreset {
+        name: "Switzerland",
+        frequency_hz: 869_618_000,
+        bandwidth_hz: 62_500,
+        spreading_factor: 8,
+        coding_rate: 5,
+        tx_power_dbm: 14,
+    },
+    RegionPreset {
+        name: "USA Arizona",
+        frequency_hz: 908_205_000,
+        bandwidth_hz: 62_500,
+        spreading_factor: 10,
+        coding_rate: 5,
+        tx_power_dbm: 20,
+    },
+    RegionPreset {
+        name: "USA/Canada",
+        frequency_hz: 910_525_000,
+        bandwidth_hz: 62_500,
+        spreading_factor: 7,
+        coding_rate: 5,
+        tx_power_dbm: 20,
+    },
+    RegionPreset {
+        name: "Vietnam",
+        frequency_hz: 920_250_000,
+        bandwidth_hz: 250_000,
+        spreading_factor: 11,
+        coding_rate: 5,
+        tx_power_dbm: 20,
+    },
+    RegionPreset {
+        name: "Off-Grid 433",
+        frequency_hz: 433_000_000,
+        bandwidth_hz: 250_000,
+        spreading_factor: 11,
+        coding_rate: 8,
+        tx_power_dbm: 20,
+    },
+    RegionPreset {
+        name: "Off-Grid 869",
+        frequency_hz: 869_000_000,
+        bandwidth_hz: 250_000,
+        spreading_factor: 11,
+        coding_rate: 8,
+        tx_power_dbm: 14,
+    },
+    RegionPreset {
+        name: "Off-Grid 918",
+        frequency_hz: 918_000_000,
+        bandwidth_hz: 250_000,
+        spreading_factor: 11,
+        coding_rate: 8,
+        tx_power_dbm: 20,
+    },
+];

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -48,8 +48,8 @@ struct Existing {
     // pymc-companion (HAT)
     region_idx: usize,
     hat_idx: usize,
-    // USB serial radio preset (index into REGION_PRESETS, None = not configured)
-    mesh_radio_preset: Option<usize>,
+    // USB serial radio config (None = not configured)
+    mesh_radio: Option<RadioChoice>,
     // GPS
     latitude: Option<f64>,
     longitude: Option<f64>,
@@ -164,12 +164,63 @@ fn load_existing(out_path: &Path) -> Existing {
     let yaml_path = companion_yaml_path(out_path);
     let yaml = fs::read_to_string(&yaml_path).unwrap_or_default();
 
-    // USB serial radio preset — read from [plugins.mesh.radio].preset
-    let mesh_radio_preset = mesh
-        .and_then(|m| m.get("radio"))
-        .and_then(|r| r.get("preset"))
-        .and_then(|v| v.as_str())
-        .and_then(|name| REGION_PRESETS.iter().position(|r| r.name == name));
+    // USB serial radio config — reconstruct from [plugins.mesh.radio]
+    let mesh_radio: Option<RadioChoice> = {
+        let radio = mesh.and_then(|m| m.get("radio"));
+        if let Some(radio) = radio {
+            // First try to match a named preset.
+            let by_preset = radio
+                .get("preset")
+                .and_then(|v| v.as_str())
+                .and_then(|name| REGION_PRESETS.iter().position(|r| r.name == name))
+                .map(RadioChoice::Preset);
+            if by_preset.is_some() {
+                by_preset
+            } else {
+                // Fall back to reading the individual fields (custom config).
+                let freq = radio
+                    .get("frequency_hz")
+                    .and_then(|v| v.as_integer())
+                    .map(|v| v as u64);
+                let bw = radio
+                    .get("bandwidth_hz")
+                    .and_then(|v| v.as_integer())
+                    .map(|v| v as u32);
+                let sf = radio
+                    .get("spreading_factor")
+                    .and_then(|v| v.as_integer())
+                    .map(|v| v as u8);
+                let cr = radio
+                    .get("coding_rate")
+                    .and_then(|v| v.as_integer())
+                    .map(|v| v as u8);
+                let tp = radio
+                    .get("tx_power_dbm")
+                    .and_then(|v| v.as_integer())
+                    .map(|v| v as i32);
+                if let (
+                    Some(frequency_hz),
+                    Some(bandwidth_hz),
+                    Some(spreading_factor),
+                    Some(coding_rate),
+                    Some(tx_power_dbm),
+                ) = (freq, bw, sf, cr, tp)
+                {
+                    Some(RadioChoice::Custom {
+                        frequency_hz,
+                        bandwidth_hz,
+                        spreading_factor,
+                        coding_rate,
+                        tx_power_dbm,
+                    })
+                } else {
+                    None
+                }
+            }
+        } else {
+            None
+        }
+    };
 
     Existing {
         bbs_name,
@@ -188,7 +239,7 @@ fn load_existing(out_path: &Path) -> Existing {
         web_backup_dir,
         region_idx: match_region_preset(&yaml),
         hat_idx: match_hat_preset(&yaml),
-        mesh_radio_preset,
+        mesh_radio,
         latitude,
         longitude,
         process_plugins_toml,
@@ -286,6 +337,21 @@ fn match_hat_preset(yaml: &str) -> usize {
 
 use crate::mesh_presets::REGION_PRESETS;
 use dialoguer::{theme::ColorfulTheme, Confirm, Input, MultiSelect, Select};
+
+/// What the operator chose in the "MeshCore radio parameters" step.
+#[derive(Clone)]
+enum RadioChoice {
+    /// A named preset from REGION_PRESETS.
+    Preset(usize),
+    /// Custom values entered field-by-field.
+    Custom {
+        frequency_hz: u64,
+        bandwidth_hz: u32,
+        spreading_factor: u8,
+        coding_rate: u8,
+        tx_power_dbm: i32,
+    },
+}
 
 // ── Public entry point ────────────────────────────────────────────────────────
 
@@ -431,21 +497,23 @@ pub fn run_wizard(config_out: Option<&Path>) {
     // later by configure_hat). For TCP mode, pymc_core owns the radio config.
     // Only USB serial devices are configured here.
 
-    let mesh_radio_preset: Option<usize> = if use_mesh && mesh_conn_type == "serial" {
+    let mesh_radio: Option<RadioChoice> = if use_mesh && mesh_conn_type == "serial" {
         section("MeshCore radio parameters");
 
-        println!("Select a region preset to configure the radio.");
-        println!("Skip this step if the device is already on the correct frequency.");
+        println!("Select a region preset to configure the radio, or choose Custom to");
+        println!("enter individual LoRa parameters. Skip if the device is already");
+        println!("on the correct frequency.");
         println!();
 
         let configure = Confirm::with_theme(&theme)
             .with_prompt("Configure radio parameters now?")
-            .default(ex.mesh_radio_preset.is_some())
+            .default(ex.mesh_radio.is_some())
             .interact()
             .unwrap_or_else(|_| cancelled());
 
         if configure {
-            let region_names: Vec<String> = REGION_PRESETS
+            // Build the menu: all presets + "Custom…" at the end.
+            let mut region_names: Vec<String> = REGION_PRESETS
                 .iter()
                 .map(|r| {
                     format!(
@@ -455,10 +523,105 @@ pub fn run_wizard(config_out: Option<&Path>) {
                     )
                 })
                 .collect();
+            region_names.push("Custom…".to_owned());
+            let custom_idx = region_names.len() - 1;
 
-            let default_region = ex.mesh_radio_preset.unwrap_or(14); // USA/Canada
+            // Default selection: match existing choice, or USA/Canada (index 14).
+            let default_region = match &ex.mesh_radio {
+                Some(RadioChoice::Preset(i)) => *i,
+                Some(RadioChoice::Custom { .. }) => custom_idx,
+                None => 14, // USA/Canada
+            };
             let choice = prompt_select(&theme, "Select your region", &region_names, default_region);
-            Some(choice)
+
+            if choice == custom_idx {
+                // Recover previous custom values (if any) for defaults.
+                let (prev_freq, prev_bw, prev_sf, prev_cr, prev_tp) =
+                    if let Some(RadioChoice::Custom {
+                        frequency_hz,
+                        bandwidth_hz,
+                        spreading_factor,
+                        coding_rate,
+                        tx_power_dbm,
+                    }) = &ex.mesh_radio
+                    {
+                        (
+                            *frequency_hz,
+                            *bandwidth_hz,
+                            *spreading_factor,
+                            *coding_rate,
+                            *tx_power_dbm,
+                        )
+                    } else {
+                        // Sensible defaults (USA/Canada values)
+                        let usa = &REGION_PRESETS[14];
+                        (
+                            usa.frequency_hz,
+                            usa.bandwidth_hz,
+                            usa.spreading_factor,
+                            usa.coding_rate,
+                            usa.tx_power_dbm,
+                        )
+                    };
+
+                println!();
+                println!("Enter each LoRa parameter. Press Enter to accept the default.");
+                println!();
+
+                let frequency_hz: u64 = Input::with_theme(&theme)
+                    .with_prompt("Carrier frequency (Hz)")
+                    .default(prev_freq)
+                    .interact_text()
+                    .unwrap_or_else(|_| cancelled());
+
+                let bandwidth_hz: u32 = Input::with_theme(&theme)
+                    .with_prompt("Channel bandwidth (Hz)  [e.g. 250000, 125000, 62500]")
+                    .default(prev_bw)
+                    .interact_text()
+                    .unwrap_or_else(|_| cancelled());
+
+                let spreading_factor: u8 = Input::with_theme(&theme)
+                    .with_prompt("Spreading factor        [7–12]")
+                    .default(prev_sf)
+                    .validate_with(|v: &u8| {
+                        if (7..=12).contains(v) {
+                            Ok(())
+                        } else {
+                            Err("Spreading factor must be 7–12")
+                        }
+                    })
+                    .interact_text()
+                    .unwrap_or_else(|_| cancelled());
+
+                let coding_rate: u8 = Input::with_theme(&theme)
+                    .with_prompt("Coding rate             [5–8]  (5 = 4/5, 8 = 4/8)")
+                    .default(prev_cr)
+                    .validate_with(|v: &u8| {
+                        if (5..=8).contains(v) {
+                            Ok(())
+                        } else {
+                            Err("Coding rate must be 5–8")
+                        }
+                    })
+                    .interact_text()
+                    .unwrap_or_else(|_| cancelled());
+
+                let tx_power_dbm: i32 = Input::with_theme(&theme)
+                    .with_prompt("TX power (dBm)          [e.g. 20]")
+                    .default(prev_tp)
+                    .interact_text()
+                    .unwrap_or_else(|_| cancelled());
+
+                Some(RadioChoice::Custom {
+                    frequency_hz,
+                    bandwidth_hz,
+                    spreading_factor,
+                    coding_rate,
+                    tx_power_dbm,
+                })
+            } else {
+                Some(RadioChoice::Preset(choice))
+            }
         } else {
             None
         }
@@ -695,7 +858,7 @@ pub fn run_wizard(config_out: Option<&Path>) {
         latitude: gps_lat,
         longitude: gps_lon,
         process_plugins_toml: ex.process_plugins_toml.as_deref(),
-        mesh_radio_preset,
+        mesh_radio: mesh_radio.as_ref(),
     });
 
     if let Some(parent) = out_path.parent() {
@@ -1298,8 +1461,8 @@ struct TomlParams<'a> {
     longitude: Option<f64>,
     // Process plugins — preserved verbatim from the previous config
     process_plugins_toml: Option<&'a str>,
-    // USB serial radio preset (index into REGION_PRESETS; None = omit section)
-    mesh_radio_preset: Option<usize>,
+    // USB serial radio config (None = omit section)
+    mesh_radio: Option<&'a RadioChoice>,
 }
 
 fn build_toml(p: &TomlParams<'_>) -> String {
@@ -1358,13 +1521,35 @@ fn build_toml(p: &TomlParams<'_>) -> String {
         }
     }
 
-    // [plugins.mesh.radio] — only for USB serial with a preset chosen
+    // [plugins.mesh.radio] — only for USB serial with a radio config chosen
     if p.use_mesh && p.mesh_connection_type == "serial" {
-        if let Some(idx) = p.mesh_radio_preset {
-            if let Some(preset) = REGION_PRESETS.get(idx) {
-                writeln!(s, "\n[plugins.mesh.radio]").unwrap();
-                writeln!(s, "preset = {}", toml_str(preset.name)).unwrap();
+        match p.mesh_radio {
+            Some(RadioChoice::Preset(idx)) => {
+                if let Some(preset) = REGION_PRESETS.get(*idx) {
+                    writeln!(s, "\n[plugins.mesh.radio]").unwrap();
+                    writeln!(s, "preset           = {}", toml_str(preset.name)).unwrap();
+                    writeln!(s, "frequency_hz     = {}", preset.frequency_hz).unwrap();
+                    writeln!(s, "bandwidth_hz     = {}", preset.bandwidth_hz).unwrap();
+                    writeln!(s, "spreading_factor = {}", preset.spreading_factor).unwrap();
+                    writeln!(s, "coding_rate      = {}", preset.coding_rate).unwrap();
+                    writeln!(s, "tx_power_dbm     = {}", preset.tx_power_dbm).unwrap();
+                }
             }
+            Some(RadioChoice::Custom {
+                frequency_hz,
+                bandwidth_hz,
+                spreading_factor,
+                coding_rate,
+                tx_power_dbm,
+            }) => {
+                writeln!(s, "\n[plugins.mesh.radio]").unwrap();
+                writeln!(s, "frequency_hz     = {frequency_hz}").unwrap();
+                writeln!(s, "bandwidth_hz     = {bandwidth_hz}").unwrap();
+                writeln!(s, "spreading_factor = {spreading_factor}").unwrap();
+                writeln!(s, "coding_rate      = {coding_rate}").unwrap();
+                writeln!(s, "tx_power_dbm     = {tx_power_dbm}").unwrap();
+            }
+            None => {}
         }
     }
 

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -48,6 +48,8 @@ struct Existing {
     // pymc-companion (HAT)
     region_idx: usize,
     hat_idx: usize,
+    // USB serial radio preset (index into REGION_PRESETS, None = not configured)
+    mesh_radio_preset: Option<usize>,
     // GPS
     latitude: Option<f64>,
     longitude: Option<f64>,
@@ -162,6 +164,13 @@ fn load_existing(out_path: &Path) -> Existing {
     let yaml_path = companion_yaml_path(out_path);
     let yaml = fs::read_to_string(&yaml_path).unwrap_or_default();
 
+    // USB serial radio preset — read from [plugins.mesh.radio].preset
+    let mesh_radio_preset = mesh
+        .and_then(|m| m.get("radio"))
+        .and_then(|r| r.get("preset"))
+        .and_then(|v| v.as_str())
+        .and_then(|name| REGION_PRESETS.iter().position(|r| r.name == name));
+
     Existing {
         bbs_name,
         data_dir,
@@ -179,6 +188,7 @@ fn load_existing(out_path: &Path) -> Existing {
         web_backup_dir,
         region_idx: match_region_preset(&yaml),
         hat_idx: match_hat_preset(&yaml),
+        mesh_radio_preset,
         latitude,
         longitude,
         process_plugins_toml,
@@ -274,6 +284,7 @@ fn match_hat_preset(yaml: &str) -> usize {
     0
 }
 
+use crate::mesh_presets::REGION_PRESETS;
 use dialoguer::{theme::ColorfulTheme, Confirm, Input, MultiSelect, Select};
 
 // ── Public entry point ────────────────────────────────────────────────────────
@@ -413,6 +424,47 @@ pub fn run_wizard(config_out: Option<&Path>) {
         mesh_baud_rate = None;
         mesh_addr = None;
     }
+
+    // ── MeshCore radio parameters (serial mode only) ──────────────────────────
+    //
+    // For HAT mode, radio parameters go into pymc-companion.yaml (handled
+    // later by configure_hat). For TCP mode, pymc_core owns the radio config.
+    // Only USB serial devices are configured here.
+
+    let mesh_radio_preset: Option<usize> = if use_mesh && mesh_conn_type == "serial" {
+        section("MeshCore radio parameters");
+
+        println!("Select a region preset to configure the radio.");
+        println!("Skip this step if the device is already on the correct frequency.");
+        println!();
+
+        let configure = Confirm::with_theme(&theme)
+            .with_prompt("Configure radio parameters now?")
+            .default(ex.mesh_radio_preset.is_some())
+            .interact()
+            .unwrap_or_else(|_| cancelled());
+
+        if configure {
+            let region_names: Vec<String> = REGION_PRESETS
+                .iter()
+                .map(|r| {
+                    format!(
+                        "{:<26} ({:.3} MHz)",
+                        r.name,
+                        r.frequency_hz as f64 / 1_000_000.0
+                    )
+                })
+                .collect();
+
+            let default_region = ex.mesh_radio_preset.unwrap_or(14); // USA/Canada
+            let choice = prompt_select(&theme, "Select your region", &region_names, default_region);
+            Some(choice)
+        } else {
+            None
+        }
+    } else {
+        None
+    };
 
     // ── Meshtastic connection ─────────────────────────────────────────────────
 
@@ -643,6 +695,7 @@ pub fn run_wizard(config_out: Option<&Path>) {
         latitude: gps_lat,
         longitude: gps_lon,
         process_plugins_toml: ex.process_plugins_toml.as_deref(),
+        mesh_radio_preset,
     });
 
     if let Some(parent) = out_path.parent() {
@@ -820,172 +873,6 @@ fn configure_uart_hat(theme: &ColorfulTheme, existing_port: Option<&str>) -> (St
 
     (port, 115_200)
 }
-
-// ── Region presets ────────────────────────────────────────────────────────────
-
-struct RegionPreset {
-    name: &'static str,
-    frequency_hz: u64,
-    bandwidth_hz: u32,
-    spreading_factor: u8,
-    coding_rate: u8,
-    tx_power_dbm: i32,
-}
-
-const REGION_PRESETS: &[RegionPreset] = &[
-    RegionPreset {
-        name: "Australia",
-        frequency_hz: 915_800_000,
-        bandwidth_hz: 250_000,
-        spreading_factor: 10,
-        coding_rate: 5,
-        tx_power_dbm: 20,
-    },
-    RegionPreset {
-        name: "Australia (Narrow)",
-        frequency_hz: 916_575_000,
-        bandwidth_hz: 62_500,
-        spreading_factor: 7,
-        coding_rate: 5,
-        tx_power_dbm: 20,
-    },
-    RegionPreset {
-        name: "Australia SA, WA, QLD",
-        frequency_hz: 923_125_000,
-        bandwidth_hz: 62_500,
-        spreading_factor: 8,
-        coding_rate: 5,
-        tx_power_dbm: 20,
-    },
-    RegionPreset {
-        name: "Czech Republic",
-        frequency_hz: 869_432_000,
-        bandwidth_hz: 62_500,
-        spreading_factor: 7,
-        coding_rate: 5,
-        tx_power_dbm: 14,
-    },
-    RegionPreset {
-        name: "EU 433MHz",
-        frequency_hz: 433_650_000,
-        bandwidth_hz: 250_000,
-        spreading_factor: 11,
-        coding_rate: 5,
-        tx_power_dbm: 20,
-    },
-    RegionPreset {
-        name: "EU/UK (Long Range)",
-        frequency_hz: 869_525_000,
-        bandwidth_hz: 250_000,
-        spreading_factor: 11,
-        coding_rate: 5,
-        tx_power_dbm: 14,
-    },
-    RegionPreset {
-        name: "EU/UK (Medium Range)",
-        frequency_hz: 869_525_000,
-        bandwidth_hz: 250_000,
-        spreading_factor: 10,
-        coding_rate: 5,
-        tx_power_dbm: 14,
-    },
-    RegionPreset {
-        name: "EU/UK (Narrow)",
-        frequency_hz: 869_618_000,
-        bandwidth_hz: 62_500,
-        spreading_factor: 8,
-        coding_rate: 5,
-        tx_power_dbm: 14,
-    },
-    RegionPreset {
-        name: "New Zealand",
-        frequency_hz: 917_375_000,
-        bandwidth_hz: 250_000,
-        spreading_factor: 11,
-        coding_rate: 5,
-        tx_power_dbm: 20,
-    },
-    RegionPreset {
-        name: "New Zealand (Narrow)",
-        frequency_hz: 917_375_000,
-        bandwidth_hz: 62_500,
-        spreading_factor: 7,
-        coding_rate: 5,
-        tx_power_dbm: 20,
-    },
-    RegionPreset {
-        name: "Portugal 433",
-        frequency_hz: 433_375_000,
-        bandwidth_hz: 62_500,
-        spreading_factor: 9,
-        coding_rate: 5,
-        tx_power_dbm: 20,
-    },
-    RegionPreset {
-        name: "Portugal 869",
-        frequency_hz: 869_618_000,
-        bandwidth_hz: 62_500,
-        spreading_factor: 7,
-        coding_rate: 5,
-        tx_power_dbm: 14,
-    },
-    RegionPreset {
-        name: "Switzerland",
-        frequency_hz: 869_618_000,
-        bandwidth_hz: 62_500,
-        spreading_factor: 8,
-        coding_rate: 5,
-        tx_power_dbm: 14,
-    },
-    RegionPreset {
-        name: "USA Arizona",
-        frequency_hz: 908_205_000,
-        bandwidth_hz: 62_500,
-        spreading_factor: 10,
-        coding_rate: 5,
-        tx_power_dbm: 20,
-    },
-    RegionPreset {
-        name: "USA/Canada",
-        frequency_hz: 910_525_000,
-        bandwidth_hz: 62_500,
-        spreading_factor: 7,
-        coding_rate: 5,
-        tx_power_dbm: 20,
-    },
-    RegionPreset {
-        name: "Vietnam",
-        frequency_hz: 920_250_000,
-        bandwidth_hz: 250_000,
-        spreading_factor: 11,
-        coding_rate: 5,
-        tx_power_dbm: 20,
-    },
-    RegionPreset {
-        name: "Off-Grid 433",
-        frequency_hz: 433_000_000,
-        bandwidth_hz: 250_000,
-        spreading_factor: 11,
-        coding_rate: 8,
-        tx_power_dbm: 20,
-    },
-    RegionPreset {
-        name: "Off-Grid 869",
-        frequency_hz: 869_000_000,
-        bandwidth_hz: 250_000,
-        spreading_factor: 11,
-        coding_rate: 8,
-        tx_power_dbm: 14,
-    },
-    RegionPreset {
-        name: "Off-Grid 918",
-        frequency_hz: 918_000_000,
-        bandwidth_hz: 250_000,
-        spreading_factor: 11,
-        coding_rate: 8,
-        tx_power_dbm: 20,
-    },
-];
 
 // ── Pi HAT configuration ──────────────────────────────────────────────────────
 
@@ -1411,6 +1298,8 @@ struct TomlParams<'a> {
     longitude: Option<f64>,
     // Process plugins — preserved verbatim from the previous config
     process_plugins_toml: Option<&'a str>,
+    // USB serial radio preset (index into REGION_PRESETS; None = omit section)
+    mesh_radio_preset: Option<usize>,
 }
 
 fn build_toml(p: &TomlParams<'_>) -> String {
@@ -1466,6 +1355,16 @@ fn build_toml(p: &TomlParams<'_>) -> String {
                 }
             }
             _ => {}
+        }
+    }
+
+    // [plugins.mesh.radio] — only for USB serial with a preset chosen
+    if p.use_mesh && p.mesh_connection_type == "serial" {
+        if let Some(idx) = p.mesh_radio_preset {
+            if let Some(preset) = REGION_PRESETS.get(idx) {
+                writeln!(s, "\n[plugins.mesh.radio]").unwrap();
+                writeln!(s, "preset = {}", toml_str(preset.name)).unwrap();
+            }
         }
     }
 

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -1546,6 +1546,23 @@ fn print_next_steps(
         }
     }
 
+    // Node key hint (MeshCore serial only — not applicable for TCP / HAT / Meshtastic)
+    if use_mesh && mesh_conn_type == "serial" {
+        println!("MeshCore node key:");
+        println!();
+        println!("  To see the current node key (public key):");
+        println!("    supply-drop-bbs node show-key");
+        println!();
+        println!("  To back up the private key before a firmware flash:");
+        println!("    supply-drop-bbs node export-key");
+        println!();
+        println!("  To restore or migrate to a new 64-char hex key:");
+        println!("    supply-drop-bbs node import-key <64-char-hex>");
+        println!();
+        println!("  The BBS service must not be running when using these commands.");
+        println!();
+    }
+
     if cfg!(target_os = "linux") {
         println!("To run Supply Drop BBS as a systemd service:");
         println!();


### PR DESCRIPTION
## Summary

- **CLI**: `node show-key`, `node export-key`, `node import-key` — companion device key management via direct serial connection (service must be stopped)
- **Web UI**: Node Identity card in Settings page — show public key, export/import private key through the live transport while the service is running
- **Radio config**: Web UI section for selecting a region preset and optionally overriding individual LoRa parameters, saved to `[plugins.mesh.radio]` in config.toml

## CLI commands

```sh
# Show the companion device's current public key (hex)
supply-drop-bbs node show-key

# Export the private key for backup or migration (keep it secret)
supply-drop-bbs node export-key > node.key

# Import a private key (64 hex chars / 32 bytes)
supply-drop-bbs node import-key <hex>

# Apply radio settings from config.toml to device
supply-drop-bbs node set-radio
supply-drop-bbs node set-radio --preset "USA/Canada" --save
```

## New web API endpoints (all sysop-gated)

```
GET  /api/v1/node-identity              — current public key hex (null if not connected)
POST /api/v1/node-identity/export-key   — returns 64-char private key hex
POST /api/v1/node-identity/import-key   — accepts 64-char private key hex
GET  /api/v1/radio-config               — read [plugins.mesh.radio] from config.toml
PATCH /api/v1/radio-config              — write [plugins.mesh.radio] to config.toml
```

## Test plan

- [ ] `node show-key` — device connected, prints 64-char hex pubkey
- [ ] `node export-key` — prints 64-char hex private key
- [ ] `node import-key <hex>` — device confirms success; `show-key` returns new pubkey
- [ ] Web UI Settings → Node Identity: public key displayed after BBS connects to device
- [ ] Web UI → Export Private Key → reveal shows hex; copy works
- [ ] Web UI → Import Private Key → paste hex, confirm; pubkey updates
- [ ] Web UI → Radio: preset dropdown populated; selecting preset + save writes config.toml
- [ ] Web UI → Radio: override fields saved when "Override individual parameters" checked
- [ ] `cargo test --workspace` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)