### PR TITLE
fix(setup): auto-chown config file for web admin writability

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2523,6 +2523,7 @@ dependencies = [
  "dialoguer",
  "dirs",
  "figment",
+ "meshcore-companion",
  "serde",
  "sysinfo",
  "thiserror 1.0.69",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ path = "src/main.rs"
 [features]
 default               = ["transport-cli", "transport-mesh", "transport-meshtastic", "admin-web", "transport-process"]
 transport-cli         = ["dep:bbs-cli"]
-transport-mesh        = ["dep:bbs-mesh"]
+transport-mesh        = ["dep:bbs-mesh", "dep:meshcore-companion"]
 transport-meshtastic  = ["dep:bbs-meshtastic"]
 admin-web             = ["dep:bbs-web"]
 transport-process     = ["dep:bbs-process-transport"]
@@ -35,6 +35,7 @@ bbs-mesh             = { workspace = true, optional = true }
 bbs-meshtastic       = { workspace = true, optional = true }
 bbs-web              = { workspace = true, optional = true }
 bbs-process-transport = { workspace = true, optional = true }
+meshcore-companion   = { workspace = true, optional = true }
 clap.workspace            = true
 dirs.workspace            = true
 figment.workspace         = true

--- a/crates/bbs-mesh/src/config.rs
+++ b/crates/bbs-mesh/src/config.rs
@@ -47,6 +47,51 @@ pub enum ConnectionType {
     Serial,
 }
 
+/// Radio parameter configuration stored in `[plugins.mesh.radio]`.
+///
+/// These values are **not** pushed to the device automatically on connect.
+/// Apply them explicitly via `supply-drop-bbs node set-radio` or during
+/// the setup wizard. Once applied the device (T114, Heltec V3, etc.)
+/// persists the settings in its own flash.
+///
+/// Either specify a named `preset` (which sets all parameters at once) or
+/// supply individual fields. Individual fields take precedence over the preset.
+#[derive(Debug, Clone, Default, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct RadioConfig {
+    /// Named region preset (e.g. `"USA/Canada"`).
+    ///
+    /// Run `supply-drop-bbs node set-radio --list-presets` to see all names.
+    #[serde(default)]
+    pub preset: Option<String>,
+
+    /// Carrier frequency in Hz (e.g. `910_525_000` for 910.525 MHz).
+    ///
+    /// Overrides the preset value when set.
+    #[serde(default)]
+    pub frequency_hz: Option<u64>,
+
+    /// Channel bandwidth in Hz (e.g. `62_500` for 62.5 kHz).
+    ///
+    /// Overrides the preset value when set.
+    #[serde(default)]
+    pub bandwidth_hz: Option<u32>,
+
+    /// LoRa spreading factor (7–12). Overrides the preset value when set.
+    #[serde(default)]
+    pub spreading_factor: Option<u8>,
+
+    /// LoRa coding rate denominator (5–8, representing 4/5 through 4/8).
+    ///
+    /// Overrides the preset value when set.
+    #[serde(default)]
+    pub coding_rate: Option<u8>,
+
+    /// Transmit power in dBm. Overrides the preset value when set.
+    #[serde(default)]
+    pub tx_power_dbm: Option<i32>,
+}
+
 /// Configuration for [`MeshTransport`](crate::MeshTransport).
 ///
 /// # Minimal TOML examples
@@ -156,6 +201,20 @@ pub struct MeshConfig {
     /// behaviour.  Defaults to `true`.
     #[serde(default = "default_flood_after_send")]
     pub flood_after_send: bool,
+
+    /// Radio parameter configuration.
+    ///
+    /// Stored here for reference and applied on demand via
+    /// `supply-drop-bbs node set-radio`.  **Not** pushed automatically on
+    /// every connect — the device persists radio settings in its own flash.
+    ///
+    /// Example:
+    /// ```toml
+    /// [plugins.mesh.radio]
+    /// preset = "USA/Canada"
+    /// ```
+    #[serde(default)]
+    pub radio: Option<RadioConfig>,
 }
 
 impl MeshConfig {
@@ -185,6 +244,7 @@ impl Default for MeshConfig {
             reconnect_delay_max_ms: default_reconnect_max_ms(),
             node_credential_ttl_days: default_node_credential_ttl_days(),
             flood_after_send: default_flood_after_send(),
+            radio: None,
         }
     }
 }

--- a/crates/meshcore-companion/src/frame.rs
+++ b/crates/meshcore-companion/src/frame.rs
@@ -276,6 +276,21 @@ pub enum OutboundFrame {
         /// Transmit power in dBm (e.g. `20` for 100 mW).
         power_dbm: i8,
     },
