### PR TITLE
fix(web): correct advert type name mapping for repeater/room (#17)

### DIFF
--- a/crates/bbs-web/src/lib.rs
+++ b/crates/bbs-web/src/lib.rs
@@ -954,8 +954,8 @@ async fn api_adverts(State(state): State<Arc<AppState>>) -> impl IntoResponse {
 fn adv_type_name(t: u8) -> &'static str {
     match t {
         1 => "chat",
-        2 => "room",
-        3 => "repeater",
+        2 => "repeater",
+        3 => "room",
         4 => "sensor",
         _ => "unknown",
     }


### PR DESCRIPTION
## Summary

- `adv_type_name()` in `crates/bbs-web/src/lib.rs` had values 2 and 3 swapped, causing repeater nodes to be labelled `"room"` and room nodes to be labelled `"repeater"` in the web API response.
- Fixed by swapping the string literals so `2 => "repeater"` and `3 => "room"`, matching the canonical constants in `crates/meshcore-companion/src/constants.rs`.

## Test plan

- [x] `cargo fmt` passes
- [x] `cargo clippy` passes (no warnings)
- [x] `cargo test` passes (all tests green)
- [x] `cargo doc` passes

Closes #17