### PR TITLE
fix(command): add whoami to command parser (#19)

### DIFF
--- a/crates/bbs-mesh/src/command.rs
+++ b/crates/bbs-mesh/src/command.rs
@@ -212,6 +212,8 @@ pub fn parse_command(text: &str, prefix: Option<char>, awaiting_reply: bool) -> 
             }),
         },
 
+        "whoami" => Some(Command::Whoami),
+
         "profile" => Some(Command::EditProfile),
 
         "passwd" => Some(Command::ChangePassword),
@@ -404,9 +406,13 @@ mod tests {
     }
 
     #[test]
-    fn logout_and_whoami_are_unknown_on_mesh() {
+    fn logout_is_unknown_on_mesh() {
         assert!(matches!(cmd("logout"), Some(Command::Unknown { .. })));
-        assert!(matches!(cmd("whoami"), Some(Command::Unknown { .. })));
+    }
+
+    #[test]
+    fn whoami_is_parsed_on_mesh() {
+        assert!(matches!(cmd("whoami"), Some(Command::Whoami)));
     }
 
     #[test]

--- a/crates/bbs-plugin-api/src/command.rs
+++ b/crates/bbs-plugin-api/src/command.rs
@@ -454,6 +454,7 @@ impl Command {
                     raw: text.to_owned(),
                 },
             },
+            "whoami" => Command::Whoami,
             "profile" => Command::EditProfile,
             "passwd" => Command::ChangePassword,
 


### PR DESCRIPTION
## Summary

- Adds `"whoami" => Command::Whoami` to the `Command::parse()` match table in `crates/bbs-plugin-api/src/command.rs`, fixing the bug where typing `WHOAMI` produced `Command::Unknown` instead of routing to the host's `handle_whoami` handler
- Adds the same arm to the `bbs-mesh` transport parser in `crates/bbs-mesh/src/command.rs` for consistency
- Updates the `bbs-mesh` test from `logout_and_whoami_are_unknown_on_mesh` (which incorrectly asserted `whoami` was unknown) to `logout_is_unknown_on_mesh` + a new `whoami_is_parsed_on_mesh` test
- Confirmed `"whoami"` was already present in the `is_cmd_keyword` guard list in `crates/bbs-core/src/host.rs` — no change needed there

## Test plan

- [x] `cargo test --workspace` passes (all pre-commit checks: fmt, clippy, tests, docs)
- [x] `command::tests::whoami_is_parsed_on_mesh` — new test verifies mesh parser returns `Command::Whoami`
- [x] `command::tests::logout_is_unknown_on_mesh` — logout still correctly unknown on mesh

Closes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)