+    /// Export the companion device's private key.
+    ///
+    /// The device responds with [`InboundFrame::PrivateKey`].
+    /// Wire format: `[CMD_EXPORT_PRIVATE_KEY]` (no body).
+    ExportPrivateKey,
+    /// Import a 32-byte private key into the companion device.
+    ///
+    /// The device responds with [`InboundFrame::Ok`] on success or
+    /// [`InboundFrame::Err`] on failure. This replaces the device's current
+    /// keypair — back up the old key with [`OutboundFrame::ExportPrivateKey`] first.
+    ///
+    /// Wire format: `[CMD_IMPORT_PRIVATE_KEY][key:32]`
+    ImportPrivateKey {
+        key: [u8; 32],
+    },
     /// Escape hatch for commands not yet modelled above.
     Raw {
         code: u8,
@@ -793,6 +808,13 @@ fn build_payload(frame: &OutboundFrame) -> Vec<u8> {
             // Wire: [CMD][power:i8]
             p.push(CMD_SET_RADIO_TX_POWER);
             p.push(*power_dbm as u8);
+        }
+        OutboundFrame::ExportPrivateKey => {
+            p.push(CMD_EXPORT_PRIVATE_KEY);
+        }
+        OutboundFrame::ImportPrivateKey { key } => {
+            p.push(CMD_IMPORT_PRIVATE_KEY);
+            p.extend_from_slice(key);
         }
         OutboundFrame::Raw { code, body } => {
             p.push(*code);

--- a/crates/meshcore-companion/tests/codec.rs
+++ b/crates/meshcore-companion/tests/codec.rs
@@ -664,6 +664,28 @@ fn encode_set_radio_tx_power_negative() {
     assert_eq!(payload[1] as i8, power_dbm, "negative dBm preserved");
 }
 
+// ── ExportPrivateKey / ImportPrivateKey ──────────────────────────────────────
+
+#[test]
+fn encode_export_private_key_layout() {
+    let bytes = encode_outbound(&OutboundFrame::ExportPrivateKey);
+    // Header: 0x3C + u16-LE payload length (1 byte for the CMD byte)
+    assert_eq!(bytes[0], FRAME_INBOUND_PREFIX);
+    assert_eq!(u16::from_le_bytes([bytes[1], bytes[2]]), 1);
+    assert_eq!(bytes[3], CMD_EXPORT_PRIVATE_KEY);
+    assert_eq!(bytes.len(), 4);
+}
+
+#[test]
+fn encode_import_private_key_layout() {
+    let key = [0xABu8; 32];
+    let bytes = encode_outbound(&OutboundFrame::ImportPrivateKey { key });
+    assert_eq!(bytes[0], FRAME_INBOUND_PREFIX);
+    assert_eq!(u16::from_le_bytes([bytes[1], bytes[2]]), 33); // 1 CMD + 32 key
+    assert_eq!(bytes[3], CMD_IMPORT_PRIVATE_KEY);
+    assert_eq!(&bytes[4..], &[0xABu8; 32]);
+}
+
 // ── wrap_payload overflow guard ───────────────────────────────────────────────
 
 /// `encode_outbound` (via `wrap_payload`) must panic with a clear message when

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -87,21 +87,32 @@ SUPPLY_DROP__LOGGING__LEVEL=trace supply-drop-bbs run
 supply-drop-bbs setup [OPTIONS]
 ```
 
-Run the interactive first-run setup wizard. Detects your radio device, asks configuration questions, and writes a `config.toml`. Safe to run on an existing installation - answers are pre-populated from the current config.
+Run the interactive first-run setup wizard. Detects your radio device, asks configuration questions, and writes a `config.toml`. Safe to run on an existing installation — answers are pre-populated from the current config.
 
 The wizard asks:
 
-1. Radio connection type - USB serial or Pi HAT
-2. Serial port *(USB only)* - auto-detected; you confirm or enter manually
-3. BBS name - shown to users on connect
-4. Data directory - defaults to `/var/lib/supply-drop-bbs`
-5. Web admin UI - whether to enable it, bind address, and password
+1. Radio connection type — USB serial or Pi HAT
+2. Serial port *(USB only)* — auto-detected; you confirm or enter manually
+3. Radio region preset *(USB serial only)* — stored in `[plugins.mesh.radio]`; can be applied later with `node set-radio`
+4. BBS name — shown to users on connect
+5. Data directory — defaults to `/var/lib/supply-drop-bbs`
+6. Web admin UI — whether to enable it, bind address, and backup directory
 
 After the wizard completes, restart the service to apply:
 
 ```sh
 sudo systemctl restart supply-drop-bbs
 ```
+
+**Run as root for automatic ownership fix**
+
+When run as `root` (e.g. `sudo supply-drop-bbs setup`), the wizard automatically sets the owner of `config.toml` and its parent directory to the `supply-drop` service user:
+
+```
+  ownership set to supply-drop:supply-drop (web admin can save config)
+```
+
+This is required for the web admin **Settings** page to be able to save configuration changes. If the wizard is not run as root, or the `supply-drop` user does not exist yet, the next-steps output will print the manual commands to run after the service user is created.
 
 **Example:**
 

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -184,6 +184,9 @@ sudo useradd --system --no-create-home --shell /sbin/nologin \
   --home-dir /var/lib/supply-drop-bbs supply-drop 2>/dev/null || true
 sudo mkdir -p /var/lib/supply-drop-bbs /etc/supply-drop-bbs
 sudo chown supply-drop:supply-drop /var/lib/supply-drop-bbs
+# Config dir ownership is set automatically by 'sudo supply-drop-bbs setup'.
+# If you create config.toml manually, fix ownership so the web admin can save changes:
+sudo chown supply-drop:supply-drop /etc/supply-drop-bbs /etc/supply-drop-bbs/config.toml
 sudo curl -fsSL \
   "https://raw.githubusercontent.com/Mesh-America/supply-drop-bbs/${TAG}/supply-drop-bbs.service" \
   -o /lib/systemd/system/supply-drop-bbs.service
@@ -810,6 +813,36 @@ ss -ltnp | grep supply-drop-bbs
 ```
 
 Check `[plugins.web] bind` and `external_origin` in config.
+
+### Web admin Settings page shows "Config file is not writable by the server process"
+
+This warning appears when the `supply-drop` service user does not have write
+permission on `config.toml` (or its parent directory). The Settings page needs
+write access to save configuration changes.
+
+**Fix for new installs — run setup as root:**
+
+```sh
+sudo supply-drop-bbs setup --config /etc/supply-drop-bbs/config.toml
+```
+
+When run as root, the setup wizard automatically sets the owner of `config.toml`
+and its parent directory to `supply-drop:supply-drop` and prints:
+
+```
+  ownership set to supply-drop:supply-drop (web admin can save config)
+```
+
+**Fix for existing installs — chown manually:**
+
+```sh
+sudo chown supply-drop:supply-drop \
+  /etc/supply-drop-bbs \
+  /etc/supply-drop-bbs/config.toml
+```
+
+No restart is required — the Settings page will work immediately after ownership
+is corrected.
 
 ## Where to get help
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,6 +11,7 @@
 #![allow(missing_docs)]
 
 mod config;
+mod mesh_presets;
 mod setup;
 
 use std::{path::PathBuf, sync::Arc};
@@ -302,6 +303,56 @@ enum NodeAction {
         port: Option<String>,
         #[arg(long)]
         baud: Option<u32>,
+    },
+
+    /// Apply radio configuration to the companion device.
+    ///
+    /// Reads parameters from `[plugins.mesh.radio]` in config.toml, with
+    /// optional per-flag overrides. The device persists the settings in its
+    /// own flash — they survive power cycles and reconnects without the BBS
+    /// re-sending them.
+    ///
+    /// The BBS service must not be running on the same port when you run this.
+    ///
+    /// Examples:
+    ///
+    ///   # Apply preset from config.toml and save any flag overrides back
+    ///   supply-drop-bbs node set-radio
+    ///
+    ///   # Apply a specific preset and save it to config.toml
+    ///   supply-drop-bbs node set-radio --preset "USA/Canada" --save
+    ///
+    ///   # List available presets
+    ///   supply-drop-bbs node set-radio --list-presets
+    SetRadio {
+        #[arg(long)]
+        port: Option<String>,
+        #[arg(long)]
+        baud: Option<u32>,
+        /// Named region preset (e.g. "USA/Canada"). Overrides config.toml preset.
+        #[arg(long)]
+        preset: Option<String>,
+        /// Carrier frequency in Hz. Overrides preset.
+        #[arg(long)]
+        frequency_hz: Option<u64>,
+        /// Channel bandwidth in Hz. Overrides preset.
+        #[arg(long)]
+        bandwidth_hz: Option<u32>,
+        /// Spreading factor 7–12. Overrides preset.
+        #[arg(long)]
+        spreading_factor: Option<u8>,
+        /// Coding rate 5–8. Overrides preset.
+        #[arg(long)]
+        coding_rate: Option<u8>,
+        /// TX power in dBm. Overrides preset.
+        #[arg(long)]
+        tx_power_dbm: Option<i32>,
+        /// Also save the resolved settings to config.toml.
+        #[arg(long)]
+        save: bool,
+        /// Print all available region preset names and exit.
+        #[arg(long)]
+        list_presets: bool,
     },
 }
 
@@ -1651,6 +1702,151 @@ async fn cmd_room(config_path: Option<&std::path::Path>, action: RoomAction) {
     }
 }
 
