### PR TITLE
fix: UX polish — anon help, whoami room name, mesh transport label

### DIFF
--- a/crates/bbs-core/src/host.rs
+++ b/crates/bbs-core/src/host.rs
@@ -1171,24 +1171,28 @@ impl Host for BbsHost {
 
 impl BbsHost {
     async fn handle_whoami(&self, session: SessionId) -> Result<Response, HostError> {
-        let sessions = self.sessions.read().await;
-        let text = sessions
-            .get(&session)
-            .map(|r| {
-                r.username
-                    .as_ref()
-                    .map(|u| {
-                        format!(
-                            "Logged in as {} ({}). Current room: room:{}",
-                            u.as_str(),
-                            r.level,
-                            r.current_room.as_i64()
-                        )
-                    })
-                    .unwrap_or_else(|| "Not logged in.".into())
-            })
-            .unwrap_or_else(|| "Unknown session.".into());
-        Ok(Response::Text(text))
+        let (username, level, current_room) = {
+            let sessions = self.sessions.read().await;
+            match sessions.get(&session) {
+                None => return Ok(Response::Text("Unknown session.".into())),
+                Some(r) => match r.username.as_ref() {
+                    None => return Ok(Response::Text("Not logged in.".into())),
+                    Some(u) => (u.clone(), r.level, r.current_room),
+                },
+            }
+        };
+        let room_name = RoomStore::get_by_id(&self.db, current_room)
+            .await
+            .ok()
+            .flatten()
+            .map(|r| r.name.to_string())
+            .unwrap_or_else(|| format!("room:{}", current_room.as_i64()));
+        Ok(Response::Text(format!(
+            "Logged in as {} ({}). Current room: {}",
+            username.as_str(),
+            level,
+            room_name
+        )))
     }
 
     async fn handle_cancel(&self, session: SessionId) -> Result<Response, HostError> {
@@ -4464,9 +4468,7 @@ fn help_for_command(cmd: &str, level: Option<PermissionLevel>) -> String {
 
 const HELP_QUICK_ANON: &str = "\
 REGISTER <user>  create an account\n\
-LOGIN <user>     log in to your account\n\
-Q  quit\n\
-H  help";
+LOGIN <user>     log in to your account";
 
 // 156 bytes — must stay ≤ MAX_REPLY_BYTES (MAX_FRAME_SIZE(172) - 16 bytes overhead).
 const HELP_QUICK_LOGGED_IN: &str = "\

--- a/crates/bbs-mesh/src/transport.rs
+++ b/crates/bbs-mesh/src/transport.rs
@@ -121,7 +121,7 @@ impl Plugin for MeshTransport {
     type Config = MeshConfig;
 
     fn name(&self) -> &'static str {
-        "mesh"
+        "meshtastic"
     }
 
     fn version(&self) -> &'static str {
@@ -961,7 +961,7 @@ async fn dispatch_message(
                 .lock()
                 .expect("state mutex poisoned")
                 .remove_by_prefix(&sender_prefix);
-            let fresh = match host.create_session("mesh").await {
+            let fresh = match host.create_session("meshtastic").await {
                 Ok(id) => id,
                 Err(e) => {
                     warn!("mesh: session refresh failed: {e}");
@@ -1124,7 +1124,7 @@ async fn get_or_create_session(
     }
 
     // Slow path: mint a new session from the host.
-    let new_id = match host.create_session("mesh").await {
+    let new_id = match host.create_session("meshtastic").await {
         Ok(id) => id,
         Err(e) => {
             // This should not happen in normal operation; log and use a dummy.

--- a/crates/bbs-mesh/src/transport.rs
+++ b/crates/bbs-mesh/src/transport.rs
@@ -121,7 +121,7 @@ impl Plugin for MeshTransport {
     type Config = MeshConfig;
 
     fn name(&self) -> &'static str {
-        "meshtastic"
+        "meshcore"
     }
 
     fn version(&self) -> &'static str {
@@ -961,7 +961,7 @@ async fn dispatch_message(
                 .lock()
                 .expect("state mutex poisoned")
                 .remove_by_prefix(&sender_prefix);
-            let fresh = match host.create_session("meshtastic").await {
+            let fresh = match host.create_session("meshcore").await {
                 Ok(id) => id,
                 Err(e) => {
                     warn!("mesh: session refresh failed: {e}");
@@ -1124,7 +1124,7 @@ async fn get_or_create_session(
     }
 
     // Slow path: mint a new session from the host.
-    let new_id = match host.create_session("meshtastic").await {
+    let new_id = match host.create_session("meshcore").await {
         Ok(id) => id,
         Err(e) => {
             // This should not happen in normal operation; log and use a dummy.


### PR DESCRIPTION
## Summary

Three small UX fixes caught in manual testing:

- **Anon help text**: `H` when not logged in no longer lists `Q` (quit) and `H` (help) — both are circular/useless before authentication. Now only shows `REGISTER` and `LOGIN`.
- **WHOAMI room name**: Previously showed the internal ID as `room:1`. Now resolves to the actual room name (e.g. `Lobby`). Falls back to `room:<id>` only if the room can't be found.
- **MeshCore transport label**: The `bbs-mesh` plugin was registered under the name `"mesh"`, which appeared in the web admin Sessions table as "mesh". Changed to `"meshtastic"` to match the Meshtastic transport's label and be consistent in the UI.

## Test plan
- [ ] Register a new account — help text shown before login contains only `REGISTER` and `LOGIN`
- [ ] Log in, type `WHOAMI` — response shows room name (e.g. `Lobby`), not `room:1`
- [ ] MeshCore session appears in Sessions table as transport `meshtastic`
- [ ] All 120+ tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)