### PR TITLE
fix: decouple MAX_PAYLOAD_SIZE from MAX_FRAME_SIZE; raise to 256

### DIFF
--- a/crates/meshcore-companion/src/constants.rs
+++ b/crates/meshcore-companion/src/constants.rs
@@ -3,10 +3,25 @@ pub const FRAME_OUTBOUND_PREFIX: u8 = 0x3E;
 /// `<` — prefix byte on frames sent from the app to the radio bridge.
 pub const FRAME_INBOUND_PREFIX: u8 = 0x3C;
 
-/// Maximum total frame size (prefix + 2-byte length + payload).
+/// Maximum total frame size for frames we *send* (prefix + 2-byte length + payload).
+///
+/// Used by the transport layer to compute [`MAX_REPLY_BYTES`] so that outgoing
+/// `SendTxtMsg` frames fit within the radio bridge's expected frame size.
+///
+/// [`MAX_REPLY_BYTES`]: bbs_mesh::transport::MAX_REPLY_BYTES
 pub const MAX_FRAME_SIZE: usize = 172;
-/// Maximum payload size (MAX_FRAME_SIZE - 3).
-pub const MAX_PAYLOAD_SIZE: usize = MAX_FRAME_SIZE - 3;
+
+/// Maximum payload size for frames we *receive* from the radio bridge.
+///
+/// This is a sanity guard against a malformed length field causing a
+/// large allocation or memory-limit panic. It is intentionally larger
+/// than `MAX_FRAME_SIZE - 3` because the firmware can send structured
+/// response frames (contact lists, advert records, etc.) whose payload
+/// exceeds the outgoing text-message limit.
+///
+/// Setting this to 256 covers every valid MeshCore companion-protocol
+/// frame while still catching obviously corrupt length values.
+pub const MAX_PAYLOAD_SIZE: usize = 256;
 
 pub const PUB_KEY_SIZE: usize = 32;
 pub const MAX_PATH_SIZE: usize = 64;

--- a/crates/meshcore-companion/src/error.rs
+++ b/crates/meshcore-companion/src/error.rs
@@ -4,7 +4,7 @@ pub enum FrameDecodeError {
     #[error("wrong frame prefix: expected 0x{expected:02X}, got 0x{got:02X}")]
     WrongPrefix { expected: u8, got: u8 },
 
-    #[error("frame payload length {0} exceeds MAX_PAYLOAD_SIZE (169)")]
+    #[error("frame payload length {0} exceeds MAX_PAYLOAD_SIZE")]
     PayloadTooLarge(usize),
 
     #[error("frame type 0x{type_byte:02X} body too short: need ≥{needed} bytes, got {got}")]

--- a/crates/meshcore-companion/tests/codec.rs
+++ b/crates/meshcore-companion/tests/codec.rs
@@ -53,11 +53,12 @@ fn strip_header_empty_rejects() {
 
 #[test]
 fn strip_header_payload_too_large() {
-    // Claim 200 bytes (> MAX_PAYLOAD_SIZE = 169).
-    let mut raw = vec![FRAME_OUTBOUND_PREFIX, 200u8, 0u8];
-    raw.extend(vec![0u8; 200]);
+    // Claim 300 bytes (> MAX_PAYLOAD_SIZE = 256). Use little-endian u16.
+    let len: u16 = 300;
+    let mut raw = vec![FRAME_OUTBOUND_PREFIX, (len & 0xFF) as u8, (len >> 8) as u8];
+    raw.extend(vec![0u8; 300]);
     let err = strip_frame_header(&raw).unwrap_err();
-    assert_eq!(err, FrameDecodeError::PayloadTooLarge(200));
+    assert_eq!(err, FrameDecodeError::PayloadTooLarge(300));
 }
 
 // ── decode_inbound — zero-body frames ─────────────────────────────────────────


### PR DESCRIPTION
## Summary

Fixes the recurring error:
```
companion/serial: session error: companion: payload length 170 exceeds MAX_PAYLOAD_SIZE (169)
```

**Root cause:** `MAX_PAYLOAD_SIZE` was derived as `MAX_FRAME_SIZE - 3 = 169`. But `MAX_FRAME_SIZE` governs the size of text-message frames we *send* — it has nothing to do with the size of structured response frames the radio *sends to us* (contact records, advert data, etc.), which can be 170+ bytes.

**Fix:** Decouple the two constants so each has a clear, single purpose:

| Constant | Value | Purpose |
|---|---|---|
| `MAX_FRAME_SIZE` | 172 | Max total size of frames we **send** (unchanged — `MAX_REPLY_BYTES` and outgoing truncation unaffected) |
| `MAX_PAYLOAD_SIZE` | 256 | Sanity guard on frames we **receive** — large enough for all valid MeshCore protocol frames, still catches corrupt length fields |

Also removes the hardcoded `169` from the `PayloadTooLarge` error string and updates the codec test to use 300 (> 256) to properly exercise the guard.

## Test plan
- [ ] All tests pass
- [ ] `payload length 170 exceeds MAX_PAYLOAD_SIZE` error no longer appears in logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)