### PR TITLE
fix(adverts): validate device timestamps and add clear action

### DIFF
--- a/crates/bbs-plugin-api/src/advert.rs
+++ b/crates/bbs-plugin-api/src/advert.rs
@@ -112,7 +112,13 @@ impl AdvertBus {
     ///
     /// Use this when the timestamp comes from the device (e.g. the
     /// `last_advert_timestamp` field in a `RESP_CODE_CONTACT` frame) rather than
-    /// the current wall clock. A `device_last_seen` of `0` falls back to `now`.
+    /// the current wall clock.
+    ///
+    /// `device_last_seen` is validated before use: MeshCore devices without a
+    /// synced RTC report seconds-since-boot (small values → near 1970 epoch)
+    /// and devices with a misconfigured clock can report future values. Any
+    /// value outside `[MIN_PLAUSIBLE_TS, now + CLOCK_FUDGE_SECS]` is treated
+    /// as unreliable and falls back to the current wall-clock time.
     ///
     /// Updates all fields for an existing record; preserves `first_seen_secs`.
     pub fn upsert_with_timestamp(
@@ -125,11 +131,19 @@ impl AdvertBus {
         device_last_seen: i64,
     ) {
         let now = unix_now();
-        let last_seen = if device_last_seen > 0 {
-            device_last_seen
-        } else {
-            now
-        };
+        // Accept only plausible Unix timestamps. Devices without a synced RTC
+        // report seconds-since-boot which are tiny (→ dates near 1970); devices
+        // with a misconfigured clock can exceed the current time by years.
+        // 2020-01-01 UTC is a safe floor — no BBS contact predates MeshCore.
+        // 5-minute ceiling fudge tolerates minor clock skew between devices.
+        const MIN_PLAUSIBLE_TS: i64 = 1_577_836_800; // 2020-01-01 00:00:00 UTC
+        const CLOCK_FUDGE_SECS: i64 = 300; // 5 minutes
+        let last_seen =
+            if device_last_seen >= MIN_PLAUSIBLE_TS && device_last_seen <= now + CLOCK_FUDGE_SECS {
+                device_last_seen
+            } else {
+                now
+            };
         let lat = gps_lat as f64 / 1_000_000.0;
         let lon = gps_lon as f64 / 1_000_000.0;
         let mut records = self.records.lock().expect("advert bus poisoned");
@@ -182,6 +196,14 @@ impl AdvertBus {
         v
     }
 
+    /// Remove all records from the bus.
+    ///
+    /// Useful when a sysop wants to flush stale data without restarting the
+    /// BBS (e.g. after correcting device clocks or clearing old contacts).
+    pub fn clear(&self) {
+        self.records.lock().expect("advert bus poisoned").clear();
+    }
+
     /// Subscribe to send-advert requests from the web UI.
     ///
     /// Delivers `true` for flood mode, `false` for direct-only.
@@ -214,4 +236,85 @@ fn hex_encode(bytes: &[u8]) -> String {
         let _ = write!(acc, "{b:02x}");
         acc
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn dummy_key(byte: u8) -> [u8; 32] {
+        [byte; 32]
+    }
+
+    fn now_secs() -> i64 {
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map_or(0, |d| d.as_secs() as i64)
+    }
+
+    /// A device timestamp of 0 (unset) falls back to wall-clock time.
+    #[test]
+    fn zero_device_ts_falls_back_to_now() {
+        let bus = AdvertBus::new();
+        bus.upsert_with_timestamp(dummy_key(1), "A".into(), 1, 0, 0, 0);
+        let records = bus.list();
+        let ts = records[0].last_seen_secs;
+        let now = now_secs();
+        assert!(
+            ts >= now - 2 && ts <= now + 2,
+            "ts {ts} should be near now {now}"
+        );
+    }
+
+    /// A boot-relative timestamp (small value — seconds since reboot, near 1970)
+    /// must be rejected and replaced with the current wall-clock time.
+    #[test]
+    fn boot_relative_ts_is_rejected() {
+        let bus = AdvertBus::new();
+        let boot_relative: i64 = 3600; // 1 hour after epoch — clearly 1970
+        bus.upsert_with_timestamp(dummy_key(2), "B".into(), 1, 0, 0, boot_relative);
+        let ts = bus.list()[0].last_seen_secs;
+        let now = now_secs();
+        assert!(
+            ts >= now - 2 && ts <= now + 2,
+            "boot-relative ts {boot_relative} should have been replaced with now ({now}), got {ts}"
+        );
+    }
+
+    /// A far-future timestamp (device with misconfigured clock) is rejected.
+    #[test]
+    fn far_future_ts_is_rejected() {
+        let bus = AdvertBus::new();
+        let far_future: i64 = 2_000_000_000; // ~year 2033 — plausible false positive guard
+                                             // Use a value well past now+fudge to ensure rejection.
+        let very_far_future: i64 = 4_000_000_000; // ~year 2096
+        bus.upsert_with_timestamp(dummy_key(3), "C".into(), 1, 0, 0, very_far_future);
+        let ts = bus.list()[0].last_seen_secs;
+        let now = now_secs();
+        assert!(
+            ts >= now - 2 && ts <= now + 2,
+            "far-future ts {very_far_future} should have been replaced with now ({now}), got {ts}"
+        );
+        let _ = far_future; // suppress unused warning
+    }
+
+    /// A plausible Unix timestamp (recent past) is accepted as-is.
+    #[test]
+    fn plausible_ts_is_accepted() {
+        let bus = AdvertBus::new();
+        let plausible: i64 = 1_700_000_000; // Nov 2023 — clearly reasonable
+        bus.upsert_with_timestamp(dummy_key(4), "D".into(), 1, 0, 0, plausible);
+        let ts = bus.list()[0].last_seen_secs;
+        assert_eq!(ts, plausible, "plausible ts should be stored unchanged");
+    }
+
+    /// `clear()` empties the bus.
+    #[test]
+    fn clear_empties_bus() {
+        let bus = AdvertBus::new();
+        bus.upsert(dummy_key(5), "E".into(), 1, 0, 0);
+        assert_eq!(bus.list().len(), 1);
+        bus.clear();
+        assert_eq!(bus.list().len(), 0);
+    }
 }

--- a/crates/bbs-web/src/lib.rs
+++ b/crates/bbs-web/src/lib.rs
@@ -534,6 +534,7 @@ fn build_router(state: Arc<AppState>) -> Router {
         .route("/native-plugins", get(api_list_native_plugins))
         .route("/native-plugins/:name", patch(api_update_native_plugin))
         .route("/adverts", get(api_adverts))
+        .route("/adverts", delete(api_adverts_clear))
         .route("/adverts/send", post(api_adverts_send))
         .route("/sessions", get(api_list_sessions))
         .route("/sessions/:id", delete(api_kill_session))
@@ -949,6 +950,16 @@ async fn api_adverts(State(state): State<Arc<AppState>>) -> impl IntoResponse {
         })
         .collect();
     Json(out)
+}
+
+/// `DELETE /api/v1/adverts` — flush all in-memory advert records.
+///
+/// Useful after correcting device clocks or clearing stale contacts.
+/// The bus repopulates automatically as adverts arrive or on the next
+/// BBS reconnect (which triggers a fresh `GetContacts` scan).
+async fn api_adverts_clear(State(state): State<Arc<AppState>>) -> impl IntoResponse {
+    state.host.advert_bus().clear();
+    axum::http::StatusCode::NO_CONTENT
 }
 
 fn adv_type_name(t: u8) -> &'static str {

--- a/crates/bbs-web/web/src/pages/AdvertsPage.vue
+++ b/crates/bbs-web/web/src/pages/AdvertsPage.vue
@@ -24,6 +24,7 @@ let timer: number | undefined
 const flood = ref(true)
 const sending = ref(false)
 const sendStatus = ref<{ kind: 'ok' | 'error'; message: string } | null>(null)
+const clearing = ref(false)
 
 async function load() {
   try {
@@ -54,6 +55,17 @@ async function sendAdvert() {
     sendStatus.value = { kind: 'error', message: msg }
   } finally {
     sending.value = false
+  }
+}
+
+async function clearAdverts() {
+  if (!confirm('Clear all advert records from memory? The list will repopulate as nodes are heard.')) return
+  clearing.value = true
+  try {
+    await api.del('/api/v1/adverts')
+    await load()
+  } finally {
+    clearing.value = false
   }
 }
 
@@ -119,6 +131,14 @@ const columns = [
             ? 'rebroadcast hop-by-hop — more reach, more airtime'
             : 'neighbours only — single hop' }}
         </span>
+        <button
+          class="btn-danger"
+          @click="clearAdverts"
+          :disabled="clearing || !auth.isSysop"
+          :title="!auth.isSysop ? 'sysop required' : 'Clear all advert records from memory'"
+        >
+          {{ clearing ? 'clearing…' : 'clear list' }}
+        </button>
       </div>
       <p v-if="sendStatus" class="status-line small" :class="sendStatus.kind">
         {{ sendStatus.message }}
@@ -178,6 +198,7 @@ h1 { margin: 0; }
 .status-line { margin: 0; padding: 0.25rem 0.5rem; border-radius: 3px; }
 .status-line.ok    { color: #2a8a2a; border: 1px solid #2a8a2a; background: rgba(42,138,42,0.08); }
 .status-line.error { color: var(--error); border: 1px solid var(--error); background: rgba(200,60,60,0.08); }
+.btn-danger { color: var(--error); border-color: var(--error); }
 
 .type-summary { margin: 0; display: flex; flex-wrap: wrap; gap: 0.4rem; }
 


### PR DESCRIPTION
## Problem

The **Last Seen** column in the Adverts page showed nonsensical dates:

- **Dates near 1970** — MeshCore devices without a synced RTC report
  seconds-since-boot as the `last_advert_timestamp` field. These small
  values (e.g. 3600 = "1 hour after Unix epoch") were stored verbatim.
- **Dates in the far future** — Devices with a misconfigured clock can
  report timestamps years ahead of the current time.

Both cases were trusted blindly by `upsert_with_timestamp`.

## Changes

### `crates/bbs-plugin-api/src/advert.rs`
- `AdvertBus::upsert_with_timestamp` now validates the device-supplied
  timestamp against a plausible range:
  - Floor: `2020-01-01 00:00:00 UTC` (1 577 836 800) — no BBS contact
    predates MeshCore.
  - Ceiling: `now + 5 minutes` — tolerates minor clock skew between devices.
  - Any value outside this range falls back to the current wall-clock time.
- Add `AdvertBus::clear()` to flush all records without restarting the BBS.
- Add five unit tests covering: epoch/boot-relative rejection,
  far-future rejection, plausible acceptance, and `clear()`.

### `crates/bbs-web/src/lib.rs`
- Add `DELETE /api/v1/adverts` → 204 No Content, backed by `AdvertBus::clear()`.

### `crates/bbs-web/web/src/pages/AdvertsPage.vue`
- Add **"clear list"** button (sysop-gated) that calls `DELETE /api/v1/adverts`
  and refreshes the table. Styled with `btn-danger` (red border/text).

## Testing

- 5 new unit tests in `bbs-plugin-api` — all pass.
- Full pre-commit suite (fmt + clippy + cargo test) — all pass.

Closes #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)