### PR TITLE
fix(setup): move BBS identity to top of wizard, before transport config

### DIFF
--- a/src/setup.rs
+++ b/src/setup.rs
@@ -386,6 +386,31 @@ pub fn run_wizard(config_out: Option<&Path>) {
 
     let ex = load_existing(&out_path);
 
+    // ── BBS identity ──────────────────────────────────────────────────────────
+    //
+    // Collected first so it is clear there is exactly one BBS instance.
+    // All radio transports (MeshCore, Meshtastic, …) configured below are
+    // simply different ways to reach the same BBS — they do not have
+    // separate identities.
+    section("BBS identity");
+
+    let bbs_name: String = Input::with_theme(&theme)
+        .with_prompt("BBS name")
+        .default(ex.bbs_name.clone())
+        .interact_text()
+        .unwrap_or_else(|_| cancelled());
+
+    // ── Data storage ──────────────────────────────────────────────────────────
+    section("Data storage");
+
+    let data_dir_str: String = Input::with_theme(&theme)
+        .with_prompt("Data directory")
+        .default(ex.data_dir.clone())
+        .interact_text()
+        .unwrap_or_else(|_| cancelled());
+
+    let data_dir = PathBuf::from(&data_dir_str);
+
     // ── Protocol selection ────────────────────────────────────────────────────
     //
     // Which protocols appear here is determined by compiled-in features:
@@ -715,26 +740,6 @@ pub fn run_wizard(config_out: Option<&Path>) {
         meshtastic_baud_rate = None;
         meshtastic_addr = None;
     }
-
-    // ── BBS identity ──────────────────────────────────────────────────────────
-    section("BBS identity");
-
-    let bbs_name: String = Input::with_theme(&theme)
-        .with_prompt("BBS name")
-        .default(ex.bbs_name.clone())
-        .interact_text()
-        .unwrap_or_else(|_| cancelled());
-
-    // ── Data storage ──────────────────────────────────────────────────────────
-    section("Data storage");
-
-    let data_dir_str: String = Input::with_theme(&theme)
-        .with_prompt("Data directory")
-        .default(ex.data_dir.clone())
-        .interact_text()
-        .unwrap_or_else(|_| cancelled());
-
-    let data_dir = PathBuf::from(&data_dir_str);
 
     // ── Web admin ─────────────────────────────────────────────────────────────
     section("Web admin UI");


### PR DESCRIPTION
## Problem

The setup wizard asked for BBS name and data directory *after* the Meshtastic connection section. This made it appear as if each transport was a separate BBS instance being configured.

## Fix

Reordered the wizard sections so BBS identity and data storage come first:

**Before:** protocols → MeshCore → Meshtastic → **BBS identity** → **data storage** → web → GPS → write

**After:** **BBS identity** → **data storage** → protocols → MeshCore → Meshtastic → web → GPS → write

Added a comment clarifying that all transports connect to the same BBS instance. Pre-existing issue — not introduced by any recent radio config changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)