### PR TITLE
fix(setup): add Meshtastic radio parameters section to setup wizard

### DIFF
--- a/crates/bbs-meshtastic/src/lib.rs
+++ b/crates/bbs-meshtastic/src/lib.rs
@@ -57,6 +57,30 @@ pub enum MeshtasticConnectionType {
 
 // ── Config ────────────────────────────────────────────────────────────────────
 
+/// Radio parameter configuration stored in `[plugins.meshtastic.radio]`.
+///
+/// These values are **not** pushed to the device automatically on connect.
+/// Apply them on demand via the web admin UI (Settings → Meshtastic radio)
+/// or `supply-drop-bbs node set-meshtastic-radio` once that command is added.
+/// Once applied the device persists the settings in its own flash.
+#[derive(Debug, Clone, Default, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct MeshtasticRadioConfig {
+    /// Meshtastic region code (e.g. `"US"`, `"EU_868"`, `"ANZ"`).
+    ///
+    /// Sets the legal frequency range for the device.  See the Meshtastic
+    /// documentation for the full list of region codes.
+    #[serde(default)]
+    pub region: Option<String>,
+
+    /// Meshtastic modem preset (e.g. `"LONG_FAST"`, `"MEDIUM_SLOW"`).
+    ///
+    /// Predefined LoRa parameter profiles.  `"LONG_FAST"` is the Meshtastic
+    /// default and works well for most outdoor deployments.
+    #[serde(default)]
+    pub modem_preset: Option<String>,
+}
+
 /// Configuration for the Meshtastic transport (`[plugins.meshtastic]`).
 #[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
