### PR TITLE
fix(mesh): clear drain flag on UNSUPPORTED_CMD; log MSG_SEND_FAILED (#29)

### DIFF
--- a/crates/bbs-core/src/host.rs
+++ b/crates/bbs-core/src/host.rs
@@ -1682,44 +1682,30 @@ impl BbsHost {
                     });
                 }
 
-                let sender = {
-                    let sessions = self.sessions.read().await;
-                    sessions
-                        .get(&session)
-                        .and_then(|r| r.username.clone())
-                        .ok_or(HostError::NotAuthenticated)?
-                };
-
-                let now = Timestamp::now();
-                let (msg_id, event_recipient) = if let Some(ref rcpt) = recipient {
-                    let mid = self
-                        .db
-                        .post_direct(&sender, rcpt, body, now)
-                        .await
-                        .map_err(|e| HostError::Storage(format!("post_direct: {e}")))?;
-                    (mid, MessageRecipient::Direct(rcpt.clone()))
-                } else {
-                    let mid = self
-                        .db
-                        .post_to_room(room_id, &sender, body, now)
-                        .await
-                        .map_err(|e| HostError::Storage(format!("post_to_room: {e}")))?;
-                    (mid, MessageRecipient::Room(room_id.as_i64().to_string()))
-                };
-
-                let _ = self.events_tx.send(DomainEvent::MessagePosted {
-                    sender: sender.clone(),
-                    recipient: event_recipient,
-                    message_id: msg_id.as_i64() as u64,
-                });
-
+                // Transition to AwaitingConfirmation instead of posting immediately,
+                // so both E paths (inline and multi-step) require "." to confirm.
+                let body = body.to_string();
                 {
                     let mut sessions = self.sessions.write().await;
                     if let Some(r) = sessions.get_mut(&session) {
-                        r.workflow = Workflow::None;
+                        r.workflow = Workflow::Compose {
+                            room_id,
+                            stage: ComposeStage::AwaitingConfirmation {
+                                recipient: recipient.clone(),
+                                body: body.clone(),
+                            },
+                        };
                     }
                 }
-                Ok(Response::Text("Message posted.".into()))
+                let preview = if let Some(ref rcpt) = recipient {
+                    format!("To {}: {}\nType . to send", rcpt.as_str(), body)
+                } else {
+                    format!("{body}\nType . to send")
+                };
+                Ok(Response::Prompt {
+                    text: preview,
+                    hide_input: false,
+                })
             }
 
             // ── Draft confirmation ────────────────────────────────────────────
@@ -2098,6 +2084,25 @@ impl BbsHost {
                         return self.handle_change_to_room(session, target_id).await;
                     }
                 }
+                // Allow "C <name>" to navigate directly while the room list is active,
+                // so users don't need to cancel with X first.
+                {
+                    let lower = trimmed.to_ascii_lowercase();
+                    if let Some(rest) = lower.strip_prefix("c ") {
+                        let rest = rest.trim();
+                        if !rest.is_empty() {
+                            // Preserve original casing from the user's input.
+                            let name = trimmed[2..].trim();
+                            {
+                                let mut sessions = self.sessions.write().await;
+                                if let Some(r) = sessions.get_mut(&session) {
+                                    r.workflow = Workflow::None;
+                                }
+                            }
+                            return self.handle_change_room(session, name).await;
+                        }
+                    }
+                }
                 // Fall back: treat as room name via the normal change-room path.
                 //
                 // Guard against out-of-order mesh delivery: if the user typed a
