### PR TITLE
fix(config): wire bbs.welcome_msg into mesh transport welcome message (#18)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -583,7 +583,8 @@ async fn cmd_run(cli: &Cli) {
     #[cfg(feature = "transport-mesh")]
     let mesh_cfg = {
         let mut c = cfg.plugins.mesh.clone();
-        c.welcome_message = cfg.bbs.welcome_msg.clone();
+        // Substitute {name} placeholder before wiring into mesh transport.
+        c.welcome_message = cfg.bbs.welcome_msg.replace("{name}", &cfg.bbs.name);
         c
     };
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -581,7 +581,14 @@ async fn cmd_run(cli: &Cli) {
     let cli_transport = init_cli_plugin(&cfg.plugins.cli, Arc::clone(&host)).await;
 
     #[cfg(feature = "transport-mesh")]
-    let mesh_transport = init_mesh_plugin(&cfg.plugins.mesh, Arc::clone(&host)).await;
+    let mesh_cfg = {
+        let mut c = cfg.plugins.mesh.clone();
+        c.welcome_message = cfg.bbs.welcome_msg.clone();
+        c
+    };
+
+    #[cfg(feature = "transport-mesh")]
+    let mesh_transport = init_mesh_plugin(&mesh_cfg, Arc::clone(&host)).await;
 
     #[cfg(feature = "transport-meshtastic")]
     let meshtastic_transport =


### PR DESCRIPTION
## Summary

- `[bbs] welcome_msg` was parsed and stored in `cfg.bbs.welcome_msg` but never forwarded to the mesh transport
- The mesh transport was always using its own `[plugins.mesh] welcome_message` field (with a hardcoded default), ignoring the operator-configured BBS welcome message
- Before calling `init_mesh_plugin`, the mesh config is now cloned and its `welcome_message` field is overridden with `cfg.bbs.welcome_msg`

## Changes

`src/main.rs` in `cmd_run()`: added a `#[cfg(feature = "transport-mesh")]` block that clones `cfg.plugins.mesh` and sets `welcome_message` from `cfg.bbs.welcome_msg` before passing it to `init_mesh_plugin`.

## Test plan

- [x] `cargo test` passes (all 170+ tests green, fmt and clippy clean)
- [ ] Manual: set `welcome_msg` in `[bbs]` config and verify the mesh transport delivers it to new nodes on first contact

Closes #18