@@ -112,6 +136,21 @@ pub struct MeshtasticConfig {
     /// Maximum reconnect delay after repeated failures.
     #[serde(default = "default_reconnect_delay_max_ms")]
     pub reconnect_delay_max_ms: u64,
+
+    /// Radio parameter configuration.
+    ///
+    /// Stored here for reference and applied on demand via the web admin UI
+    /// (Settings → Meshtastic radio).  **Not** pushed automatically on every
+    /// connect — the device persists radio settings in its own flash.
+    ///
+    /// Example:
+    /// ```toml
+    /// [plugins.meshtastic.radio]
+    /// region       = "US"
+    /// modem_preset = "LONG_FAST"
+    /// ```
+    #[serde(default)]
+    pub radio: Option<MeshtasticRadioConfig>,
 }
 
 impl Default for MeshtasticConfig {
@@ -130,6 +169,7 @@ impl Default for MeshtasticConfig {
             want_ack: default_want_ack(),
             reconnect_delay_initial_ms: default_reconnect_delay_initial_ms(),
             reconnect_delay_max_ms: default_reconnect_delay_max_ms(),
+            radio: None,
         }
     }
 }

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -41,6 +41,8 @@ struct Existing {
     meshtastic_connection_type: String,
     meshtastic_serial_port: Option<String>,
     meshtastic_baud_rate: u32,
+    meshtastic_radio_region: Option<String>,
+    meshtastic_radio_preset: Option<String>,
     // Web
     web_enabled: bool,
     web_bind: String,
@@ -136,6 +138,16 @@ fn load_existing(out_path: &Path) -> Existing {
         .and_then(|v| v.as_integer())
         .map(|v| v as u32)
         .unwrap_or(115_200);
+    let meshtastic_radio_region = meshtastic
+        .and_then(|m| m.get("radio"))
+        .and_then(|r| r.get("region"))
+        .and_then(|v| v.as_str())
+        .map(str::to_owned);
+    let meshtastic_radio_preset = meshtastic
+        .and_then(|m| m.get("radio"))
+        .and_then(|r| r.get("modem_preset"))
+        .and_then(|v| v.as_str())
+        .map(str::to_owned);
 
     // Web
     let web_enabled = web
@@ -234,6 +246,8 @@ fn load_existing(out_path: &Path) -> Existing {
         meshtastic_connection_type,
         meshtastic_serial_port,
         meshtastic_baud_rate,
+        meshtastic_radio_region,
+        meshtastic_radio_preset,
         web_enabled,
         web_bind,
         web_backup_dir,
@@ -735,6 +749,107 @@ pub fn run_wizard(config_out: Option<&Path>) {
         .unwrap_or_else(|_| cancelled());
 
     let data_dir = PathBuf::from(&data_dir_str);
+    // ── Meshtastic radio parameters ───────────────────────────────────────────
+
+    /// (code, display label)
+    const MESHTASTIC_REGIONS: &[(&str, &str)] = &[
+        ("US", "United States"),
+        ("EU_433", "Europe 433 MHz"),
+        ("EU_868", "Europe 868 MHz"),
+        ("ANZ", "Australia / New Zealand"),
+        ("JP", "Japan"),
+        ("CN", "China"),
+        ("KR", "South Korea"),
+        ("TW", "Taiwan"),
+        ("RU", "Russia"),
+        ("IN", "India"),
+        ("NZ_865", "New Zealand 865 MHz"),
+        ("TH", "Thailand"),
+        ("LORA_24", "2.4 GHz LoRa"),
+        ("UA_433", "Ukraine 433 MHz"),
+        ("UA_868", "Ukraine 868 MHz"),
+        ("MY_433", "Malaysia 433 MHz"),
+        ("MY_919", "Malaysia 919 MHz"),
+        ("SG_923", "Singapore 923 MHz"),
+    ];
+
+    /// (code, display label)
+    const MESHTASTIC_PRESETS: &[(&str, &str)] = &[
+        (
+            "LONG_FAST",
+            "Long range, fast      (default — good starting point)",
+        ),
+        ("LONG_MODERATE", "Long range, moderate"),
+        ("MEDIUM_SLOW", "Medium range, slow"),
+        ("MEDIUM_FAST", "Medium range, fast"),
+        ("SHORT_SLOW", "Short range, slow"),
+        ("SHORT_FAST", "Short range, fast"),
+        ("LONG_SLOW", "Long range, slow      (very slow data rate)"),
+        (
+            "MAX_RANGE",
+            "Maximum range         (extremely slow data rate)",
+        ),
+        ("SHORT_TURBO", "Short range, turbo    (high data rate)"),
+    ];
+
+    let (meshtastic_radio_region, meshtastic_radio_preset): (Option<String>, Option<String>) =
+        if use_meshtastic {
+            section("Meshtastic radio parameters");
+
+            println!("Select the region and modem preset for your Meshtastic device.");
+            println!("These are saved to config.toml and can be pushed to the device");
+            println!("at any time via the web admin (Settings → Meshtastic radio).");
+            println!("Skip if the device is already configured correctly.");
+            println!();
+
+            let configure = Confirm::with_theme(&theme)
+                .with_prompt("Configure Meshtastic radio parameters now?")
+                .default(ex.meshtastic_radio_region.is_some())
+                .interact()
+                .unwrap_or_else(|_| cancelled());
+
+            if configure {
+                let region_labels: Vec<String> = MESHTASTIC_REGIONS
+                    .iter()
+                    .map(|(code, name)| format!("{code:<10} {name}"))
+                    .collect();
+                let default_region = ex
+                    .meshtastic_radio_region
+                    .as_deref()
+                    .and_then(|r| MESHTASTIC_REGIONS.iter().position(|(c, _)| *c == r))
+                    .unwrap_or(0); // US
+                let region_choice =
+                    prompt_select(&theme, "Select your region", &region_labels, default_region);
+                let region = MESHTASTIC_REGIONS[region_choice].0.to_owned();
+
+                println!();
+                let preset_labels: Vec<String> = MESHTASTIC_PRESETS
+                    .iter()
+                    .map(|(_, d)| d.to_string())
+                    .collect();
+                let default_preset = ex
+                    .meshtastic_radio_preset
+                    .as_deref()
+                    .and_then(|p| MESHTASTIC_PRESETS.iter().position(|(c, _)| *c == p))
+                    .unwrap_or(0); // LONG_FAST
+                let preset_choice = prompt_select(
+                    &theme,
+                    "Select modem preset",
+                    &preset_labels,
+                    default_preset,
+                );
+                let preset = MESHTASTIC_PRESETS[preset_choice].0.to_owned();
+
+                (Some(region), Some(preset))
+            } else {
+                (
+                    ex.meshtastic_radio_region.clone(),
+                    ex.meshtastic_radio_preset.clone(),
+                )
+            }
+        } else {
+            (None, None)
+        };
 
     // ── Web admin ─────────────────────────────────────────────────────────────
     section("Web admin UI");
@@ -872,6 +987,8 @@ pub fn run_wizard(config_out: Option<&Path>) {
         meshtastic_serial_port: meshtastic_serial_port.as_deref(),
         meshtastic_baud_rate,
         meshtastic_addr: meshtastic_addr.as_deref(),
+        meshtastic_radio_region: meshtastic_radio_region.as_deref(),
+        meshtastic_radio_preset: meshtastic_radio_preset.as_deref(),
         web_enabled,
         web_bind: web_bind.as_deref(),
         web_backup_dir: web_backup_dir.as_deref(),
@@ -1515,6 +1632,8 @@ struct TomlParams<'a> {
     meshtastic_serial_port: Option<&'a str>,
     meshtastic_baud_rate: Option<u32>,
     meshtastic_addr: Option<&'a str>,
+    meshtastic_radio_region: Option<&'a str>,
+    meshtastic_radio_preset: Option<&'a str>,
     // Web
     web_enabled: bool,
     web_bind: Option<&'a str>,
@@ -1650,6 +1769,20 @@ fn build_toml(p: &TomlParams<'_>) -> String {
             }
         }
     }
+    // [plugins.meshtastic.radio] — only when Meshtastic is enabled and params chosen
+    #[cfg(feature = "transport-meshtastic")]
+    if p.use_meshtastic
+        && (p.meshtastic_radio_region.is_some() || p.meshtastic_radio_preset.is_some())
+    {
+        writeln!(s, "\n[plugins.meshtastic.radio]").unwrap();
+        if let Some(region) = p.meshtastic_radio_region {
+            writeln!(s, "region       = {}", toml_str(region)).unwrap();
+        }
+        if let Some(preset) = p.meshtastic_radio_preset {
+            writeln!(s, "modem_preset = {}", toml_str(preset)).unwrap();
+        }
+    }
+
     // Suppress unused-variable warnings when feature is off.
     #[cfg(not(feature = "transport-meshtastic"))]
     {
@@ -1659,6 +1792,8 @@ fn build_toml(p: &TomlParams<'_>) -> String {
             p.meshtastic_serial_port,
             p.meshtastic_baud_rate,
             p.meshtastic_addr,
+            p.meshtastic_radio_region,
+            p.meshtastic_radio_preset,
         );
     }
 


### PR DESCRIPTION
## Problem

After selecting a Meshtastic device in the setup wizard, the user was never prompted for radio parameters (region, modem preset). The wizard went straight from connection type / serial port to Web admin UI. MeshCore gets a full radio parameters section; Meshtastic got nothing.

## Changes

- **`MeshtasticConfig`**: added `MeshtasticRadioConfig` struct with `region` and `modem_preset` fields, stored under `[plugins.meshtastic.radio]` in config.toml
- **Setup wizard**: new "Meshtastic radio parameters" section after the connection config — 18 region codes + 9 modem presets, skippable for already-configured devices
- Re-running setup pre-fills existing values as defaults
- `build_toml()` writes `[plugins.meshtastic.radio]` when params are chosen

## New config.toml output (when configured)

```toml
[plugins.meshtastic.radio]
region       = "US"
modem_preset = "LONG_FAST"
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)