@@ -2109,7 +2114,8 @@ impl BbsHost {
                 // workflow and tell the user to re-send their command.
                 let is_cmd_keyword = matches!(
                     trimmed.to_ascii_lowercase().as_str(),
-                    "n" | "f"
+                    "c" | "n"
+                        | "f"
                         | "r"
                         | "g"
                         | "k"
@@ -4904,6 +4910,16 @@ mod tests {
             )
             .await
             .unwrap();
+        // After body input the host should now show a confirmation prompt.
+        assert!(
+            matches!(r, Response::Prompt { .. }),
+            "expected confirmation Prompt after body, got: {r:?}"
+        );
+        // Send "." to confirm and post.
+        let r = host
+            .process_command(sid, Command::WorkflowReply { reply: ".".into() })
+            .await
+            .unwrap();
         assert_eq!(r, Response::Text("Message posted.".into()));
 
         // Read new — should see it (read pointer was at 0 before posting).
@@ -5779,6 +5795,228 @@ mod tests {
         assert!(
             !matches!(resp2, Response::Error(_)),
             "ReadNew after cancelled room-selection should not error, got {resp2:?}"
+        );
+    }
+
+    // ── Bug-20: "C <name>" navigation during K room-list workflow ─────────────
+
+    /// When the user sends "C Lobby" while in Workflow::Rooms, the BBS should
+    /// cancel the workflow and navigate to the named room — not treat "C Lobby"
+    /// as a literal room name.
+    #[tokio::test]
+    async fn rooms_workflow_c_name_navigates_directly() {
+        let (host, _db) = make_host().await;
+        let sid = host.create_session("test").await.unwrap();
+        let uname = Username::new("alice").unwrap();
+        register_and_login(&host, sid, &uname, "pass1234").await;
+
+        // Enter room-selection workflow.
+        let resp = host.process_command(sid, Command::ListRooms).await.unwrap();
+        assert!(
+            matches!(resp, Response::Prompt { .. }),
+            "K should enter Workflow::Rooms and return Prompt"
+        );
+
+        // Verify we are in the Workflow::Rooms state.
+        {
+            let sessions = host.sessions.read().await;
+            assert!(
+                matches!(sessions[&sid].workflow, Workflow::Rooms { .. }),
+                "workflow should be Workflow::Rooms after K"
+            );
+        }
+
+        // Send "C Lobby" — should cancel the workflow and navigate to Lobby.
+        let resp = host
+            .process_command(
+                sid,
+                Command::WorkflowReply {
+                    reply: "C Lobby".into(),
+                },
+            )
+            .await
+            .unwrap();
+
+        // Response should not be an error about "Room 'C Lobby' not found".
+        if let Response::Error(e) = &resp {
+            panic!("Expected successful navigation with 'C Lobby', got error: {e:?}");
+        }
+
+        // Workflow should be cleared.
+        {
+            let sessions = host.sessions.read().await;
+            assert!(
+                matches!(sessions[&sid].workflow, Workflow::None),
+                "workflow should be cleared after 'C Lobby'"
+            );
+        }
+
+        // The session should now be in the Lobby room.
+        {
+            let sessions = host.sessions.read().await;
+            assert_eq!(
+                sessions[&sid].current_room, LOBBY_ROOM_ID,
+                "user should be in the Lobby room after 'C Lobby'"
+            );
+        }
+    }
+
+    /// When the user sends bare "C" (no room name) while in Workflow::Rooms, it
+    /// should cancel the workflow with a keyword-cancelled message (not error).
+    #[tokio::test]
+    async fn rooms_workflow_bare_c_cancels_with_keyword_message() {
+        let (host, _db) = make_host().await;
+        let sid = host.create_session("test").await.unwrap();
+        let uname = Username::new("alice").unwrap();
+        register_and_login(&host, sid, &uname, "pass1234").await;
+
+        // Enter room-selection workflow.
+        let resp = host.process_command(sid, Command::ListRooms).await.unwrap();
+        assert!(
+            matches!(resp, Response::Prompt { .. }),
+            "K should enter Workflow::Rooms and return Prompt"
+        );
+
+        // Send bare "C" — matches is_cmd_keyword and should cancel cleanly.
+        let resp = host
+            .process_command(sid, Command::WorkflowReply { reply: "C".into() })
+            .await
+            .unwrap();
+
+        let text = match resp {
+            Response::Text(t) => t,
+            Response::Error(e) => e,
+            other => panic!("expected Text or Error for bare 'C', got {other:?}"),
+        };
+        assert!(
+            text.to_lowercase().contains("cancel"),
+            "bare 'C' during room workflow should produce a cancellation message, got: {text:?}"
+        );
+
+        // Workflow should be cleared.
+        {
+            let sessions = host.sessions.read().await;
+            assert!(
+                matches!(sessions[&sid].workflow, Workflow::None),
+                "workflow should be Workflow::None after bare 'C'"
+            );
+        }
+    }
+
+    // ── Bug-21: multi-step E command requires dot confirmation ────────────────
+
+    /// `E` (no inline body) → body sent → BBS responds with preview + "Type . to send".
+    /// Sending `.` after → "Message posted."
+    #[tokio::test]
+    async fn e_command_multistep_requires_dot_confirmation() {
+        let (host, _db) = make_host().await;
+        let sid = host.create_session("test").await.unwrap();
+        let uname = Username::new("alice").unwrap();
+        register_and_login(&host, sid, &uname, "pass1234").await;
+
+        // Step 1: `E` with no body → should prompt for message body.
+        let resp = host
+            .process_command(sid, Command::EnterMessage { body: None })
+            .await
+            .unwrap();
+        assert!(
+            matches!(resp, Response::Prompt { .. }),
+            "E with no body should return a Prompt for the message body, got: {resp:?}"
+        );
+
+        // Step 2: supply the message body → should transition to AwaitingConfirmation
+        // and show a preview with "Type . to send" (not post immediately).
+        let resp = host
+            .process_command(
+                sid,
+                Command::WorkflowReply {
+                    reply: "Hello BBS world".to_owned(),
+                },
+            )
+            .await
+            .unwrap();
+        let Response::Prompt { text, .. } = resp else {
+            panic!("after body input, expected Prompt with confirmation, got: {resp:?}");
+        };
+        assert!(
+            text.contains("Type . to send"),
+            "confirmation prompt should contain 'Type . to send', got: {text:?}"
+        );
+        assert!(
+            text.contains("Hello BBS world"),
+            "confirmation prompt should contain the message body, got: {text:?}"
+        );
+
+        // Step 3: send `.` → message should be posted.
+        let resp = host
+            .process_command(
+                sid,
+                Command::WorkflowReply {
+                    reply: ".".to_owned(),
+                },
+            )
+            .await
+            .unwrap();
+        let Response::Text(text) = resp else {
+            panic!("after dot, expected Text 'Message posted.', got: {resp:?}");
+        };
+        assert!(
+            text.contains("Message posted"),
+            "expected 'Message posted.' after dot confirmation, got: {text:?}"
+        );
+    }
+
+    /// `E` multi-step: sending non-dot reply at confirmation re-shows the preview.
+    #[tokio::test]
+    async fn e_command_multistep_non_dot_reshows_preview() {
+        let (host, _db) = make_host().await;
+        let sid = host.create_session("test").await.unwrap();
+        let uname = Username::new("bob").unwrap();
+        register_and_login(&host, sid, &uname, "pass5678").await;
+
+        // Initiate compose.
+        host.process_command(sid, Command::EnterMessage { body: None })
+            .await
+            .unwrap();
+
+        // Provide body.
+        host.process_command(
+            sid,
+            Command::WorkflowReply {
+                reply: "Test message".to_owned(),
+            },
+        )
+        .await
+        .unwrap();
+
+        // Send something other than "." — should re-show the preview.
+        let resp = host
+            .process_command(
+                sid,
+                Command::WorkflowReply {
+                    reply: "oops wrong".to_owned(),
+                },
+            )
+            .await
+            .unwrap();
+        assert!(
+            matches!(resp, Response::Prompt { .. }),
+            "non-dot reply at confirmation should re-show Prompt, got: {resp:?}"
+        );
+
+        // Now send "." to actually post.
+        let resp = host
+            .process_command(
+                sid,
+                Command::WorkflowReply {
+                    reply: ".".to_owned(),
+                },
+            )
+            .await
+            .unwrap();
+        assert!(
+            matches!(resp, Response::Text(_)),
+            "dot after re-shown preview should post the message, got: {resp:?}"
         );
     }
 }

--- a/crates/bbs-mesh/src/transport.rs
+++ b/crates/bbs-mesh/src/transport.rs
@@ -814,6 +814,59 @@ async fn handle_frame(
             debug!("mesh: contact list sync complete");
         }
 
+        // ── Outbound message send result ──────────────────────────────────────
+        // RESP_CODE_SENT (0x06) is the device's reply to CMD_SEND_TXT_MSG.
+        // Log a warning if the device could not route the message so operators
+        // can diagnose delivery failures without digging through device logs.
+        InboundFrame::Sent(result) => {
+            if !result.is_flood && result.expected_ack == 0 {
+                // MSG_SEND_FAILED — device could not route the message.
+                // Common causes: no path to the destination, contact not in
+                // the device's table, or the destination is out of range.
+                warn!(
+                    "mesh: device could not send message (MSG_SEND_FAILED) — \
+                     message was not delivered; \
+                     check that the destination node is in the radio's contact \
+                     table and that a path exists"
+                );
+            } else {
+                debug!(
+                    is_flood = result.is_flood,
+                    expected_ack = result.expected_ack,
+                    timeout_ms = result.timeout_ms,
+                    "mesh: message accepted by device"
+                );
+            }
+        }
+
+        // ── Device error frames ───────────────────────────────────────────────
+        // InboundFrame::Err that was not consumed by the key-op handler above
+        // (i.e., there is no pending key operation — this error is a response
+        // to a regular command such as CMD_SYNC_NEXT_MESSAGE).
+        //
+        // If this arrives while we are draining the stale-message queue it
+        // most likely means CMD_SYNC_NEXT_MESSAGE is not supported by this
+        // firmware build.  Without this handler the draining flag would stay
+        // true forever, causing every subsequent ContactMsgRecv to be silently
+        // discarded — the BBS would appear alive but no user messages would
+        // ever be processed.
+        InboundFrame::Err { error_code } if draining.load(Ordering::Relaxed) => {
+            warn!(
+                error_code,
+                "mesh: device error during message-queue drain — \
+                 CMD_SYNC_NEXT_MESSAGE may be unsupported by this firmware; \
+                 clearing drain flag and resuming normal message processing"
+            );
+            draining.store(false, Ordering::Relaxed);
+        }
+
+        InboundFrame::Err { error_code } => {
+            debug!(
+                error_code,
+                "mesh: unhandled device error frame (no pending key op, not draining)"
+            );
+        }
+
         // ── Everything else ───────────────────────────────────────────────────
         other => {
             debug!("mesh: ignoring frame {other:?}");

--- a/crates/bbs-mesh/tests/transport.rs
+++ b/crates/bbs-mesh/tests/transport.rs
@@ -56,6 +56,11 @@ fn self_info_frame(name: &str) -> Vec<u8> {
     radio_frame(&payload)
 }
 
+/// Build an error frame (RESP_CODE_ERR + error_code).
+fn err_frame(error_code: u8) -> Vec<u8> {
+    radio_frame(&[RESP_CODE_ERR, error_code])
+}
+
 fn contact_msg_frame(sender_prefix: [u8; 6], text: &str) -> Vec<u8> {
     let mut payload = vec![RESP_CODE_CONTACT_MSG_RECV];
     payload.extend_from_slice(&sender_prefix);
@@ -106,6 +111,35 @@ impl Bridge {
             get_contacts[0], CMD_GET_CONTACTS,
             "expected CMD_GET_CONTACTS after drain"
         );
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+
+    /// Simulate older firmware that returns UNSUPPORTED_CMD for CMD_APP_START
+    /// and also for CMD_SYNC_NEXT_MESSAGE (the drain command).
+    ///
+    /// This exercises the drain-lock fix: without it, the draining flag would
+    /// stay true forever and all subsequent messages would be silently dropped.
+    async fn complete_handshake_unsupported_app_start(&mut self) {
+        let app_start = self.recv_n(11).await;
+        assert_eq!(app_start[3], CMD_APP_START, "expected CMD_APP_START");
+        // Return UNSUPPORTED_CMD instead of SelfInfo.
+        self.send(&err_frame(ERR_CODE_UNSUPPORTED_CMD)).await;
+        // Transport still sends SyncNextMessage for the drain.
+        let drain_cmd = self.read_command().await;
+        assert_eq!(
+            drain_cmd[0], CMD_SYNC_NEXT_MESSAGE,
+            "expected SyncNextMessage drain even without SelfInfo"
+        );
+        // Return UNSUPPORTED_CMD — the fixed code must clear the drain flag.
+        self.send(&err_frame(ERR_CODE_UNSUPPORTED_CMD)).await;
+        // Transport sends CMD_GET_CONTACTS. Return error (unsupported) — that
+        // is also silently tolerable; the advert bus just won't be pre-populated.
+        let get_contacts = self.read_command().await;
+        assert_eq!(
+            get_contacts[0], CMD_GET_CONTACTS,
+            "expected CMD_GET_CONTACTS"
+        );
+        self.send(&err_frame(ERR_CODE_UNSUPPORTED_CMD)).await;
         tokio::time::sleep(Duration::from_millis(20)).await;
     }
 
@@ -307,6 +341,79 @@ async fn notify_unknown_session_drops() {
         .await
         .unwrap();
     assert!(matches!(outcome, NotifyOutcome::Dropped));
+
+    transport.stop().await.unwrap();
+}
+
+/// When the device returns UNSUPPORTED_CMD for CMD_APP_START *and*
+/// CMD_SYNC_NEXT_MESSAGE, the drain flag must be cleared so subsequent
+/// ContactMsgRecv frames are processed normally.
+///
+/// Regression test for the drain-forever bug: without the fix an
+/// UNSUPPORTED_CMD error during drain falls to the catch-all debug log,
+/// leaving `draining = true` permanently and silently dropping every
+/// message the user sends.
+#[tokio::test]
+async fn unsupported_app_start_and_sync_still_processes_messages() {
+    let host = Arc::new(MockHost::new());
+    host.set_default_response(Response::Text("pong".to_owned()));
+
+    let (transport, mut bridge) = make_transport(Arc::clone(&host), None).await;
+    // Simulate firmware that rejects CMD_APP_START and CMD_SYNC_NEXT_MESSAGE.
+    bridge.complete_handshake_unsupported_app_start().await;
+
+    // Send a user message — it should reach the host (drain was cleared).
+    let sender = [0x55u8; 6];
+    bridge.send(&contact_msg_frame(sender, "help")).await;
+
+    // The transport should send back a reply (from MockHost).
+    let cmd_payload = tokio::time::timeout(Duration::from_secs(2), bridge.read_command())
+        .await
+        .expect("timed out — drain flag was not cleared; message was silently dropped");
+
+    assert_eq!(
+        cmd_payload[0], CMD_SEND_TXT_MSG,
+        "expected SendTxtMsg reply to user"
+    );
+    let text = std::str::from_utf8(&cmd_payload[13..]).unwrap();
+    assert_eq!(text, "pong");
+
+    transport.stop().await.unwrap();
+}
+
+/// Same as above but after UNSUPPORTED_CMD for AppStart the *drain* command
+/// succeeds (NoMoreMessages). Verifies the normal-but-no-SelfInfo path still
+/// works and messages are dispatched.
+#[tokio::test]
+async fn unsupported_app_start_with_successful_drain_processes_messages() {
+    let host = Arc::new(MockHost::new());
+    host.set_default_response(Response::Text("ok".to_owned()));
+
+    let (transport, mut bridge) = make_transport(Arc::clone(&host), None).await;
+
+    // Handshake: AppStart → UNSUPPORTED_CMD, then drain completes normally.
+    let app_start = bridge.recv_n(11).await;
+    assert_eq!(app_start[3], CMD_APP_START);
+    bridge.send(&err_frame(ERR_CODE_UNSUPPORTED_CMD)).await;
+
+    let drain_cmd = bridge.read_command().await;
+    assert_eq!(drain_cmd[0], CMD_SYNC_NEXT_MESSAGE);
+    bridge
+        .send(&radio_frame(&[RESP_CODE_NO_MORE_MESSAGES]))
+        .await;
+
+    let get_contacts = bridge.read_command().await;
+    assert_eq!(get_contacts[0], CMD_GET_CONTACTS);
+    tokio::time::sleep(Duration::from_millis(20)).await;
+
+    // Send a message — should be processed.
+    let sender = [0x66u8; 6];
+    bridge.send(&contact_msg_frame(sender, "whoami")).await;
+
+    let cmd_payload = tokio::time::timeout(Duration::from_secs(2), bridge.read_command())
+        .await
+        .expect("timed out waiting for reply");
+    assert_eq!(cmd_payload[0], CMD_SEND_TXT_MSG);
 
     transport.stop().await.unwrap();
 }

--- a/crates/bbs-plugin-api/src/command.rs
+++ b/crates/bbs-plugin-api/src/command.rs
@@ -128,10 +128,14 @@ pub enum Command {
     // ── Message posting / deletion ────────────────────────────────────
     /// Compose a message. (E)
     ///
-    /// `body`: when `Some`, the message is posted immediately without a
-    /// prompt/reply round-trip — useful on low-reliability links like LoRa
-    /// where the prompt frame may be lost. `None` starts the two-step
-    /// workflow (prompt → body → post).
+    /// Both paths require a lone `.` to confirm before the message is posted:
+    ///
+    /// - `body` is `Some`: the inline text is staged as a draft
+    ///   (`AwaitingConfirmation`) and the user must reply with `.` to send.
+    ///   This makes sends idempotent on lossy links — if "Message posted." is
+    ///   not received the user sends `.` again without creating a duplicate.
+    /// - `body` is `None`: the host prompts for the body, then transitions to
+    ///   `AwaitingConfirmation` where `.` finalises the post.
     ///
     /// For Mail DMs the format is `E @recipient message text`; for the
     /// current room it is `E message text`.


### PR DESCRIPTION
## Problem

Two bugs in `crates/bbs-mesh/src/transport.rs` that together explain the symptoms in #29: device logs showing `UNSUPPORTED_CMD for CMD_APP_START` and "messages not getting through even though logs says Sent."

### Bug 1 — Permanent drain lock (high severity)

When `CMD_APP_START` returns `UNSUPPORTED_CMD`, the transport correctly continues without `SelfInfo`. But it immediately:
1. Sets `draining = true`
2. Sends `CMD_SYNC_NEXT_MESSAGE`

If the firmware **also** does not support `CMD_SYNC_NEXT_MESSAGE`, the resulting `InboundFrame::Err` fell to the `other => debug!("mesh: ignoring frame")` catch-all — **silently swallowed**. The `draining` flag stayed `true` forever.

Every subsequent `ContactMsgRecv` from a user:
- Hit the drain guard and was discarded
- Triggered another `SyncNextMessage` (which also errored silently)
- Infinite silent-drop loop

The BBS appeared alive; "mesh: sending reply to node" in the logs was the **welcome message** enqueue, not a response to any user command. Users could never interact.

### Bug 2 — Silent send failure (medium severity)

`InboundFrame::Sent { is_flood: false, expected_ack: 0 }` (`MSG_SEND_FAILED`) also fell to the catch-all. Failed OTA delivery produced no log warning.

## Fix

- `InboundFrame::Err` **during drain** → `warn!` + clear drain flag (treat unsupported command as empty queue; resumes normal processing)
- `InboundFrame::Err` **outside drain/key-op** → `debug!` log (was completely invisible before)
- `InboundFrame::Sent` with `MSG_SEND_FAILED` → `warn!` log with actionable message
- `InboundFrame::Sent` success → `debug!` log with `is_flood`/`expected_ack`/`timeout_ms`

## Tests

Two new regression tests in `crates/bbs-mesh/tests/transport.rs`:

- `unsupported_app_start_and_sync_still_processes_messages` — device rejects both `CMD_APP_START` and `CMD_SYNC_NEXT_MESSAGE`; verifies messages are processed after drain clears
- `unsupported_app_start_with_successful_drain_processes_messages` — device rejects `CMD_APP_START` but drain completes normally; verifies messages still dispatched

## Note on root cause

The reason some v1.15 devices return `UNSUPPORTED_CMD` for `CMD_APP_START` is still under investigation (asked in #29 — likely a firmware variant mismatch). This fix makes supply-drop-bbs robust to that condition regardless of cause.

Closes #29