+// ── Radio helpers ─────────────────────────────────────────────────────────────
+
+#[cfg(feature = "transport-mesh")]
+struct ResolvedRadio {
+    frequency_hz: u32,
+    bandwidth_hz: u32,
+    spreading_factor: u8,
+    coding_rate: u8,
+    tx_power_dbm: i32,
+}
+
+/// Resolve final radio parameters by layering: preset → config fields → CLI flags.
+#[cfg(feature = "transport-mesh")]
+fn resolve_radio(
+    cfg_radio: Option<&bbs_mesh::config::RadioConfig>,
+    preset_override: Option<&str>,
+    freq_override: Option<u64>,
+    bw_override: Option<u32>,
+    sf_override: Option<u8>,
+    cr_override: Option<u8>,
+    pwr_override: Option<i32>,
+) -> Result<ResolvedRadio, String> {
+    let mut freq: Option<u32> = None;
+    let mut bw: Option<u32> = None;
+    let mut sf: Option<u8> = None;
+    let mut cr: Option<u8> = None;
+    let mut pwr: Option<i32> = None;
+
+    // 1. Named preset (CLI flag > config.toml preset).
+    let preset_name = preset_override.or_else(|| cfg_radio.and_then(|r| r.preset.as_deref()));
+    if let Some(name) = preset_name {
+        let p = mesh_presets::REGION_PRESETS
+            .iter()
+            .find(|p| p.name.eq_ignore_ascii_case(name))
+            .ok_or_else(|| {
+                format!(
+                    "unknown preset '{name}' — run \
+                     'supply-drop-bbs node set-radio --list-presets' to see valid names"
+                )
+            })?;
+        freq = Some(p.frequency_hz as u32);
+        bw = Some(p.bandwidth_hz);
+        sf = Some(p.spreading_factor);
+        cr = Some(p.coding_rate);
+        pwr = Some(p.tx_power_dbm);
+    }
+
+    // 2. Individual config.toml fields overlay preset.
+    if let Some(r) = cfg_radio {
+        if let Some(v) = r.frequency_hz {
+            freq = Some(v as u32);
+        }
+        if let Some(v) = r.bandwidth_hz {
+            bw = Some(v);
+        }
+        if let Some(v) = r.spreading_factor {
+            sf = Some(v);
+        }
+        if let Some(v) = r.coding_rate {
+            cr = Some(v);
+        }
+        if let Some(v) = r.tx_power_dbm {
+            pwr = Some(v);
+        }
+    }
+
+    // 3. CLI flag overrides take highest precedence.
+    if let Some(v) = freq_override {
+        freq = Some(v as u32);
+    }
+    if let Some(v) = bw_override {
+        bw = Some(v);
+    }
+    if let Some(v) = sf_override {
+        sf = Some(v);
+    }
+    if let Some(v) = cr_override {
+        cr = Some(v);
+    }
+    if let Some(v) = pwr_override {
+        pwr = Some(v);
+    }
+
+    Ok(ResolvedRadio {
+        frequency_hz: freq
+            .ok_or("frequency_hz not set — specify a preset or frequency_hz in config")?,
+        bandwidth_hz: bw.ok_or("bandwidth_hz not set")?,
+        spreading_factor: sf.ok_or("spreading_factor not set")?,
+        coding_rate: cr.ok_or("coding_rate not set")?,
+        tx_power_dbm: pwr.ok_or("tx_power_dbm not set")?,
+    })
+}
+
+/// Write radio settings back to config.toml under `[plugins.mesh.radio]`.
+#[cfg(feature = "transport-mesh")]
+fn save_radio_config(config_path: Option<&std::path::Path>, r: &ResolvedRadio) {
+    #[cfg(feature = "transport-process")]
+    let path_opt = config::resolve_config_path(config_path);
+    #[cfg(not(feature = "transport-process"))]
+    let path_opt = {
+        let explicit = config_path.map(|p| p.to_path_buf());
+        explicit.or_else(|| {
+            [
+                std::path::PathBuf::from("config.toml"),
+                std::path::PathBuf::from("/etc/supply-drop-bbs/config.toml"),
+            ]
+            .iter()
+            .find(|p| p.exists())
+            .cloned()
+        })
+    };
+
+    let path = match path_opt {
+        Some(p) => p,
+        None => {
+            eprintln!("warning: --save: no config file found, skipping write");
+            return;
+        }
+    };
+
+    let content = std::fs::read_to_string(&path).unwrap_or_default();
+    let mut doc: toml_edit::DocumentMut = content.parse().unwrap_or_default();
+
+    // Ensure [plugins] and [plugins.mesh] exist.
+    if doc.get("plugins").is_none() {
+        doc["plugins"] = toml_edit::Item::Table(toml_edit::Table::new());
+    }
+    if doc["plugins"].get("mesh").is_none() {
+        doc["plugins"]["mesh"] = toml_edit::Item::Table(toml_edit::Table::new());
+    }
+    // Write [plugins.mesh.radio] fields.
+    doc["plugins"]["mesh"]["radio"]["frequency_hz"] = toml_edit::value(r.frequency_hz as i64);
+    doc["plugins"]["mesh"]["radio"]["bandwidth_hz"] = toml_edit::value(r.bandwidth_hz as i64);
+    doc["plugins"]["mesh"]["radio"]["spreading_factor"] =
+        toml_edit::value(r.spreading_factor as i64);
+    doc["plugins"]["mesh"]["radio"]["coding_rate"] = toml_edit::value(r.coding_rate as i64);
+    doc["plugins"]["mesh"]["radio"]["tx_power_dbm"] = toml_edit::value(r.tx_power_dbm as i64);
+
+    if let Err(e) = std::fs::write(&path, doc.to_string()) {
+        eprintln!("warning: --save: could not write {}: {e}", path.display());
+    } else {
+        eprintln!("Saved radio config to {}.", path.display());
+    }
+}
+
 async fn cmd_node(config_path: Option<&std::path::Path>, action: NodeAction) {
     #[cfg(feature = "transport-mesh")]
     {
@@ -1666,10 +1862,32 @@ async fn cmd_node(config_path: Option<&std::path::Path>, action: NodeAction) {
         let cfg = config::load(config_path).unwrap_or_default();
         let mesh_cfg = &cfg.plugins.mesh;
 
+        // --list-presets is handled before we even open the port.
+        if let NodeAction::SetRadio {
+            list_presets: true, ..
+        } = &action
+        {
+            println!("{:<28} FREQUENCY   BANDWIDTH  SF  CR  PWR", "PRESET NAME");
+            println!("{}", "-".repeat(72));
+            for p in mesh_presets::REGION_PRESETS {
+                println!(
+                    "{:<28} {:>10.3} MHz  {:>6} kHz  {:>2}  {:>2}  {:>3} dBm",
+                    p.name,
+                    p.frequency_hz as f64 / 1_000_000.0,
+                    p.bandwidth_hz / 1_000,
+                    p.spreading_factor,
+                    p.coding_rate,
+                    p.tx_power_dbm,
+                );
+            }
+            return;
+        }
+
         let (port_flag, baud_flag) = match &action {
             NodeAction::ShowKey { port, baud } => (port.clone(), *baud),
             NodeAction::ExportKey { port, baud } => (port.clone(), *baud),
             NodeAction::ImportKey { port, baud, .. } => (port.clone(), *baud),
+            NodeAction::SetRadio { port, baud, .. } => (port.clone(), *baud),
         };
 
         let port = match port_flag.or_else(|| {
@@ -1692,6 +1910,57 @@ async fn cmd_node(config_path: Option<&std::path::Path>, action: NodeAction) {
         let baud = baud_flag.unwrap_or(mesh_cfg.baud_rate);
 
         eprintln!("Connecting to {port} at {baud} baud...");
+
+        // ── Resolve radio params for set-radio ────────────────────────────
+        // Do this before connecting so we can fail fast on bad config.
+        let resolved_radio: Option<ResolvedRadio> = if let NodeAction::SetRadio {
+            preset,
+            frequency_hz,
+            bandwidth_hz,
+            spreading_factor,
+            coding_rate,
+            tx_power_dbm,
+            save,
+            ..
+        } = &action
+        {
+            match resolve_radio(
+                cfg.plugins.mesh.radio.as_ref(),
+                preset.as_deref(),
+                *frequency_hz,
+                *bandwidth_hz,
+                *spreading_factor,
+                *coding_rate,
+                *tx_power_dbm,
+            ) {
+                Ok(r) => {
+                    eprintln!(
+                        "Radio: {:.3} MHz  BW={} kHz  SF={}  CR={}  PWR={} dBm",
+                        r.frequency_hz as f64 / 1_000_000.0,
+                        r.bandwidth_hz / 1_000,
+                        r.spreading_factor,
+                        r.coding_rate,
+                        r.tx_power_dbm,
+                    );
+                    if *save {
+                        save_radio_config(config_path, &r);
+                    }
+                    Some(r)
+                }
+                Err(e) => {
+                    eprintln!("error: {e}");
+                    eprintln!(
+                        "Tip: add a [plugins.mesh.radio] section to config.toml, or use --preset."
+                    );
+                    eprintln!(
+                        "     Run 'supply-drop-bbs node set-radio --list-presets' for preset names."
+                    );
+                    std::process::exit(1);
+                }
+            }
+        } else {
+            None
+        };
 
         // ── Build the command to send after Connected ─────────────────────
         let cmd_to_send: OutboundFrame = match &action {
@@ -1723,6 +1992,11 @@ async fn cmd_node(config_path: Option<&std::path::Path>, action: NodeAction) {
                 }
                 OutboundFrame::ImportPrivateKey { key: bytes }
             }
+            NodeAction::SetRadio { .. } => {
+                // First frame sent in the event loop after the radio params frame.
+                // Placeholder — the actual send is handled specially below.
+                OutboundFrame::GetBattAndStorage
+            }
         };
 
         let serial_cfg = SerialConfig {
@@ -1739,6 +2013,9 @@ async fn cmd_node(config_path: Option<&std::path::Path>, action: NodeAction) {
         // ── Wait up to 15 s for the whole operation ───────────────────────
         let result = timeout(Duration::from_secs(15), async {
             let mut connected = false;
+            // For set-radio: track how many Ok responses we've received
+            // (one for SetRadioParams, one for SetRadioTxPower).
+            let mut radio_ok_count: u8 = 0;
 
             while let Some(event) = client.recv().await {
                 match event {
@@ -1770,6 +2047,22 @@ async fn cmd_node(config_path: Option<&std::path::Path>, action: NodeAction) {
                             }
                         }
 
+                        // For set-radio, send SetRadioParams first.
+                        if let NodeAction::SetRadio { .. } = &action {
+                            if let Some(ref r) = resolved_radio {
+                                let frame = OutboundFrame::SetRadioParams {
+                                    frequency_hz: r.frequency_hz,
+                                    bandwidth_hz: r.bandwidth_hz,
+                                    spreading_factor: r.spreading_factor,
+                                    coding_rate: r.coding_rate,
+                                };
+                                if let Err(e) = client.send(frame).await {
+                                    return Err(format!("send SetRadioParams failed: {e}"));
+                                }
+                            }
+                            continue;
+                        }
+
                         // For export/import, send the command now.
                         if let Err(e) = client.send(cmd_to_send.clone()).await {
                             return Err(format!("send failed: {e}"));
@@ -1787,6 +2080,26 @@ async fn cmd_node(config_path: Option<&std::path::Path>, action: NodeAction) {
                             if let NodeAction::ImportKey { .. } = &action {
                                 eprintln!("Key imported successfully.");
                                 return Ok(());
+                            }
+                            if let NodeAction::SetRadio { .. } = &action {
+                                radio_ok_count += 1;
+                                if radio_ok_count == 1 {
+                                    // SetRadioParams acknowledged — now send SetRadioTxPower.
+                                    if let Some(ref r) = resolved_radio {
+                                        let frame = OutboundFrame::SetRadioTxPower {
+                                            power_dbm: r.tx_power_dbm as i8,
+                                        };
+                                        if let Err(e) = client.send(frame).await {
+                                            return Err(format!(
+                                                "send SetRadioTxPower failed: {e}"
+                                            ));
+                                        }
+                                    }
+                                } else {
+                                    // Both commands acknowledged — done.
+                                    eprintln!("Radio configured successfully.");
+                                    return Ok(());
+                                }
                             }
                         }
                         InboundFrame::Err { error_code } => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -112,6 +112,15 @@ enum Commands {
 
     /// Print a system metrics snapshot (CPU, memory, disk, network) and exit.
     Metrics,
+
+    /// Manage the USB serial MeshCore companion device's node identity.
+    ///
+    /// These commands open the serial port directly to communicate with the device.
+    /// The BBS service must not be running on the same port when you execute them.
+    Node {
+        #[command(subcommand)]
+        action: NodeAction,
+    },
 }
 
 #[derive(Subcommand)]
@@ -254,6 +263,48 @@ enum ConfigAction {
     },
 }
 
+#[derive(Subcommand)]
+#[allow(clippy::enum_variant_names)] // "Key" postfix is intentional — all actions operate on a key
+enum NodeAction {
+    /// Show the companion device's public key (hex).
+    ///
+    /// Connects to the device, performs the AppStart handshake, and prints the
+    /// 32-byte public key from the SelfInfo response.
+    ShowKey {
+        /// Serial port to connect to (e.g. /dev/ttyACM0, COM3).
+        /// Defaults to the port in config.toml [plugins.mesh].
+        #[arg(long)]
+        port: Option<String>,
+        /// Baud rate. Defaults to the value in config.toml or 115200.
+        #[arg(long)]
+        baud: Option<u32>,
+    },
+    /// Export the companion device's private key as hex.
+    ///
+    /// The private key uniquely identifies the node on the mesh.
+    /// Keep it secret and back it up — you will need it to restore the node's
+    /// identity after a firmware flash or to migrate to new hardware.
+    ExportKey {
+        #[arg(long)]
+        port: Option<String>,
+        #[arg(long)]
+        baud: Option<u32>,
+    },
+    /// Import a private key into the companion device.
+    ///
+    /// The key must be exactly 64 hex characters (32 bytes).
+    /// The device's current key is replaced immediately. Back it up first with
+    /// `export-key` if you may need to restore it.
+    ImportKey {
+        /// 64 hex characters (32 bytes).
+        key: String,
+        #[arg(long)]
+        port: Option<String>,
+        #[arg(long)]
+        baud: Option<u32>,
+    },
+}
+
 // ── Entry point ───────────────────────────────────────────────────────────────
 
 #[tokio::main]
@@ -273,6 +324,7 @@ async fn main() {
         #[cfg(feature = "transport-process")]
         Some(Commands::Plugin { action }) => cmd_plugin(config_path.as_deref(), action),
         Some(Commands::Metrics) => cmd_metrics(),
+        Some(Commands::Node { action }) => cmd_node(config_path.as_deref(), action).await,
     }
 }
 
@@ -1596,6 +1648,190 @@ async fn cmd_room(config_path: Option<&std::path::Path>, action: RoomAction) {
                 }
             }
         }
+    }
+}
+
+async fn cmd_node(config_path: Option<&std::path::Path>, action: NodeAction) {
+    #[cfg(feature = "transport-mesh")]
+    {
+        use meshcore_companion::{
+            client::{ClientEvent, CompanionClient, SerialConfig},
+            constants::APP_TARGET_VER_V3,
+            frame::{InboundFrame, OutboundFrame},
+        };
+        use std::time::Duration;
+        use tokio::time::timeout;
+
+        // ── Resolve port / baud from flags or config ──────────────────────
+        let cfg = config::load(config_path).unwrap_or_default();
+        let mesh_cfg = &cfg.plugins.mesh;
+
+        let (port_flag, baud_flag) = match &action {
+            NodeAction::ShowKey { port, baud } => (port.clone(), *baud),
+            NodeAction::ExportKey { port, baud } => (port.clone(), *baud),
+            NodeAction::ImportKey { port, baud, .. } => (port.clone(), *baud),
+        };
+
+        let port = match port_flag.or_else(|| {
+            if mesh_cfg.connection_type == bbs_mesh::config::ConnectionType::Serial {
+                mesh_cfg.serial_port.clone()
+            } else {
+                None
+            }
+        }) {
+            Some(p) => p,
+            None => {
+                eprintln!(
+                    "error: no serial port specified. Use --port or set [plugins.mesh] \
+                     connection_type = \"serial\" and serial_port in config.toml"
+                );
+                std::process::exit(1);
+            }
+        };
+
+        let baud = baud_flag.unwrap_or(mesh_cfg.baud_rate);
+
+        eprintln!("Connecting to {port} at {baud} baud...");
+
+        // ── Build the command to send after Connected ─────────────────────
+        let cmd_to_send: OutboundFrame = match &action {
+            NodeAction::ShowKey { .. } => {
+                // We only need SelfInfo from the Connected event — no extra command needed.
+                // Send GetBattAndStorage as a no-op to keep the connection alive.
+                OutboundFrame::GetBattAndStorage
+            }
+            NodeAction::ExportKey { .. } => OutboundFrame::ExportPrivateKey,
+            NodeAction::ImportKey { key, .. } => {
+                let hex = key.trim();
+                if hex.len() != 64 {
+                    eprintln!(
+                        "error: key must be exactly 64 hex characters ({} given)",
+                        hex.len()
+                    );
+                    std::process::exit(1);
+                }
+                let mut bytes = [0u8; 32];
+                for (i, chunk) in hex.as_bytes().chunks(2).enumerate() {
+                    let s = std::str::from_utf8(chunk).unwrap_or("??");
+                    bytes[i] = match u8::from_str_radix(s, 16) {
+                        Ok(b) => b,
+                        Err(_) => {
+                            eprintln!("error: invalid hex character in key at position {}", i * 2);
+                            std::process::exit(1);
+                        }
+                    };
+                }
+                OutboundFrame::ImportPrivateKey { key: bytes }
+            }
+        };
+
+        let serial_cfg = SerialConfig {
+            port,
+            baud_rate: baud,
+            app_target_version: APP_TARGET_VER_V3,
+            // Don't retry on CLI — if the port is unavailable, fail fast.
+            reconnect_delay_initial: Duration::from_secs(60),
+            reconnect_delay_max: Duration::from_secs(60),
+        };
+
+        let mut client = CompanionClient::connect_serial(serial_cfg);
+
+        // ── Wait up to 15 s for the whole operation ───────────────────────
+        let result = timeout(Duration::from_secs(15), async {
+            let mut connected = false;
+
+            while let Some(event) = client.recv().await {
+                match event {
+                    ClientEvent::Connected { self_info } => {
+                        connected = true;
+                        if let Some(ref info) = self_info {
+                            let pk_hex: String =
+                                info.pubkey.iter().map(|b| format!("{b:02x}")).collect();
+                            eprintln!("Connected: {} ({})", info.node_name, pk_hex);
+                        } else {
+                            eprintln!("Connected (no SelfInfo)");
+                        }
+
+                        // For show-key we're done once we have SelfInfo.
+                        if let NodeAction::ShowKey { .. } = &action {
+                            match self_info {
+                                Some(info) => {
+                                    let hex: String =
+                                        info.pubkey.iter().map(|b| format!("{b:02x}")).collect();
+                                    println!("{hex}");
+                                    return Ok::<(), String>(());
+                                }
+                                None => {
+                                    return Err(
+                                        "device did not return SelfInfo — public key unavailable"
+                                            .to_owned(),
+                                    );
+                                }
+                            }
+                        }
+
+                        // For export/import, send the command now.
+                        if let Err(e) = client.send(cmd_to_send.clone()).await {
+                            return Err(format!("send failed: {e}"));
+                        }
+                    }
+                    ClientEvent::Frame(frame) => match frame {
+                        InboundFrame::PrivateKey { ref key } => {
+                            if let NodeAction::ExportKey { .. } = &action {
+                                let hex: String = key.iter().map(|b| format!("{b:02x}")).collect();
+                                println!("{hex}");
+                                return Ok(());
+                            }
+                        }
+                        InboundFrame::Ok => {
+                            if let NodeAction::ImportKey { .. } = &action {
+                                eprintln!("Key imported successfully.");
+                                return Ok(());
+                            }
+                        }
+                        InboundFrame::Err { error_code } => {
+                            return Err(format!("device returned error code {error_code}"));
+                        }
+                        _ => {} // ignore other frames
+                    },
+                    ClientEvent::Disconnected { will_retry: false } => {
+                        if !connected {
+                            return Err("connection failed".to_owned());
+                        }
+                        return Err("disconnected before operation completed".to_owned());
+                    }
+                    ClientEvent::Disconnected { will_retry: true } => {
+                        if !connected {
+                            return Err("connection failed".to_owned());
+                        }
+                    }
+                }
+            }
+            Err("connection closed unexpectedly".to_owned())
+        })
+        .await;
+
+        match result {
+            Ok(Ok(())) => {}
+            Ok(Err(e)) => {
+                eprintln!("error: {e}");
+                std::process::exit(1);
+            }
+            Err(_) => {
+                eprintln!("error: timed out waiting for device response (15s)");
+                std::process::exit(1);
+            }
+        }
+    }
+
+    #[cfg(not(feature = "transport-mesh"))]
+    {
+        let _ = (config_path, action);
+        eprintln!(
+            "error: the `node` subcommand requires the `transport-mesh` feature. \
+             Rebuild with --features transport-mesh."
+        );
+        std::process::exit(1);
     }
 }
 

--- a/src/mesh_presets.rs
+++ b/src/mesh_presets.rs
@@ -1,0 +1,173 @@
+//! Region presets for MeshCore radio configuration.
+//!
+//! Shared between the setup wizard (`setup.rs`) and the CLI `node set-radio`
+//! command (`main.rs`).
+
+/// A named radio region preset with default LoRa parameters.
+pub struct RegionPreset {
+    pub name: &'static str,
+    /// Carrier frequency in Hz.
+    pub frequency_hz: u64,
+    /// Channel bandwidth in Hz.
+    pub bandwidth_hz: u32,
+    pub spreading_factor: u8,
+    /// Coding rate denominator (5 = 4/5, 8 = 4/8).
+    pub coding_rate: u8,
+    /// Transmit power in dBm.
+    pub tx_power_dbm: i32,
+}
+
+pub const REGION_PRESETS: &[RegionPreset] = &[
+    RegionPreset {
+        name: "Australia",
+        frequency_hz: 915_800_000,
+        bandwidth_hz: 250_000,
+        spreading_factor: 10,
+        coding_rate: 5,
+        tx_power_dbm: 20,
+    },
+    RegionPreset {
+        name: "Australia (Narrow)",
+        frequency_hz: 916_575_000,
+        bandwidth_hz: 62_500,
+        spreading_factor: 7,
+        coding_rate: 5,
+        tx_power_dbm: 20,
+    },
+    RegionPreset {
+        name: "Australia SA, WA, QLD",
+        frequency_hz: 923_125_000,
+        bandwidth_hz: 62_500,
+        spreading_factor: 8,
+        coding_rate: 5,
+        tx_power_dbm: 20,
+    },
+    RegionPreset {
+        name: "Czech Republic",
+        frequency_hz: 869_432_000,
+        bandwidth_hz: 62_500,
+        spreading_factor: 7,
+        coding_rate: 5,
+        tx_power_dbm: 14,
+    },
+    RegionPreset {
+        name: "EU 433MHz",
+        frequency_hz: 433_650_000,
+        bandwidth_hz: 250_000,
+        spreading_factor: 11,
+        coding_rate: 5,
+        tx_power_dbm: 20,
+    },
+    RegionPreset {
+        name: "EU/UK (Long Range)",
+        frequency_hz: 869_525_000,
+        bandwidth_hz: 250_000,
+        spreading_factor: 11,
+        coding_rate: 5,
+        tx_power_dbm: 14,
+    },
+    RegionPreset {
+        name: "EU/UK (Medium Range)",
+        frequency_hz: 869_525_000,
+        bandwidth_hz: 250_000,
+        spreading_factor: 10,
+        coding_rate: 5,
+        tx_power_dbm: 14,
+    },
+    RegionPreset {
+        name: "EU/UK (Narrow)",
+        frequency_hz: 869_618_000,
+        bandwidth_hz: 62_500,
+        spreading_factor: 8,
+        coding_rate: 5,
+        tx_power_dbm: 14,
+    },
+    RegionPreset {
+        name: "New Zealand",
+        frequency_hz: 917_375_000,
+        bandwidth_hz: 250_000,
+        spreading_factor: 11,
+        coding_rate: 5,
+        tx_power_dbm: 20,
+    },
+    RegionPreset {
+        name: "New Zealand (Narrow)",
+        frequency_hz: 917_375_000,
+        bandwidth_hz: 62_500,
+        spreading_factor: 7,
+        coding_rate: 5,
+        tx_power_dbm: 20,
+    },
+    RegionPreset {
+        name: "Portugal 433",
+        frequency_hz: 433_375_000,
+        bandwidth_hz: 62_500,
+        spreading_factor: 9,
+        coding_rate: 5,
+        tx_power_dbm: 20,
+    },
+    RegionPreset {
+        name: "Portugal 869",
+        frequency_hz: 869_618_000,
+        bandwidth_hz: 62_500,
+        spreading_factor: 7,
+        coding_rate: 5,
+        tx_power_dbm: 14,
+    },
+    RegionPreset {
+        name: "Switzerland",
+        frequency_hz: 869_618_000,
+        bandwidth_hz: 62_500,
+        spreading_factor: 8,
+        coding_rate: 5,
+        tx_power_dbm: 14,
+    },
+    RegionPreset {
+        name: "USA Arizona",
+        frequency_hz: 908_205_000,
+        bandwidth_hz: 62_500,
+        spreading_factor: 10,
+        coding_rate: 5,
+        tx_power_dbm: 20,
+    },
+    RegionPreset {
+        name: "USA/Canada",
+        frequency_hz: 910_525_000,
+        bandwidth_hz: 62_500,
+        spreading_factor: 7,
+        coding_rate: 5,
+        tx_power_dbm: 20,
+    },
+    RegionPreset {
+        name: "Vietnam",
+        frequency_hz: 920_250_000,
+        bandwidth_hz: 250_000,
+        spreading_factor: 11,
+        coding_rate: 5,
+        tx_power_dbm: 20,
+    },
+    RegionPreset {
+        name: "Off-Grid 433",
+        frequency_hz: 433_000_000,
+        bandwidth_hz: 250_000,
+        spreading_factor: 11,
+        coding_rate: 8,
+        tx_power_dbm: 20,
+    },
+    RegionPreset {
+        name: "Off-Grid 869",
+        frequency_hz: 869_000_000,
+        bandwidth_hz: 250_000,
+        spreading_factor: 11,
+        coding_rate: 8,
+        tx_power_dbm: 14,
+    },
+    RegionPreset {
+        name: "Off-Grid 918",
+        frequency_hz: 918_000_000,
+        bandwidth_hz: 250_000,
+        spreading_factor: 11,
+        coding_rate: 8,
+        tx_power_dbm: 20,
+    },
+];

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -717,6 +717,38 @@ pub fn run_wizard(config_out: Option<&Path>) {
 
     println!("\nConfig written to {}.", out_path.display());
 
+    // On Linux, set ownership of the config file (and its parent directory)
+    // so the BBS service process can update config.toml from the web admin.
+    // Succeeds when setup is run as root (e.g. sudo supply-drop-bbs setup).
+    // If it fails, a manual command is printed in the next-steps section.
+    #[cfg(target_os = "linux")]
+    let config_chown_ok = {
+        const SERVICE_USER: &str = "supply-drop-bbs";
+        let chown_arg = format!("{SERVICE_USER}:{SERVICE_USER}");
+        // Chown the parent directory so the service can atomically rewrite the file.
+        if let Some(parent) = out_path.parent() {
+            if !parent.as_os_str().is_empty() {
+                let _ = std::process::Command::new("chown")
+                    .args([chown_arg.as_str(), &parent.to_string_lossy()])
+                    .status();
+            }
+        }
+        let file_ok = matches!(
+            std::process::Command::new("chown")
+                .args([chown_arg.as_str(), &out_path.to_string_lossy()])
+                .status(),
+            Ok(s) if s.success()
+        );
+        if file_ok {
+            println!(
+                "  ownership set to {SERVICE_USER}:{SERVICE_USER} (web admin can save config)"
+            );
+        }
+        file_ok
+    };
+    #[cfg(not(target_os = "linux"))]
+    let config_chown_ok = true;
+
     if let Some(ref dir) = web_backup_dir {
         if !dir.is_empty() {
             match fs::create_dir_all(dir) {
@@ -767,6 +799,8 @@ pub fn run_wizard(config_out: Option<&Path>) {
         use_meshtastic,
         meshtastic_conn_type,
         web_bind.as_deref(),
+        &out_path,
+        config_chown_ok,
     );
 }
 
@@ -1510,6 +1544,7 @@ fn list_serial_ports() -> Vec<PortInfo> {
 
 // ── Next steps ────────────────────────────────────────────────────────────────
 
+#[allow(clippy::too_many_arguments)]
 fn print_next_steps(
     use_mesh: bool,
     mesh_conn_type: &str,
@@ -1517,6 +1552,8 @@ fn print_next_steps(
     use_meshtastic: bool,
     meshtastic_conn_type: &str,
     web_bind: Option<&str>,
+    config_path: &std::path::Path,
+    config_chown_ok: bool,
 ) {
     if use_mesh && mesh_conn_type == "tcp" {
         println!("MeshCore TCP mode: Supply Drop BBS will connect to pymc_core at");
@@ -1553,6 +1590,28 @@ fn print_next_steps(
         println!("  sudo systemctl daemon-reload");
         println!("  sudo systemctl enable --now supply-drop-bbs");
         println!();
+
+        // If ownership was not set during setup (not run as root, or the
+        // service user didn't exist yet), remind the operator to do it
+        // manually so the web admin can save config changes.
+        if !config_chown_ok {
+            println!("After the service user is created, allow the BBS to update config.toml:");
+            println!();
+            println!(
+                "  sudo chown supply-drop-bbs:supply-drop-bbs {}",
+                config_path.display()
+            );
+            if let Some(parent) = config_path.parent() {
+                if !parent.as_os_str().is_empty() {
+                    println!(
+                        "  sudo chown supply-drop-bbs:supply-drop-bbs {}",
+                        parent.display()
+                    );
+                }
+            }
+            println!();
+        }
+
         println!("Or run it directly in the foreground:");
         println!();
         println!("  supply-drop-bbs run");

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -48,6 +48,8 @@ struct Existing {
     // pymc-companion (HAT)
     region_idx: usize,
     hat_idx: usize,
+    // USB serial radio preset (index into REGION_PRESETS, None = not configured)
+    mesh_radio_preset: Option<usize>,
     // GPS
     latitude: Option<f64>,
     longitude: Option<f64>,
@@ -162,6 +164,13 @@ fn load_existing(out_path: &Path) -> Existing {
     let yaml_path = companion_yaml_path(out_path);
     let yaml = fs::read_to_string(&yaml_path).unwrap_or_default();
 
+    // USB serial radio preset — read from [plugins.mesh.radio].preset
+    let mesh_radio_preset = mesh
+        .and_then(|m| m.get("radio"))
+        .and_then(|r| r.get("preset"))
+        .and_then(|v| v.as_str())
+        .and_then(|name| REGION_PRESETS.iter().position(|r| r.name == name));
+
     Existing {
         bbs_name,
         data_dir,
@@ -179,6 +188,7 @@ fn load_existing(out_path: &Path) -> Existing {
         web_backup_dir,
         region_idx: match_region_preset(&yaml),
         hat_idx: match_hat_preset(&yaml),
+        mesh_radio_preset,
         latitude,
         longitude,
         process_plugins_toml,
@@ -274,6 +284,7 @@ fn match_hat_preset(yaml: &str) -> usize {
     0
 }
 
+use crate::mesh_presets::REGION_PRESETS;
 use dialoguer::{theme::ColorfulTheme, Confirm, Input, MultiSelect, Select};
 
 // ── Public entry point ────────────────────────────────────────────────────────
@@ -413,6 +424,47 @@ pub fn run_wizard(config_out: Option<&Path>) {
         mesh_baud_rate = None;
         mesh_addr = None;
     }
+
+    // ── MeshCore radio parameters (serial mode only) ──────────────────────────
+    //
+    // For HAT mode, radio parameters go into pymc-companion.yaml (handled
+    // later by configure_hat). For TCP mode, pymc_core owns the radio config.
+    // Only USB serial devices are configured here.
+
+    let mesh_radio_preset: Option<usize> = if use_mesh && mesh_conn_type == "serial" {
+        section("MeshCore radio parameters");
+
+        println!("Select a region preset to configure the radio.");
+        println!("Skip this step if the device is already on the correct frequency.");
+        println!();
+
+        let configure = Confirm::with_theme(&theme)
+            .with_prompt("Configure radio parameters now?")
+            .default(ex.mesh_radio_preset.is_some())
+            .interact()
+            .unwrap_or_else(|_| cancelled());
+
+        if configure {
+            let region_names: Vec<String> = REGION_PRESETS
+                .iter()
+                .map(|r| {
+                    format!(
+                        "{:<26} ({:.3} MHz)",
+                        r.name,
+                        r.frequency_hz as f64 / 1_000_000.0
+                    )
+                })
+                .collect();
+
+            let default_region = ex.mesh_radio_preset.unwrap_or(14); // USA/Canada
+            let choice = prompt_select(&theme, "Select your region", &region_names, default_region);
+            Some(choice)
+        } else {
+            None
+        }
+    } else {
+        None
+    };
 
     // ── Meshtastic connection ─────────────────────────────────────────────────
 
@@ -643,6 +695,7 @@ pub fn run_wizard(config_out: Option<&Path>) {
         latitude: gps_lat,
         longitude: gps_lon,
         process_plugins_toml: ex.process_plugins_toml.as_deref(),
+        mesh_radio_preset,
     });
 
     if let Some(parent) = out_path.parent() {
@@ -820,172 +873,6 @@ fn configure_uart_hat(theme: &ColorfulTheme, existing_port: Option<&str>) -> (St
 
     (port, 115_200)
 }
-
-// ── Region presets ────────────────────────────────────────────────────────────
-
-struct RegionPreset {
-    name: &'static str,
-    frequency_hz: u64,
-    bandwidth_hz: u32,
-    spreading_factor: u8,
-    coding_rate: u8,
-    tx_power_dbm: i32,
-}
-
-const REGION_PRESETS: &[RegionPreset] = &[
-    RegionPreset {
-        name: "Australia",
-        frequency_hz: 915_800_000,
-        bandwidth_hz: 250_000,
-        spreading_factor: 10,
-        coding_rate: 5,
-        tx_power_dbm: 20,
-    },
-    RegionPreset {
-        name: "Australia (Narrow)",
-        frequency_hz: 916_575_000,
-        bandwidth_hz: 62_500,
-        spreading_factor: 7,
-        coding_rate: 5,
-        tx_power_dbm: 20,
-    },
-    RegionPreset {
-        name: "Australia SA, WA, QLD",
-        frequency_hz: 923_125_000,
-        bandwidth_hz: 62_500,
-        spreading_factor: 8,
-        coding_rate: 5,
-        tx_power_dbm: 20,
-    },
-    RegionPreset {
-        name: "Czech Republic",
-        frequency_hz: 869_432_000,
-        bandwidth_hz: 62_500,
-        spreading_factor: 7,
-        coding_rate: 5,
-        tx_power_dbm: 14,
-    },
-    RegionPreset {
-        name: "EU 433MHz",
-        frequency_hz: 433_650_000,
-        bandwidth_hz: 250_000,
-        spreading_factor: 11,
-        coding_rate: 5,
-        tx_power_dbm: 20,
-    },
-    RegionPreset {
-        name: "EU/UK (Long Range)",
-        frequency_hz: 869_525_000,
-        bandwidth_hz: 250_000,
-        spreading_factor: 11,
-        coding_rate: 5,
-        tx_power_dbm: 14,
-    },
-    RegionPreset {
-        name: "EU/UK (Medium Range)",
-        frequency_hz: 869_525_000,
-        bandwidth_hz: 250_000,
-        spreading_factor: 10,
-        coding_rate: 5,
-        tx_power_dbm: 14,
-    },
-    RegionPreset {
-        name: "EU/UK (Narrow)",
-        frequency_hz: 869_618_000,
-        bandwidth_hz: 62_500,
-        spreading_factor: 8,
-        coding_rate: 5,
-        tx_power_dbm: 14,
-    },
-    RegionPreset {
-        name: "New Zealand",
-        frequency_hz: 917_375_000,
-        bandwidth_hz: 250_000,
-        spreading_factor: 11,
-        coding_rate: 5,
-        tx_power_dbm: 20,
-    },
-    RegionPreset {
-        name: "New Zealand (Narrow)",
-        frequency_hz: 917_375_000,
-        bandwidth_hz: 62_500,
-        spreading_factor: 7,
-        coding_rate: 5,
-        tx_power_dbm: 20,
-    },
-    RegionPreset {
-        name: "Portugal 433",
-        frequency_hz: 433_375_000,
-        bandwidth_hz: 62_500,
-        spreading_factor: 9,
-        coding_rate: 5,
-        tx_power_dbm: 20,
-    },
-    RegionPreset {
-        name: "Portugal 869",
-        frequency_hz: 869_618_000,
-        bandwidth_hz: 62_500,
-        spreading_factor: 7,
-        coding_rate: 5,
-        tx_power_dbm: 14,
-    },
-    RegionPreset {
-        name: "Switzerland",
-        frequency_hz: 869_618_000,
-        bandwidth_hz: 62_500,
-        spreading_factor: 8,
-        coding_rate: 5,
-        tx_power_dbm: 14,
-    },
-    RegionPreset {
-        name: "USA Arizona",
-        frequency_hz: 908_205_000,
-        bandwidth_hz: 62_500,
-        spreading_factor: 10,
-        coding_rate: 5,
-        tx_power_dbm: 20,
-    },
-    RegionPreset {
-        name: "USA/Canada",
-        frequency_hz: 910_525_000,
-        bandwidth_hz: 62_500,
-        spreading_factor: 7,
-        coding_rate: 5,
-        tx_power_dbm: 20,
-    },
-    RegionPreset {
-        name: "Vietnam",
-        frequency_hz: 920_250_000,
-        bandwidth_hz: 250_000,
-        spreading_factor: 11,
-        coding_rate: 5,
-        tx_power_dbm: 20,
-    },
-    RegionPreset {
-        name: "Off-Grid 433",
-        frequency_hz: 433_000_000,
-        bandwidth_hz: 250_000,
-        spreading_factor: 11,
-        coding_rate: 8,
-        tx_power_dbm: 20,
-    },
-    RegionPreset {
-        name: "Off-Grid 869",
-        frequency_hz: 869_000_000,
-        bandwidth_hz: 250_000,
-        spreading_factor: 11,
-        coding_rate: 8,
-        tx_power_dbm: 14,
-    },
-    RegionPreset {
-        name: "Off-Grid 918",
-        frequency_hz: 918_000_000,
-        bandwidth_hz: 250_000,
-        spreading_factor: 11,
-        coding_rate: 8,
-        tx_power_dbm: 20,
-    },
-];
 
 // ── Pi HAT configuration ──────────────────────────────────────────────────────
 
@@ -1411,6 +1298,8 @@ struct TomlParams<'a> {
     longitude: Option<f64>,
     // Process plugins — preserved verbatim from the previous config
     process_plugins_toml: Option<&'a str>,
+    // USB serial radio preset (index into REGION_PRESETS; None = omit section)
+    mesh_radio_preset: Option<usize>,
 }
 
 fn build_toml(p: &TomlParams<'_>) -> String {
@@ -1466,6 +1355,16 @@ fn build_toml(p: &TomlParams<'_>) -> String {
                 }
             }
             _ => {}
+        }
+    }
+
+    // [plugins.mesh.radio] — only for USB serial with a preset chosen
+    if p.use_mesh && p.mesh_connection_type == "serial" {
+        if let Some(idx) = p.mesh_radio_preset {
+            if let Some(preset) = REGION_PRESETS.get(idx) {
+                writeln!(s, "\n[plugins.mesh.radio]").unwrap();
+                writeln!(s, "preset = {}", toml_str(preset.name)).unwrap();
+            }
         }
     }
 

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -725,26 +725,35 @@ pub fn run_wizard(config_out: Option<&Path>) {
     let config_chown_ok = {
         const SERVICE_USER: &str = "supply-drop";
         let chown_arg = format!("{SERVICE_USER}:{SERVICE_USER}");
-        // Chown the parent directory so the service can atomically rewrite the file.
-        if let Some(parent) = out_path.parent() {
-            if !parent.as_os_str().is_empty() {
-                let _ = std::process::Command::new("chown")
+        // Chown the parent directory so the service can atomically rewrite the
+        // file.  Track whether this succeeds — if it fails, the web admin
+        // still cannot save config even if the file itself was chowned.
+        let dir_ok = match out_path.parent() {
+            Some(parent) if !parent.as_os_str().is_empty() => matches!(
+                std::process::Command::new("chown")
                     .args([chown_arg.as_str(), &parent.to_string_lossy()])
-                    .status();
-            }
-        }
+                    .status(),
+                Ok(s) if s.success()
+            ),
+            // No meaningful parent (e.g. path is just a filename with no
+            // directory component) — nothing to chown, not a failure.
+            _ => true,
+        };
         let file_ok = matches!(
             std::process::Command::new("chown")
                 .args([chown_arg.as_str(), &out_path.to_string_lossy()])
                 .status(),
             Ok(s) if s.success()
         );
-        if file_ok {
+        // Both the directory AND the file must be re-owned for the web admin
+        // to write config.toml atomically.
+        let both_ok = dir_ok && file_ok;
+        if both_ok {
             println!(
                 "  ownership set to {SERVICE_USER}:{SERVICE_USER} (web admin can save config)"
             );
         }
-        file_ok
+        both_ok
     };
     #[cfg(not(target_os = "linux"))]
     let config_chown_ok = true;

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -723,7 +723,7 @@ pub fn run_wizard(config_out: Option<&Path>) {
     // If it fails, a manual command is printed in the next-steps section.
     #[cfg(target_os = "linux")]
     let config_chown_ok = {
-        const SERVICE_USER: &str = "supply-drop-bbs";
+        const SERVICE_USER: &str = "supply-drop";
         let chown_arg = format!("{SERVICE_USER}:{SERVICE_USER}");
         // Chown the parent directory so the service can atomically rewrite the file.
         if let Some(parent) = out_path.parent() {
@@ -1598,15 +1598,12 @@ fn print_next_steps(
             println!("After the service user is created, allow the BBS to update config.toml:");
             println!();
             println!(
-                "  sudo chown supply-drop-bbs:supply-drop-bbs {}",
+                "  sudo chown supply-drop:supply-drop {}",
                 config_path.display()
             );
             if let Some(parent) = config_path.parent() {
                 if !parent.as_os_str().is_empty() {
-                    println!(
-                        "  sudo chown supply-drop-bbs:supply-drop-bbs {}",
-                        parent.display()
-                    );
+                    println!("  sudo chown supply-drop:supply-drop {}", parent.display());
                 }
             }
             println!();


### PR DESCRIPTION
## Summary

- When `sudo supply-drop-bbs setup` runs, automatically `chown` `config.toml` and its parent directory to `supply-drop:supply-drop` so the web admin Settings page can save configuration changes
- When run as a non-root user (or when the `supply-drop` service user doesn't exist yet), the wizard prints the manual `chown` commands in the next-steps output instead
- Documents the behavior in `docs/CLI.md` (new "Run as root for automatic ownership fix" section under `setup`) and `docs/OPERATIONS.md` (new troubleshooting entry for the "Config file is not writable" warning)

## Why

New installs consistently show "Config file is not writable by the server process" in the web admin Settings page because the config file ends up owned by root (whoever ran `sudo supply-drop-bbs setup`). This fix makes the wizard fix ownership automatically when it has the privilege to do so.

## Test plan

- [ ] `sudo supply-drop-bbs setup` — prints `ownership set to supply-drop:supply-drop (web admin can save config)`; `ls -la /etc/supply-drop-bbs/` shows `supply-drop` as owner
- [ ] `supply-drop-bbs setup` (non-root) — prints manual `chown` commands in next steps
- [ ] After chown, web admin Settings page saves without the "not writable" warning
- [ ] Non-Linux build: ownership block compiles out cleanly (`#[cfg(target_os = "linux")]`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)