### PR TITLE
feat(meshtastic): device config — owner info, security/PKC key, UI clarity

### DIFF
--- a/crates/bbs-core/src/host.rs
+++ b/crates/bbs-core/src/host.rs
@@ -688,6 +688,96 @@ impl Host for BbsHost {
             .map_err(bbs_plugin_api::HostError::Internal)
     }
 
+    async fn admin_get_meshtastic_owner(
+        &self,
+    ) -> Result<bbs_plugin_api::MeshtasticOwnerInfo, bbs_plugin_api::HostError> {
+        let tx = self
+            .meshtastic_admin_tx
+            .read()
+            .expect("meshtastic_admin_tx poisoned")
+            .clone()
+            .ok_or_else(|| {
+                bbs_plugin_api::HostError::Internal("meshtastic transport not connected".into())
+            })?;
+        let (reply_tx, reply_rx) = tokio::sync::oneshot::channel();
+        tx.send(bbs_plugin_api::MeshtasticAdminRequest::GetOwner { reply: reply_tx })
+            .await
+            .map_err(|_| {
+                bbs_plugin_api::HostError::Internal("meshtastic transport disconnected".into())
+            })?;
+        tokio::time::timeout(std::time::Duration::from_secs(10), reply_rx)
+            .await
+            .map_err(|_| {
+                bbs_plugin_api::HostError::Internal("meshtastic owner get timed out".into())
+            })?
+            .map_err(|_| {
+                bbs_plugin_api::HostError::Internal("meshtastic owner get cancelled".into())
+            })?
+            .map_err(bbs_plugin_api::HostError::Internal)
+    }
+
+    async fn admin_set_meshtastic_owner(
+        &self,
+        long_name: Option<String>,
+        short_name: Option<String>,
+    ) -> Result<(), bbs_plugin_api::HostError> {
+        let tx = self
+            .meshtastic_admin_tx
+            .read()
+            .expect("meshtastic_admin_tx poisoned")
+            .clone()
+            .ok_or_else(|| {
+                bbs_plugin_api::HostError::Internal("meshtastic transport not connected".into())
+            })?;
+        let (reply_tx, reply_rx) = tokio::sync::oneshot::channel();
+        tx.send(bbs_plugin_api::MeshtasticAdminRequest::SetOwner {
+            long_name,
+            short_name,
+            reply: reply_tx,
+        })
+        .await
+        .map_err(|_| {
+            bbs_plugin_api::HostError::Internal("meshtastic transport disconnected".into())
+        })?;
+        tokio::time::timeout(std::time::Duration::from_secs(10), reply_rx)
+            .await
+            .map_err(|_| {
+                bbs_plugin_api::HostError::Internal("meshtastic owner set timed out".into())
+            })?
+            .map_err(|_| {
+                bbs_plugin_api::HostError::Internal("meshtastic owner set cancelled".into())
+            })?
+            .map_err(bbs_plugin_api::HostError::Internal)
+    }
+
+    async fn admin_get_meshtastic_security(
+        &self,
+    ) -> Result<bbs_plugin_api::MeshtasticSecurityInfo, bbs_plugin_api::HostError> {
+        let tx = self
+            .meshtastic_admin_tx
+            .read()
+            .expect("meshtastic_admin_tx poisoned")
+            .clone()
+            .ok_or_else(|| {
+                bbs_plugin_api::HostError::Internal("meshtastic transport not connected".into())
+            })?;
+        let (reply_tx, reply_rx) = tokio::sync::oneshot::channel();
+        tx.send(bbs_plugin_api::MeshtasticAdminRequest::GetSecurity { reply: reply_tx })
+            .await
+            .map_err(|_| {
+                bbs_plugin_api::HostError::Internal("meshtastic transport disconnected".into())
+            })?;
+        tokio::time::timeout(std::time::Duration::from_secs(10), reply_rx)
+            .await
+            .map_err(|_| {
+                bbs_plugin_api::HostError::Internal("meshtastic security get timed out".into())
+            })?
+            .map_err(|_| {
+                bbs_plugin_api::HostError::Internal("meshtastic security get cancelled".into())
+            })?
+            .map_err(bbs_plugin_api::HostError::Internal)
+    }
+
     // ── Admin / web-UI operations ─────────────────────────────────────────────
 
     async fn admin_verify_credentials(

--- a/crates/bbs-core/src/host.rs
+++ b/crates/bbs-core/src/host.rs
@@ -218,6 +218,11 @@ pub struct BbsHost {
     /// None when the mesh transport has not registered itself.
     mesh_key_tx:
         std::sync::RwLock<Option<tokio::sync::mpsc::Sender<bbs_plugin_api::MeshKeyRequest>>>,
+    /// Sending half of the Meshtastic admin channel.
+    /// None when the Meshtastic transport has not registered itself.
+    meshtastic_admin_tx: std::sync::RwLock<
+        Option<tokio::sync::mpsc::Sender<bbs_plugin_api::MeshtasticAdminRequest>>,
+    >,
 }
 
 impl BbsHost {
@@ -255,6 +260,7 @@ impl BbsHost {
             config_path,
             node_pubkey: std::sync::RwLock::new(None),
             mesh_key_tx: std::sync::RwLock::new(None),
+            meshtastic_admin_tx: std::sync::RwLock::new(None),
         }
     }
 
@@ -583,6 +589,102 @@ impl Host for BbsHost {
         reply_rx
             .await
             .map_err(|_| bbs_plugin_api::HostError::Internal("key op cancelled".into()))?
+            .map_err(bbs_plugin_api::HostError::Internal)
+    }
+
+    async fn admin_apply_mesh_radio(
+        &self,
+        params: bbs_plugin_api::MeshRadioParams,
+    ) -> Result<(), bbs_plugin_api::HostError> {
+        let tx = self
+            .mesh_key_tx
+            .read()
+            .expect("mesh_key_tx poisoned")
+            .clone()
+            .ok_or_else(|| {
+                bbs_plugin_api::HostError::Internal("mesh transport not connected".into())
+            })?;
+        let (reply_tx, reply_rx) = tokio::sync::oneshot::channel();
+        tx.send(bbs_plugin_api::MeshKeyRequest::ApplyRadio {
+            params,
+            reply: reply_tx,
+        })
+        .await
+        .map_err(|_| bbs_plugin_api::HostError::Internal("mesh transport disconnected".into()))?;
+        tokio::time::timeout(std::time::Duration::from_secs(10), reply_rx)
+            .await
+            .map_err(|_| bbs_plugin_api::HostError::Internal("radio apply timed out".into()))?
+            .map_err(|_| bbs_plugin_api::HostError::Internal("radio apply cancelled".into()))?
+            .map_err(bbs_plugin_api::HostError::Internal)
+    }
+
+    fn register_meshtastic_admin_ops(
+        &self,
+        sender: tokio::sync::mpsc::Sender<bbs_plugin_api::MeshtasticAdminRequest>,
+    ) {
+        *self
+            .meshtastic_admin_tx
+            .write()
+            .expect("meshtastic_admin_tx poisoned") = Some(sender);
+    }
+
+    async fn admin_get_meshtastic_lora(
+        &self,
+    ) -> Result<bbs_plugin_api::MeshtasticLoRaConfig, bbs_plugin_api::HostError> {
+        let tx = self
+            .meshtastic_admin_tx
+            .read()
+            .expect("meshtastic_admin_tx poisoned")
+            .clone()
+            .ok_or_else(|| {
+                bbs_plugin_api::HostError::Internal("meshtastic transport not connected".into())
+            })?;
+        let (reply_tx, reply_rx) = tokio::sync::oneshot::channel();
+        tx.send(bbs_plugin_api::MeshtasticAdminRequest::GetLoRaConfig { reply: reply_tx })
+            .await
+            .map_err(|_| {
+                bbs_plugin_api::HostError::Internal("meshtastic transport disconnected".into())
+            })?;
+        tokio::time::timeout(std::time::Duration::from_secs(10), reply_rx)
+            .await
+            .map_err(|_| {
+                bbs_plugin_api::HostError::Internal("meshtastic lora get timed out".into())
+            })?
+            .map_err(|_| {
+                bbs_plugin_api::HostError::Internal("meshtastic lora get cancelled".into())
+            })?
+            .map_err(bbs_plugin_api::HostError::Internal)
+    }
+
+    async fn admin_set_meshtastic_lora(
+        &self,
+        config: bbs_plugin_api::MeshtasticLoRaConfig,
+    ) -> Result<(), bbs_plugin_api::HostError> {
+        let tx = self
+            .meshtastic_admin_tx
+            .read()
+            .expect("meshtastic_admin_tx poisoned")
+            .clone()
+            .ok_or_else(|| {
+                bbs_plugin_api::HostError::Internal("meshtastic transport not connected".into())
+            })?;
+        let (reply_tx, reply_rx) = tokio::sync::oneshot::channel();
+        tx.send(bbs_plugin_api::MeshtasticAdminRequest::SetLoRaConfig {
+            config,
+            reply: reply_tx,
+        })
+        .await
+        .map_err(|_| {
+            bbs_plugin_api::HostError::Internal("meshtastic transport disconnected".into())
+        })?;
+        tokio::time::timeout(std::time::Duration::from_secs(10), reply_rx)
+            .await
+            .map_err(|_| {
+                bbs_plugin_api::HostError::Internal("meshtastic lora set timed out".into())
+            })?
+            .map_err(|_| {
+                bbs_plugin_api::HostError::Internal("meshtastic lora set cancelled".into())
+            })?
             .map_err(bbs_plugin_api::HostError::Internal)
     }
 

--- a/crates/bbs-mesh/src/transport.rs
+++ b/crates/bbs-mesh/src/transport.rs
@@ -484,6 +484,13 @@ enum PendingKeyOp {
     Import {
         reply: tokio::sync::oneshot::Sender<Result<(), String>>,
     },
+    ApplyRadio {
+        reply: tokio::sync::oneshot::Sender<Result<(), String>>,
+        /// true = waiting for SetRadioParams Ok; false = waiting for SetRadioTxPower Ok
+        waiting_for_params: bool,
+        /// tx_power to send after params Ok arrives
+        tx_power_dbm: i8,
+    },
 }
 
 /// Background task: receive [`ClientEvent`]s and dispatch them.
@@ -597,6 +604,7 @@ async fn event_loop(
                             match op {
                                 PendingKeyOp::Export { reply } => { let _ = reply.send(Err(err)); }
                                 PendingKeyOp::Import { reply } => { let _ = reply.send(Err(err)); }
+                                PendingKeyOp::ApplyRadio { reply, .. } => { let _ = reply.send(Err(err)); }
                             }
                         }
                         if will_retry {
@@ -620,11 +628,30 @@ async fn event_loop(
                                 }
                             }
                             InboundFrame::Ok => {
-                                if let Some(PendingKeyOp::Import { reply }) = pending_key_op.take() {
-                                    let _ = reply.send(Ok(()));
-                                    true
-                                } else {
-                                    false
+                                match pending_key_op.take() {
+                                    Some(PendingKeyOp::Import { reply }) => {
+                                        let _ = reply.send(Ok(()));
+                                        true
+                                    }
+                                    Some(PendingKeyOp::ApplyRadio { reply, waiting_for_params: true, tx_power_dbm }) => {
+                                        // Params acknowledged — now send TX power
+                                        let _ = cmd_tx.send(OutboundFrame::SetRadioTxPower { power_dbm: tx_power_dbm }).await;
+                                        pending_key_op = Some(PendingKeyOp::ApplyRadio {
+                                            reply,
+                                            waiting_for_params: false,
+                                            tx_power_dbm,
+                                        });
+                                        true
+                                    }
+                                    Some(PendingKeyOp::ApplyRadio { reply, waiting_for_params: false, .. }) => {
+                                        // TX power acknowledged — done
+                                        let _ = reply.send(Ok(()));
+                                        true
+                                    }
+                                    other => {
+                                        pending_key_op = other;
+                                        false
+                                    }
                                 }
                             }
                             // Device returned an error frame while a key op was in
@@ -635,6 +662,7 @@ async fn event_loop(
                                     match op {
                                         PendingKeyOp::Export { reply } => { let _ = reply.send(Err(msg)); }
                                         PendingKeyOp::Import { reply } => { let _ = reply.send(Err(msg)); }
+                                        PendingKeyOp::ApplyRadio { reply, .. } => { let _ = reply.send(Err(msg)); }
                                     }
                                     true
                                 } else {
@@ -666,6 +694,23 @@ async fn event_loop(
                         } else {
                             let _ = cmd_tx.send(OutboundFrame::ImportPrivateKey { key }).await;
                             pending_key_op = Some(PendingKeyOp::Import { reply });
+                        }
+                    }
+                    MeshKeyRequest::ApplyRadio { params, reply } => {
+                        if pending_key_op.is_some() {
+                            let _ = reply.send(Err("another device operation is already in progress".into()));
+                        } else {
+                            let _ = cmd_tx.send(OutboundFrame::SetRadioParams {
+                                frequency_hz: params.frequency_hz,
+                                bandwidth_hz: params.bandwidth_hz,
+                                spreading_factor: params.spreading_factor,
+                                coding_rate: params.coding_rate,
+                            }).await;
+                            pending_key_op = Some(PendingKeyOp::ApplyRadio {
+                                reply,
+                                waiting_for_params: true,
+                                tx_power_dbm: params.tx_power_dbm,
+                            });
                         }
                     }
                 }

--- a/crates/bbs-meshtastic/src/lib.rs
+++ b/crates/bbs-meshtastic/src/lib.rs
@@ -33,10 +33,11 @@ use bbs_plugin_api::MeshtasticAdminRequest;
 use crate::{
     command::{format_response, parse_command, render_notification, truncate_utf8},
     proto::{
-        admin_get_lora_config, admin_message, admin_set_lora_config, direct_text_packet,
-        from_radio, mesh_packet, mt_config, node_key, synthetic_pubkey, AdminMessage, Data,
-        LoRaConfig, MeshPacket, MtConfig, NodeInfo, BROADCAST_ADDR, PORT_ADMIN_APP,
-        PORT_NODEINFO_APP, PORT_TEXT_MESSAGE_APP,
+        admin_get_lora_config, admin_get_owner, admin_get_security_config, admin_message,
+        admin_set_lora_config, admin_set_owner, direct_text_packet, from_radio, mesh_packet,
+        mt_config, node_key, synthetic_pubkey, AdminMessage, Data, LoRaConfig, MeshPacket,
+        MtConfig, NodeInfo, User, BROADCAST_ADDR, PORT_ADMIN_APP, PORT_NODEINFO_APP,
+        PORT_TEXT_MESSAGE_APP,
     },
     session::SessionState,
     stream::{ClientEvent, MeshtasticClient, SerialConfig, TcpConfig},
@@ -155,6 +156,21 @@ pub struct MeshtasticConfig {
     /// ```
     #[serde(default)]
     pub radio: Option<MeshtasticRadioConfig>,
+
+    /// Short node name shown on OLED maps and mesh UIs (≤ 4 chars).
+    ///
+    /// Stored here for reference.  Push to the device via the web admin UI
+    /// (Settings → Meshtastic device → Node name → Save to device) or by
+    /// running `supply-drop-bbs node set-meshtastic-owner` once that CLI
+    /// command is available.
+    #[serde(default)]
+    pub short_name: Option<String>,
+
+    /// Full node display name shown in Meshtastic apps.
+    ///
+    /// Stored alongside `short_name`; applied on demand via the web admin UI.
+    #[serde(default)]
+    pub long_name: Option<String>,
 }
 
 impl Default for MeshtasticConfig {
@@ -174,6 +190,8 @@ impl Default for MeshtasticConfig {
             reconnect_delay_initial_ms: default_reconnect_delay_initial_ms(),
             reconnect_delay_max_ms: default_reconnect_delay_max_ms(),
             radio: None,
+            short_name: None,
+            long_name: None,
         }
     }
 }
@@ -458,6 +476,18 @@ enum PendingMeshtasticAdmin {
         request_id: u32,
         reply: tokio::sync::oneshot::Sender<Result<(), String>>,
     },
+    GetOwner {
+        request_id: u32,
+        reply: tokio::sync::oneshot::Sender<Result<bbs_plugin_api::MeshtasticOwnerInfo, String>>,
+    },
+    SetOwner {
+        request_id: u32,
+        reply: tokio::sync::oneshot::Sender<Result<(), String>>,
+    },
+    GetSecurity {
+        request_id: u32,
+        reply: tokio::sync::oneshot::Sender<Result<bbs_plugin_api::MeshtasticSecurityInfo, String>>,
+    },
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -477,6 +507,9 @@ async fn event_loop(
     mut admin_rx: mpsc::Receiver<MeshtasticAdminRequest>,
 ) {
     let mut pending_admin: Option<PendingMeshtasticAdmin> = None;
+    // Session passkey received from the last GET response; echo it back in SET
+    // commands as a replay-attack guard (Meshtastic 2.5+, field 101).
+    let mut last_session_passkey: Vec<u8> = Vec::new();
 
     loop {
         tokio::select! {
@@ -491,6 +524,9 @@ async fn event_loop(
                         match op {
                             PendingMeshtasticAdmin::GetLora { reply, .. } => { let _ = reply.send(Err(err)); }
                             PendingMeshtasticAdmin::SetLora { reply, .. } => { let _ = reply.send(Err(err)); }
+                            PendingMeshtasticAdmin::GetOwner { reply, .. } => { let _ = reply.send(Err(err)); }
+                            PendingMeshtasticAdmin::SetOwner { reply, .. } => { let _ = reply.send(Err(err)); }
+                            PendingMeshtasticAdmin::GetSecurity { reply, .. } => { let _ = reply.send(Err(err)); }
                         }
                     }
                     if will_retry {
@@ -502,7 +538,11 @@ async fn event_loop(
                 }
                 Some(ClientEvent::FromRadio(msg)) => {
                     // Check if this is an admin response packet before general dispatch.
-                    let consumed = try_handle_admin_response(&msg, &mut pending_admin);
+                    let consumed = try_handle_admin_response(
+                        &msg,
+                        &mut pending_admin,
+                        &mut last_session_passkey,
+                    );
                     if !consumed {
                         handle_from_radio(
                             msg,
@@ -516,7 +556,8 @@ async fn event_loop(
                             hop_limit,
                             want_ack,
                             &packet_counter,
-                        ).await;
+                        )
+                        .await;
                     }
                 }
                 None => break,
@@ -524,38 +565,46 @@ async fn event_loop(
             Some(req) = admin_rx.recv() => {
                 let my_node_num = state.lock().expect("state mutex poisoned").my_node_num;
                 let Some(my_node_num) = my_node_num else {
-                    match req {
-                        MeshtasticAdminRequest::GetLoRaConfig { reply } => {
-                            let _ = reply.send(Err("node num not yet received from radio".into()));
-                        }
-                        MeshtasticAdminRequest::SetLoRaConfig { reply, .. } => {
-                            let _ = reply.send(Err("node num not yet received from radio".into()));
+                    // Node number not yet received — reject all admin requests.
+                    fn reject_no_num(req: MeshtasticAdminRequest) {
+                        let e = "node num not yet received from radio".to_owned();
+                        match req {
+                            MeshtasticAdminRequest::GetLoRaConfig { reply } => { let _ = reply.send(Err(e)); }
+                            MeshtasticAdminRequest::SetLoRaConfig { reply, .. } => { let _ = reply.send(Err(e)); }
+                            MeshtasticAdminRequest::GetOwner { reply } => { let _ = reply.send(Err(e)); }
+                            MeshtasticAdminRequest::SetOwner { reply, .. } => { let _ = reply.send(Err(e)); }
+                            MeshtasticAdminRequest::GetSecurity { reply } => { let _ = reply.send(Err(e)); }
                         }
                     }
+                    reject_no_num(req);
                     continue;
                 };
                 if pending_admin.is_some() {
-                    match req {
-                        MeshtasticAdminRequest::GetLoRaConfig { reply } => {
-                            let _ = reply.send(Err("another admin operation is already in progress".into()));
-                        }
-                        MeshtasticAdminRequest::SetLoRaConfig { reply, .. } => {
-                            let _ = reply.send(Err("another admin operation is already in progress".into()));
+                    // Another admin operation is in flight — reject immediately.
+                    fn reject_busy(req: MeshtasticAdminRequest) {
+                        let e = "another admin operation is already in progress".to_owned();
+                        match req {
+                            MeshtasticAdminRequest::GetLoRaConfig { reply } => { let _ = reply.send(Err(e)); }
+                            MeshtasticAdminRequest::SetLoRaConfig { reply, .. } => { let _ = reply.send(Err(e)); }
+                            MeshtasticAdminRequest::GetOwner { reply } => { let _ = reply.send(Err(e)); }
+                            MeshtasticAdminRequest::SetOwner { reply, .. } => { let _ = reply.send(Err(e)); }
+                            MeshtasticAdminRequest::GetSecurity { reply } => { let _ = reply.send(Err(e)); }
                         }
                     }
+                    reject_busy(req);
                     continue;
                 }
                 match req {
                     MeshtasticAdminRequest::GetLoRaConfig { reply } => {
-                        let request_id = packet_counter.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-                        if cmd_tx.send(admin_get_lora_config(my_node_num, request_id)).await.is_err() {
+                        let rid = packet_counter.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                        if cmd_tx.send(admin_get_lora_config(my_node_num, rid)).await.is_err() {
                             let _ = reply.send(Err("meshtastic client disconnected".into()));
                         } else {
-                            pending_admin = Some(PendingMeshtasticAdmin::GetLora { request_id, reply });
+                            pending_admin = Some(PendingMeshtasticAdmin::GetLora { request_id: rid, reply });
                         }
                     }
                     MeshtasticAdminRequest::SetLoRaConfig { config, reply } => {
-                        let request_id = packet_counter.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                        let rid = packet_counter.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
                         let lora = LoRaConfig {
                             use_preset: config.use_preset,
                             modem_preset: config.modem_preset,
@@ -570,10 +619,46 @@ async fn event_loop(
                             channel_num: config.channel_num,
                             override_frequency: config.override_frequency,
                         };
-                        if cmd_tx.send(admin_set_lora_config(my_node_num, request_id, lora)).await.is_err() {
+                        let passkey = last_session_passkey.clone();
+                        if cmd_tx.send(admin_set_lora_config(my_node_num, rid, lora, passkey)).await.is_err() {
                             let _ = reply.send(Err("meshtastic client disconnected".into()));
                         } else {
-                            pending_admin = Some(PendingMeshtasticAdmin::SetLora { request_id, reply });
+                            pending_admin = Some(PendingMeshtasticAdmin::SetLora { request_id: rid, reply });
+                        }
+                    }
+                    MeshtasticAdminRequest::GetOwner { reply } => {
+                        let rid = packet_counter.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                        if cmd_tx.send(admin_get_owner(my_node_num, rid)).await.is_err() {
+                            let _ = reply.send(Err("meshtastic client disconnected".into()));
+                        } else {
+                            pending_admin = Some(PendingMeshtasticAdmin::GetOwner { request_id: rid, reply });
+                        }
+                    }
+                    MeshtasticAdminRequest::SetOwner { long_name, short_name, reply } => {
+                        // For SetOwner we need the current values to merge — do a
+                        // GetOwner first and then set. For simplicity, send SetOwner
+                        // with only the provided fields; the device keeps others.
+                        // We synthesize a User with empty fields for what we don't change.
+                        let rid = packet_counter.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                        let user = User {
+                            id: String::new(),
+                            long_name: long_name.unwrap_or_default(),
+                            short_name: short_name.unwrap_or_default(),
+                            public_key: Vec::new(),
+                        };
+                        let passkey = last_session_passkey.clone();
+                        if cmd_tx.send(admin_set_owner(my_node_num, rid, user, passkey)).await.is_err() {
+                            let _ = reply.send(Err("meshtastic client disconnected".into()));
+                        } else {
+                            pending_admin = Some(PendingMeshtasticAdmin::SetOwner { request_id: rid, reply });
+                        }
+                    }
+                    MeshtasticAdminRequest::GetSecurity { reply } => {
+                        let rid = packet_counter.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                        if cmd_tx.send(admin_get_security_config(my_node_num, rid)).await.is_err() {
+                            let _ = reply.send(Err("meshtastic client disconnected".into()));
+                        } else {
+                            pending_admin = Some(PendingMeshtasticAdmin::GetSecurity { request_id: rid, reply });
                         }
                     }
                 }
@@ -587,10 +672,13 @@ async fn event_loop(
 }
 
 /// Try to handle an admin-channel response packet.
+///
 /// Returns `true` if the message was consumed (caller should skip general dispatch).
+/// Updates `session_passkey` with any passkey found in the decoded `AdminMessage`.
 fn try_handle_admin_response(
     msg: &proto::FromRadio,
     pending_admin: &mut Option<PendingMeshtasticAdmin>,
+    session_passkey: &mut Vec<u8>,
 ) -> bool {
     use prost::Message as _;
 
@@ -607,36 +695,41 @@ fn try_handle_admin_response(
     match pending_admin.take() {
         Some(PendingMeshtasticAdmin::GetLora { request_id, reply }) => {
             if data.reply_id != request_id && data.request_id != request_id {
-                // Not our response — put it back and don't consume.
                 *pending_admin = Some(PendingMeshtasticAdmin::GetLora { request_id, reply });
                 return false;
             }
-            // Decode AdminMessage to extract GetConfigResponse.
             match AdminMessage::decode(data.payload.as_slice()) {
-                Ok(AdminMessage {
-                    payload_variant:
+                Ok(msg) => {
+                    // Capture session passkey for subsequent SET commands.
+                    if !msg.session_passkey.is_empty() {
+                        *session_passkey = msg.session_passkey.clone();
+                    }
+                    match msg.payload_variant {
                         Some(admin_message::PayloadVariant::GetConfigResponse(MtConfig {
                             payload_variant: Some(mt_config::PayloadVariant::Lora(lora)),
-                        })),
-                }) => {
-                    let config = bbs_plugin_api::MeshtasticLoRaConfig {
-                        use_preset: lora.use_preset,
-                        modem_preset: lora.modem_preset,
-                        bandwidth: lora.bandwidth,
-                        spread_factor: lora.spread_factor,
-                        coding_rate: lora.coding_rate,
-                        frequency_offset: lora.frequency_offset,
-                        region: lora.region,
-                        hop_limit: lora.hop_limit,
-                        tx_enabled: lora.tx_enabled,
-                        tx_power: lora.tx_power,
-                        channel_num: lora.channel_num,
-                        override_frequency: lora.override_frequency,
-                    };
-                    let _ = reply.send(Ok(config));
-                }
-                Ok(_) => {
-                    let _ = reply.send(Err("unexpected admin response payload".into()));
+                        })) => {
+                            let config = bbs_plugin_api::MeshtasticLoRaConfig {
+                                use_preset: lora.use_preset,
+                                modem_preset: lora.modem_preset,
+                                bandwidth: lora.bandwidth,
+                                spread_factor: lora.spread_factor,
+                                coding_rate: lora.coding_rate,
+                                frequency_offset: lora.frequency_offset,
+                                region: lora.region,
+                                hop_limit: lora.hop_limit,
+                                tx_enabled: lora.tx_enabled,
+                                tx_power: lora.tx_power,
+                                channel_num: lora.channel_num,
+                                override_frequency: lora.override_frequency,
+                            };
+                            let _ = reply.send(Ok(config));
+                        }
+                        _ => {
+                            let _ = reply.send(Err(
+                                "unexpected admin response (expected LoRa config)".into(),
+                            ));
+                        }
+                    }
                 }
                 Err(e) => {
                     let _ = reply.send(Err(format!("failed to decode admin response: {e}")));
@@ -649,12 +742,97 @@ fn try_handle_admin_response(
                 *pending_admin = Some(PendingMeshtasticAdmin::SetLora { request_id, reply });
                 return false;
             }
-            // Any admin packet with matching reply_id/request_id for SetConfig is the ACK.
+            // Any matching admin packet is the ACK for a SET command.
             let _ = reply.send(Ok(()));
+            true
+        }
+        Some(PendingMeshtasticAdmin::GetOwner { request_id, reply }) => {
+            if data.reply_id != request_id && data.request_id != request_id {
+                *pending_admin = Some(PendingMeshtasticAdmin::GetOwner { request_id, reply });
+                return false;
+            }
+            match AdminMessage::decode(data.payload.as_slice()) {
+                Ok(msg) => {
+                    if !msg.session_passkey.is_empty() {
+                        *session_passkey = msg.session_passkey.clone();
+                    }
+                    match msg.payload_variant {
+                        Some(admin_message::PayloadVariant::GetOwnerResponse(user)) => {
+                            let info = bbs_plugin_api::MeshtasticOwnerInfo {
+                                id: user.id,
+                                long_name: user.long_name,
+                                short_name: user.short_name,
+                                public_key_hex: hex_encode(&user.public_key),
+                            };
+                            let _ = reply.send(Ok(info));
+                        }
+                        _ => {
+                            let _ = reply.send(Err(
+                                "unexpected admin response (expected owner info)".into(),
+                            ));
+                        }
+                    }
+                }
+                Err(e) => {
+                    let _ = reply.send(Err(format!("failed to decode admin response: {e}")));
+                }
+            }
+            true
+        }
+        Some(PendingMeshtasticAdmin::SetOwner { request_id, reply }) => {
+            if data.reply_id != request_id && data.request_id != request_id {
+                *pending_admin = Some(PendingMeshtasticAdmin::SetOwner { request_id, reply });
+                return false;
+            }
+            let _ = reply.send(Ok(()));
+            true
+        }
+        Some(PendingMeshtasticAdmin::GetSecurity { request_id, reply }) => {
+            if data.reply_id != request_id && data.request_id != request_id {
+                *pending_admin = Some(PendingMeshtasticAdmin::GetSecurity { request_id, reply });
+                return false;
+            }
+            match AdminMessage::decode(data.payload.as_slice()) {
+                Ok(msg) => {
+                    if !msg.session_passkey.is_empty() {
+                        *session_passkey = msg.session_passkey.clone();
+                    }
+                    match msg.payload_variant {
+                        Some(admin_message::PayloadVariant::GetConfigResponse(MtConfig {
+                            payload_variant: Some(mt_config::PayloadVariant::Security(sec)),
+                        })) => {
+                            let info = bbs_plugin_api::MeshtasticSecurityInfo {
+                                public_key_hex: hex_encode(&sec.public_key),
+                                admin_channel_enabled: sec.admin_channel_enabled,
+                            };
+                            let _ = reply.send(Ok(info));
+                        }
+                        _ => {
+                            let _ = reply.send(Err(
+                                "unexpected admin response (expected security config)".into(),
+                            ));
+                        }
+                    }
+                }
+                Err(e) => {
+                    let _ = reply.send(Err(format!("failed to decode admin response: {e}")));
+                }
+            }
             true
         }
         None => false,
     }
+}
+
+/// Hex-encode a byte slice (lowercase, no prefix).
+fn hex_encode(bytes: &[u8]) -> String {
+    bytes
+        .iter()
+        .fold(String::with_capacity(bytes.len() * 2), |mut s, b| {
+            use std::fmt::Write as _;
+            write!(s, "{b:02x}").unwrap();
+            s
+        })
 }
 
 #[allow(clippy::too_many_arguments)]

--- a/crates/bbs-meshtastic/src/lib.rs
+++ b/crates/bbs-meshtastic/src/lib.rs
@@ -61,6 +61,30 @@ pub enum MeshtasticConnectionType {
 
 // ── Config ────────────────────────────────────────────────────────────────────
 
+/// Radio parameter configuration stored in `[plugins.meshtastic.radio]`.
+///
+/// These values are **not** pushed to the device automatically on connect.
+/// Apply them on demand via the web admin UI (Settings → Meshtastic radio)
+/// or `supply-drop-bbs node set-meshtastic-radio` once that command is added.
+/// Once applied the device persists the settings in its own flash.
+#[derive(Debug, Clone, Default, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct MeshtasticRadioConfig {
+    /// Meshtastic region code (e.g. `"US"`, `"EU_868"`, `"ANZ"`).
+    ///
+    /// Sets the legal frequency range for the device.  See the Meshtastic
+    /// documentation for the full list of region codes.
+    #[serde(default)]
+    pub region: Option<String>,
+
+    /// Meshtastic modem preset (e.g. `"LONG_FAST"`, `"MEDIUM_SLOW"`).
+    ///
+    /// Predefined LoRa parameter profiles.  `"LONG_FAST"` is the Meshtastic
+    /// default and works well for most outdoor deployments.
+    #[serde(default)]
+    pub modem_preset: Option<String>,
+}
+
 /// Configuration for the Meshtastic transport (`[plugins.meshtastic]`).
 #[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
@@ -116,6 +140,21 @@ pub struct MeshtasticConfig {
     /// Maximum reconnect delay after repeated failures.
     #[serde(default = "default_reconnect_delay_max_ms")]
     pub reconnect_delay_max_ms: u64,
+
+    /// Radio parameter configuration.
+    ///
+    /// Stored here for reference and applied on demand via the web admin UI
+    /// (Settings → Meshtastic radio).  **Not** pushed automatically on every
+    /// connect — the device persists radio settings in its own flash.
+    ///
+    /// Example:
+    /// ```toml
+    /// [plugins.meshtastic.radio]
+    /// region       = "US"
+    /// modem_preset = "LONG_FAST"
+    /// ```
+    #[serde(default)]
+    pub radio: Option<MeshtasticRadioConfig>,
 }
 
 impl Default for MeshtasticConfig {
@@ -134,6 +173,7 @@ impl Default for MeshtasticConfig {
             want_ack: default_want_ack(),
             reconnect_delay_initial_ms: default_reconnect_delay_initial_ms(),
             reconnect_delay_max_ms: default_reconnect_delay_max_ms(),
+            radio: None,
         }
     }
 }

--- a/crates/bbs-meshtastic/src/lib.rs
+++ b/crates/bbs-meshtastic/src/lib.rs
@@ -64,10 +64,10 @@ pub enum MeshtasticConnectionType {
 
 /// Radio parameter configuration stored in `[plugins.meshtastic.radio]`.
 ///
-/// These values are **not** pushed to the device automatically on connect.
-/// Apply them on demand via the web admin UI (Settings → Meshtastic radio)
-/// or `supply-drop-bbs node set-meshtastic-radio` once that command is added.
-/// Once applied the device persists the settings in its own flash.
+/// These values are pushed to the device automatically once config sync
+/// completes after the transport connects (see `apply_config_on_connect`), so
+/// changes made in setup or the web admin UI take effect the next time the BBS
+/// connects.  The device persists the settings in its own flash.
 #[derive(Debug, Clone, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct MeshtasticRadioConfig {
@@ -144,9 +144,7 @@ pub struct MeshtasticConfig {
 
     /// Radio parameter configuration.
     ///
-    /// Stored here for reference and applied on demand via the web admin UI
-    /// (Settings → Meshtastic radio).  **Not** pushed automatically on every
-    /// connect — the device persists radio settings in its own flash.
+    /// Applied to the device automatically when the BBS connects.
     ///
     /// Example:
     /// ```toml
@@ -159,16 +157,13 @@ pub struct MeshtasticConfig {
 
     /// Short node name shown on OLED maps and mesh UIs (≤ 4 chars).
     ///
-    /// Stored here for reference.  Push to the device via the web admin UI
-    /// (Settings → Meshtastic device → Node name → Save to device) or by
-    /// running `supply-drop-bbs node set-meshtastic-owner` once that CLI
-    /// command is available.
+    /// Applied to the device automatically when the BBS connects.
     #[serde(default)]
     pub short_name: Option<String>,
 
     /// Full node display name shown in Meshtastic apps.
     ///
-    /// Stored alongside `short_name`; applied on demand via the web admin UI.
+    /// Applied to the device automatically when the BBS connects.
     #[serde(default)]
     pub long_name: Option<String>,
 }
@@ -262,6 +257,13 @@ pub struct MeshtasticTransport {
     admin_tx: mpsc::Sender<MeshtasticAdminRequest>,
     /// Admin channel receiver — taken by `start()` into the event loop.
     admin_rx: Mutex<Option<mpsc::Receiver<MeshtasticAdminRequest>>>,
+    /// Radio config from `[plugins.meshtastic.radio]`, applied to the device
+    /// automatically once config sync completes after connecting.
+    radio_config: Option<MeshtasticRadioConfig>,
+    /// Short node name from `[plugins.meshtastic]`, applied on connect.
+    short_name: Option<String>,
+    /// Long node name from `[plugins.meshtastic]`, applied on connect.
+    long_name: Option<String>,
 }
 
 #[async_trait]
@@ -326,6 +328,9 @@ impl Plugin for MeshtasticTransport {
             packet_counter: Arc::new(AtomicU32::new(1)),
             admin_tx,
             admin_rx: Mutex::new(Some(admin_rx)),
+            radio_config: config.radio,
+            short_name: config.short_name,
+            long_name: config.long_name,
         })
     }
 
@@ -363,6 +368,11 @@ impl Plugin for MeshtasticTransport {
         let hop_limit = self.hop_limit;
         let want_ack = self.want_ack;
         let packet_counter = Arc::clone(&self.packet_counter);
+        let auto_apply = AutoApplyConfig {
+            radio: self.radio_config.clone(),
+            short_name: self.short_name.clone(),
+            long_name: self.long_name.clone(),
+        };
 
         tokio::spawn(event_loop(
             client,
@@ -378,6 +388,7 @@ impl Plugin for MeshtasticTransport {
             want_ack,
             packet_counter,
             admin_rx,
+            auto_apply,
         ));
 
         // Subscribe to advisory domain events, mirroring the MeshCore transport.
@@ -466,6 +477,28 @@ impl TransportEngine for MeshtasticTransport {
 
 // ── Event loop ────────────────────────────────────────────────────────────────
 
+/// Settings from config.toml that are pushed to the device automatically once
+/// config sync completes after each (re)connection.  This is what makes
+/// "configure in setup or web UI → it just works" true: the operator never has
+/// to run a CLI command to apply settings.
+#[derive(Clone, Default)]
+struct AutoApplyConfig {
+    radio: Option<MeshtasticRadioConfig>,
+    short_name: Option<String>,
+    long_name: Option<String>,
+}
+
+impl AutoApplyConfig {
+    /// True when there is at least one setting to push.
+    fn has_anything(&self) -> bool {
+        self.radio
+            .as_ref()
+            .is_some_and(|r| r.region.is_some() || r.modem_preset.is_some())
+            || self.short_name.is_some()
+            || self.long_name.is_some()
+    }
+}
+
 /// Pending admin request in the Meshtastic event loop.
 enum PendingMeshtasticAdmin {
     GetLora {
@@ -505,17 +538,22 @@ async fn event_loop(
     want_ack: bool,
     packet_counter: Arc<AtomicU32>,
     mut admin_rx: mpsc::Receiver<MeshtasticAdminRequest>,
+    auto_apply: AutoApplyConfig,
 ) {
     let mut pending_admin: Option<PendingMeshtasticAdmin> = None;
     // Session passkey received from the last GET response; echo it back in SET
     // commands as a replay-attack guard (Meshtastic 2.5+, field 101).
     let mut last_session_passkey: Vec<u8> = Vec::new();
+    // Whether we've pushed the config.toml settings to the device on this
+    // connection. Reset on disconnect so settings re-apply after a reconnect.
+    let mut auto_applied = false;
 
     loop {
         tokio::select! {
             event = client.recv() => match event {
                 Some(ClientEvent::Connected) => {
                     info!("meshtastic: connected to radio");
+                    auto_applied = false;
                 }
                 Some(ClientEvent::Disconnected { will_retry }) => {
                     // Fail any in-flight admin request.
@@ -529,6 +567,7 @@ async fn event_loop(
                             PendingMeshtasticAdmin::GetSecurity { reply, .. } => { let _ = reply.send(Err(err)); }
                         }
                     }
+                    auto_applied = false;
                     if will_retry {
                         info!("meshtastic: radio disconnected, will retry");
                     } else {
@@ -537,6 +576,24 @@ async fn event_loop(
                     }
                 }
                 Some(ClientEvent::FromRadio(msg)) => {
+                    // Auto-apply config.toml settings once config sync completes.
+                    // ConfigCompleteId marks the end of the initial sync, by which
+                    // point MyInfo (node number) has already been received.
+                    if !auto_applied
+                        && matches!(
+                            msg.payload_variant,
+                            Some(from_radio::PayloadVariant::ConfigCompleteId(_))
+                        )
+                        && auto_apply.has_anything()
+                    {
+                        let node_num = state.lock().expect("state mutex poisoned").my_node_num;
+                        if let Some(node_num) = node_num {
+                            apply_config_on_connect(&cmd_tx, node_num, &auto_apply, &packet_counter)
+                                .await;
+                            auto_applied = true;
+                        }
+                    }
+
                     // Check if this is an admin response packet before general dispatch.
                     let consumed = try_handle_admin_response(
                         &msg,
@@ -667,6 +724,76 @@ async fn event_loop(
                 info!("meshtastic: shutdown signal received");
                 break;
             }
+        }
+    }
+}
+
+/// Push the operator's configured radio and node-name settings to the device.
+///
+/// Called once per connection after config sync completes.  Fire-and-forget:
+/// the device applies SetConfig / SetOwner and persists them in flash, so we
+/// don't block on ACKs here.  This is what makes settings configured in setup
+/// or the web UI take effect automatically — no CLI step required.
+///
+/// `SetOwner` is sent with an empty `public_key`; Meshtastic firmware only
+/// copies `long_name`/`short_name` from the message and never overwrites the
+/// node's PKC key from a SetOwner (the key is managed via SecurityConfig), so
+/// the node's identity key is preserved.
+async fn apply_config_on_connect(
+    cmd_tx: &mpsc::Sender<proto::ToRadio>,
+    node_num: u32,
+    cfg: &AutoApplyConfig,
+    packet_counter: &AtomicU32,
+) {
+    use proto::{admin_set_lora_config, admin_set_owner, LoRaConfig, User};
+
+    // Radio config (region + modem preset).
+    if let Some(radio) = &cfg.radio {
+        if radio.region.is_some() || radio.modem_preset.is_some() {
+            let region = region_str_to_int(radio.region.as_deref().unwrap_or("UNSET"));
+            let preset = preset_str_to_int(radio.modem_preset.as_deref().unwrap_or("LONG_FAST"));
+            let lora = LoRaConfig {
+                use_preset: true,
+                modem_preset: preset,
+                region,
+                ..Default::default()
+            };
+            let rid = packet_counter.fetch_add(1, Ordering::Relaxed);
+            info!(
+                region = radio.region.as_deref().unwrap_or("UNSET"),
+                modem_preset = radio.modem_preset.as_deref().unwrap_or("LONG_FAST"),
+                "meshtastic: auto-applying radio config from config.toml"
+            );
+            if cmd_tx
+                .send(admin_set_lora_config(node_num, rid, lora, Vec::new()))
+                .await
+                .is_err()
+            {
+                warn!("meshtastic: failed to send auto-apply radio config");
+            }
+        }
+    }
+
+    // Node name (long + short).
+    if cfg.short_name.is_some() || cfg.long_name.is_some() {
+        let user = User {
+            id: String::new(),
+            long_name: cfg.long_name.clone().unwrap_or_default(),
+            short_name: cfg.short_name.clone().unwrap_or_default(),
+            public_key: Vec::new(),
+        };
+        let rid = packet_counter.fetch_add(1, Ordering::Relaxed);
+        info!(
+            long_name = cfg.long_name.as_deref().unwrap_or(""),
+            short_name = cfg.short_name.as_deref().unwrap_or(""),
+            "meshtastic: auto-applying node name from config.toml"
+        );
+        if cmd_tx
+            .send(admin_set_owner(node_num, rid, user, Vec::new()))
+            .await
+            .is_err()
+        {
+            warn!("meshtastic: failed to send auto-apply node name");
         }
     }
 }

--- a/crates/bbs-meshtastic/src/lib.rs
+++ b/crates/bbs-meshtastic/src/lib.rs
@@ -28,11 +28,15 @@ use serde::{Deserialize, Serialize};
 use tokio::sync::{mpsc, watch};
 use tracing::{debug, info, warn};
 
+use bbs_plugin_api::MeshtasticAdminRequest;
+
 use crate::{
     command::{format_response, parse_command, render_notification, truncate_utf8},
     proto::{
-        direct_text_packet, from_radio, mesh_packet, node_key, synthetic_pubkey, Data, MeshPacket,
-        NodeInfo, BROADCAST_ADDR, PORT_NODEINFO_APP, PORT_TEXT_MESSAGE_APP,
+        admin_get_lora_config, admin_message, admin_set_lora_config, direct_text_packet,
+        from_radio, mesh_packet, mt_config, node_key, synthetic_pubkey, AdminMessage, Data,
+        LoRaConfig, MeshPacket, MtConfig, NodeInfo, BROADCAST_ADDR, PORT_ADMIN_APP,
+        PORT_NODEINFO_APP, PORT_TEXT_MESSAGE_APP,
     },
     session::SessionState,
     stream::{ClientEvent, MeshtasticClient, SerialConfig, TcpConfig},
@@ -196,6 +200,10 @@ pub struct MeshtasticTransport {
     hop_limit: u32,
     want_ack: bool,
     packet_counter: Arc<AtomicU32>,
+    /// Admin channel sender — stored so `start()` can register it with the host.
+    admin_tx: mpsc::Sender<MeshtasticAdminRequest>,
+    /// Admin channel receiver — taken by `start()` into the event loop.
+    admin_rx: Mutex<Option<mpsc::Receiver<MeshtasticAdminRequest>>>,
 }
 
 #[async_trait]
@@ -243,6 +251,7 @@ impl Plugin for MeshtasticTransport {
 
         let cmd_tx = client.sender();
         let (shutdown_tx, _) = watch::channel(false);
+        let (admin_tx, admin_rx) = mpsc::channel::<MeshtasticAdminRequest>(4);
 
         Ok(Self {
             host,
@@ -257,6 +266,8 @@ impl Plugin for MeshtasticTransport {
             hop_limit: config.hop_limit,
             want_ack: config.want_ack,
             packet_counter: Arc::new(AtomicU32::new(1)),
+            admin_tx,
+            admin_rx: Mutex::new(Some(admin_rx)),
         })
     }
 
@@ -269,6 +280,19 @@ impl Plugin for MeshtasticTransport {
             .ok_or_else(|| {
                 PluginError::StartFailed("meshtastic transport already started".into())
             })?;
+
+        let admin_rx = self
+            .admin_rx
+            .lock()
+            .expect("admin_rx mutex poisoned")
+            .take()
+            .ok_or_else(|| {
+                PluginError::StartFailed("meshtastic admin channel already taken".into())
+            })?;
+
+        // Register admin channel with the host before spawning the event loop.
+        self.host
+            .register_meshtastic_admin_ops(self.admin_tx.clone());
 
         let host = Arc::clone(&self.host);
         let cmd_tx = self.cmd_tx.clone();
@@ -295,6 +319,7 @@ impl Plugin for MeshtasticTransport {
             hop_limit,
             want_ack,
             packet_counter,
+            admin_rx,
         ));
 
         // Subscribe to advisory domain events, mirroring the MeshCore transport.
@@ -383,6 +408,18 @@ impl TransportEngine for MeshtasticTransport {
 
 // ── Event loop ────────────────────────────────────────────────────────────────
 
+/// Pending admin request in the Meshtastic event loop.
+enum PendingMeshtasticAdmin {
+    GetLora {
+        request_id: u32,
+        reply: tokio::sync::oneshot::Sender<Result<bbs_plugin_api::MeshtasticLoRaConfig, String>>,
+    },
+    SetLora {
+        request_id: u32,
+        reply: tokio::sync::oneshot::Sender<Result<(), String>>,
+    },
+}
+
 #[allow(clippy::too_many_arguments)]
 async fn event_loop(
     mut client: MeshtasticClient,
@@ -397,7 +434,10 @@ async fn event_loop(
     hop_limit: u32,
     want_ack: bool,
     packet_counter: Arc<AtomicU32>,
+    mut admin_rx: mpsc::Receiver<MeshtasticAdminRequest>,
 ) {
+    let mut pending_admin: Option<PendingMeshtasticAdmin> = None;
+
     loop {
         tokio::select! {
             event = client.recv() => match event {
@@ -405,6 +445,14 @@ async fn event_loop(
                     info!("meshtastic: connected to radio");
                 }
                 Some(ClientEvent::Disconnected { will_retry }) => {
+                    // Fail any in-flight admin request.
+                    if let Some(op) = pending_admin.take() {
+                        let err = "device disconnected".to_owned();
+                        match op {
+                            PendingMeshtasticAdmin::GetLora { reply, .. } => { let _ = reply.send(Err(err)); }
+                            PendingMeshtasticAdmin::SetLora { reply, .. } => { let _ = reply.send(Err(err)); }
+                        }
+                    }
                     if will_retry {
                         info!("meshtastic: radio disconnected, will retry");
                     } else {
@@ -413,27 +461,159 @@ async fn event_loop(
                     }
                 }
                 Some(ClientEvent::FromRadio(msg)) => {
-                    handle_from_radio(
-                        msg,
-                        &host,
-                        &cmd_tx,
-                        &state,
-                        command_prefix,
-                        &welcome_message,
-                        node_credential_ttl_days,
-                        max_payload_bytes,
-                        hop_limit,
-                        want_ack,
-                        &packet_counter,
-                    ).await;
+                    // Check if this is an admin response packet before general dispatch.
+                    let consumed = try_handle_admin_response(&msg, &mut pending_admin);
+                    if !consumed {
+                        handle_from_radio(
+                            msg,
+                            &host,
+                            &cmd_tx,
+                            &state,
+                            command_prefix,
+                            &welcome_message,
+                            node_credential_ttl_days,
+                            max_payload_bytes,
+                            hop_limit,
+                            want_ack,
+                            &packet_counter,
+                        ).await;
+                    }
                 }
                 None => break,
+            },
+            Some(req) = admin_rx.recv() => {
+                let my_node_num = state.lock().expect("state mutex poisoned").my_node_num;
+                let Some(my_node_num) = my_node_num else {
+                    match req {
+                        MeshtasticAdminRequest::GetLoRaConfig { reply } => {
+                            let _ = reply.send(Err("node num not yet received from radio".into()));
+                        }
+                        MeshtasticAdminRequest::SetLoRaConfig { reply, .. } => {
+                            let _ = reply.send(Err("node num not yet received from radio".into()));
+                        }
+                    }
+                    continue;
+                };
+                if pending_admin.is_some() {
+                    match req {
+                        MeshtasticAdminRequest::GetLoRaConfig { reply } => {
+                            let _ = reply.send(Err("another admin operation is already in progress".into()));
+                        }
+                        MeshtasticAdminRequest::SetLoRaConfig { reply, .. } => {
+                            let _ = reply.send(Err("another admin operation is already in progress".into()));
+                        }
+                    }
+                    continue;
+                }
+                match req {
+                    MeshtasticAdminRequest::GetLoRaConfig { reply } => {
+                        let request_id = packet_counter.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                        if cmd_tx.send(admin_get_lora_config(my_node_num, request_id)).await.is_err() {
+                            let _ = reply.send(Err("meshtastic client disconnected".into()));
+                        } else {
+                            pending_admin = Some(PendingMeshtasticAdmin::GetLora { request_id, reply });
+                        }
+                    }
+                    MeshtasticAdminRequest::SetLoRaConfig { config, reply } => {
+                        let request_id = packet_counter.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                        let lora = LoRaConfig {
+                            use_preset: config.use_preset,
+                            modem_preset: config.modem_preset,
+                            bandwidth: config.bandwidth,
+                            spread_factor: config.spread_factor,
+                            coding_rate: config.coding_rate,
+                            frequency_offset: config.frequency_offset,
+                            region: config.region,
+                            hop_limit: config.hop_limit,
+                            tx_enabled: config.tx_enabled,
+                            tx_power: config.tx_power,
+                            channel_num: config.channel_num,
+                            override_frequency: config.override_frequency,
+                        };
+                        if cmd_tx.send(admin_set_lora_config(my_node_num, request_id, lora)).await.is_err() {
+                            let _ = reply.send(Err("meshtastic client disconnected".into()));
+                        } else {
+                            pending_admin = Some(PendingMeshtasticAdmin::SetLora { request_id, reply });
+                        }
+                    }
+                }
             },
             _ = shutdown_rx.changed() => {
                 info!("meshtastic: shutdown signal received");
                 break;
             }
         }
+    }
+}
+
+/// Try to handle an admin-channel response packet.
+/// Returns `true` if the message was consumed (caller should skip general dispatch).
+fn try_handle_admin_response(
+    msg: &proto::FromRadio,
+    pending_admin: &mut Option<PendingMeshtasticAdmin>,
+) -> bool {
+    use prost::Message as _;
+
+    let Some(from_radio::PayloadVariant::Packet(packet)) = &msg.payload_variant else {
+        return false;
+    };
+    let Some(mesh_packet::PayloadVariant::Decoded(data)) = &packet.payload_variant else {
+        return false;
+    };
+    if data.portnum != PORT_ADMIN_APP {
+        return false;
+    }
+
+    match pending_admin.take() {
+        Some(PendingMeshtasticAdmin::GetLora { request_id, reply }) => {
+            if data.reply_id != request_id && data.request_id != request_id {
+                // Not our response — put it back and don't consume.
+                *pending_admin = Some(PendingMeshtasticAdmin::GetLora { request_id, reply });
+                return false;
+            }
+            // Decode AdminMessage to extract GetConfigResponse.
+            match AdminMessage::decode(data.payload.as_slice()) {
+                Ok(AdminMessage {
+                    payload_variant:
+                        Some(admin_message::PayloadVariant::GetConfigResponse(MtConfig {
+                            payload_variant: Some(mt_config::PayloadVariant::Lora(lora)),
+                        })),
+                }) => {
+                    let config = bbs_plugin_api::MeshtasticLoRaConfig {
+                        use_preset: lora.use_preset,
+                        modem_preset: lora.modem_preset,
+                        bandwidth: lora.bandwidth,
+                        spread_factor: lora.spread_factor,
+                        coding_rate: lora.coding_rate,
+                        frequency_offset: lora.frequency_offset,
+                        region: lora.region,
+                        hop_limit: lora.hop_limit,
+                        tx_enabled: lora.tx_enabled,
+                        tx_power: lora.tx_power,
+                        channel_num: lora.channel_num,
+                        override_frequency: lora.override_frequency,
+                    };
+                    let _ = reply.send(Ok(config));
+                }
+                Ok(_) => {
+                    let _ = reply.send(Err("unexpected admin response payload".into()));
+                }
+                Err(e) => {
+                    let _ = reply.send(Err(format!("failed to decode admin response: {e}")));
+                }
+            }
+            true
+        }
+        Some(PendingMeshtasticAdmin::SetLora { request_id, reply }) => {
+            if data.reply_id != request_id && data.request_id != request_id {
+                *pending_admin = Some(PendingMeshtasticAdmin::SetLora { request_id, reply });
+                return false;
+            }
+            // Any admin packet with matching reply_id/request_id for SetConfig is the ACK.
+            let _ = reply.send(Ok(()));
+            true
+        }
+        None => false,
     }
 }
 
@@ -542,6 +722,10 @@ async fn handle_packet(
                 from = format_node_id(packet.from),
                 "meshtastic: nodeinfo packet observed"
             );
+            return;
+        }
+        if data.portnum == PORT_ADMIN_APP {
+            // Admin packets are handled by try_handle_admin_response in the event loop.
             return;
         }
     }

--- a/crates/bbs-meshtastic/src/lib.rs
+++ b/crates/bbs-meshtastic/src/lib.rs
@@ -500,22 +500,22 @@ impl AutoApplyConfig {
 }
 
 /// Pending admin request in the Meshtastic event loop.
+///
+/// Only GET operations are tracked here — they wait for the device's response.
+/// SET operations (LoRa config, owner) are fire-and-forget: Meshtastic does not
+/// send a reliable admin response for config writes — it applies them silently
+/// (and reboots only when a LoRa parameter actually changes). Waiting for an ACK
+/// would always time out, so SET requests reply success as soon as the command
+/// is sent to the device.
+#[allow(clippy::enum_variant_names)] // all are Get* by design; Set* are fire-and-forget
 enum PendingMeshtasticAdmin {
     GetLora {
         request_id: u32,
         reply: tokio::sync::oneshot::Sender<Result<bbs_plugin_api::MeshtasticLoRaConfig, String>>,
     },
-    SetLora {
-        request_id: u32,
-        reply: tokio::sync::oneshot::Sender<Result<(), String>>,
-    },
     GetOwner {
         request_id: u32,
         reply: tokio::sync::oneshot::Sender<Result<bbs_plugin_api::MeshtasticOwnerInfo, String>>,
-    },
-    SetOwner {
-        request_id: u32,
-        reply: tokio::sync::oneshot::Sender<Result<(), String>>,
     },
     GetSecurity {
         request_id: u32,
@@ -561,9 +561,7 @@ async fn event_loop(
                         let err = "device disconnected".to_owned();
                         match op {
                             PendingMeshtasticAdmin::GetLora { reply, .. } => { let _ = reply.send(Err(err)); }
-                            PendingMeshtasticAdmin::SetLora { reply, .. } => { let _ = reply.send(Err(err)); }
                             PendingMeshtasticAdmin::GetOwner { reply, .. } => { let _ = reply.send(Err(err)); }
-                            PendingMeshtasticAdmin::SetOwner { reply, .. } => { let _ = reply.send(Err(err)); }
                             PendingMeshtasticAdmin::GetSecurity { reply, .. } => { let _ = reply.send(Err(err)); }
                         }
                     }
@@ -677,10 +675,15 @@ async fn event_loop(
                             override_frequency: config.override_frequency,
                         };
                         let passkey = last_session_passkey.clone();
+                        // Fire-and-forget: Meshtastic does not send a reliable admin
+                        // response for a config write — it applies it silently (and
+                        // reboots only if a LoRa parameter actually changed). Waiting
+                        // for an ACK would always time out, so report success once
+                        // the command has been handed to the device.
                         if cmd_tx.send(admin_set_lora_config(my_node_num, rid, lora, passkey)).await.is_err() {
                             let _ = reply.send(Err("meshtastic client disconnected".into()));
                         } else {
-                            pending_admin = Some(PendingMeshtasticAdmin::SetLora { request_id: rid, reply });
+                            let _ = reply.send(Ok(()));
                         }
                     }
                     MeshtasticAdminRequest::GetOwner { reply } => {
@@ -692,10 +695,10 @@ async fn event_loop(
                         }
                     }
                     MeshtasticAdminRequest::SetOwner { long_name, short_name, reply } => {
-                        // For SetOwner we need the current values to merge — do a
-                        // GetOwner first and then set. For simplicity, send SetOwner
-                        // with only the provided fields; the device keeps others.
-                        // We synthesize a User with empty fields for what we don't change.
+                        // Firmware only copies non-empty long_name/short_name from
+                        // the User and never overwrites the PKC public key on a
+                        // SetOwner, so sending empty id/public_key is safe and
+                        // leaves the node identity key intact.
                         let rid = packet_counter.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
                         let user = User {
                             id: String::new(),
@@ -704,10 +707,13 @@ async fn event_loop(
                             public_key: Vec::new(),
                         };
                         let passkey = last_session_passkey.clone();
+                        // Fire-and-forget, consistent with SetLoRaConfig: Meshtastic
+                        // applies the owner change without a reliable admin response.
+                        // Report success once the command has been sent.
                         if cmd_tx.send(admin_set_owner(my_node_num, rid, user, passkey)).await.is_err() {
                             let _ = reply.send(Err("meshtastic client disconnected".into()));
                         } else {
-                            pending_admin = Some(PendingMeshtasticAdmin::SetOwner { request_id: rid, reply });
+                            let _ = reply.send(Ok(()));
                         }
                     }
                     MeshtasticAdminRequest::GetSecurity { reply } => {
@@ -864,15 +870,6 @@ fn try_handle_admin_response(
             }
             true
         }
-        Some(PendingMeshtasticAdmin::SetLora { request_id, reply }) => {
-            if data.reply_id != request_id && data.request_id != request_id {
-                *pending_admin = Some(PendingMeshtasticAdmin::SetLora { request_id, reply });
-                return false;
-            }
-            // Any matching admin packet is the ACK for a SET command.
-            let _ = reply.send(Ok(()));
-            true
-        }
         Some(PendingMeshtasticAdmin::GetOwner { request_id, reply }) => {
             if data.reply_id != request_id && data.request_id != request_id {
                 *pending_admin = Some(PendingMeshtasticAdmin::GetOwner { request_id, reply });
@@ -904,14 +901,6 @@ fn try_handle_admin_response(
                     let _ = reply.send(Err(format!("failed to decode admin response: {e}")));
                 }
             }
-            true
-        }
-        Some(PendingMeshtasticAdmin::SetOwner { request_id, reply }) => {
-            if data.reply_id != request_id && data.request_id != request_id {
-                *pending_admin = Some(PendingMeshtasticAdmin::SetOwner { request_id, reply });
-                return false;
-            }
-            let _ = reply.send(Ok(()));
             true
         }
         Some(PendingMeshtasticAdmin::GetSecurity { request_id, reply }) => {

--- a/crates/bbs-meshtastic/src/lib.rs
+++ b/crates/bbs-meshtastic/src/lib.rs
@@ -33,10 +33,10 @@ use bbs_plugin_api::MeshtasticAdminRequest;
 use crate::{
     command::{format_response, parse_command, render_notification, truncate_utf8},
     proto::{
-        admin_get_lora_config, admin_get_owner, admin_get_security_config, admin_message,
-        admin_set_lora_config, admin_set_owner, direct_text_packet, from_radio, mesh_packet,
-        mt_config, node_key, synthetic_pubkey, AdminMessage, Data, LoRaConfig, MeshPacket,
-        MtConfig, NodeInfo, User, BROADCAST_ADDR, PORT_ADMIN_APP, PORT_NODEINFO_APP,
+        admin_get_lora_config, admin_get_owner, admin_get_security_config, admin_get_session_key,
+        admin_message, admin_set_lora_config, admin_set_owner, direct_text_packet, from_radio,
+        mesh_packet, mt_config, node_key, synthetic_pubkey, AdminMessage, Data, LoRaConfig,
+        MeshPacket, MtConfig, NodeInfo, BROADCAST_ADDR, PORT_ADMIN_APP, PORT_NODEINFO_APP,
         PORT_TEXT_MESSAGE_APP,
     },
     session::SessionState,
@@ -533,6 +533,87 @@ fn pending_reply_abandoned(op: &PendingMeshtasticAdmin) -> bool {
     }
 }
 
+/// An admin WRITE waiting for a fresh session passkey before it can be sent.
+///
+/// Meshtastic gates admin writes on an 8-byte `session_passkey` that the device
+/// only hands out in a get-response. So a write is deferred: we send a
+/// session-key request, and once the passkey arrives we build and send the
+/// write with it echoed in.
+enum DeferredWrite {
+    Lora {
+        lora: proto::LoRaConfig,
+        reply: Option<tokio::sync::oneshot::Sender<Result<(), String>>>,
+    },
+    Owner {
+        user: proto::User,
+        reply: Option<tokio::sync::oneshot::Sender<Result<(), String>>>,
+    },
+}
+
+/// Extract the `session_passkey` (AdminMessage field 101) from an inbound admin
+/// packet, if present. Every Meshtastic admin get-response carries a fresh
+/// 8-byte passkey; harvesting it lets us authorize subsequent writes.
+fn harvest_session_passkey(msg: &proto::FromRadio) -> Option<Vec<u8>> {
+    use prost::Message as _;
+    let Some(from_radio::PayloadVariant::Packet(p)) = &msg.payload_variant else {
+        return None;
+    };
+    let Some(mesh_packet::PayloadVariant::Decoded(d)) = &p.payload_variant else {
+        return None;
+    };
+    if d.portnum != PORT_ADMIN_APP {
+        return None;
+    }
+    let admin = AdminMessage::decode(d.payload.as_slice()).ok()?;
+    (!admin.session_passkey.is_empty()).then_some(admin.session_passkey)
+}
+
+/// Send all deferred writes now that a session passkey is available.
+async fn flush_deferred_writes(
+    cmd_tx: &mpsc::Sender<proto::ToRadio>,
+    node: u32,
+    passkey: &[u8],
+    deferred: &mut Vec<DeferredWrite>,
+) {
+    for w in deferred.drain(..) {
+        let rid = random_packet_id();
+        match w {
+            DeferredWrite::Lora { lora, reply } => {
+                let ok = cmd_tx
+                    .send(admin_set_lora_config(node, rid, lora, passkey.to_vec()))
+                    .await
+                    .is_ok();
+                if let Some(r) = reply {
+                    let _ = r.send(if ok {
+                        Ok(())
+                    } else {
+                        Err("meshtastic client disconnected".into())
+                    });
+                }
+                if ok {
+                    info!("meshtastic: applied LoRa config to device");
+                }
+            }
+            DeferredWrite::Owner { user, reply } => {
+                let ok = cmd_tx
+                    .send(admin_set_owner(node, rid, user, passkey.to_vec()))
+                    .await
+                    .is_ok();
+                if let Some(r) = reply {
+                    let _ = r.send(if ok {
+                        Ok(())
+                    } else {
+                        Err("meshtastic client disconnected".into())
+                    });
+                }
+                if ok {
+                    info!("meshtastic: applied node owner info to device");
+                }
+            }
+        }
+    }
+}
+
 #[allow(clippy::too_many_arguments)]
 async fn event_loop(
     mut client: MeshtasticClient,
@@ -551,11 +632,15 @@ async fn event_loop(
     auto_apply: AutoApplyConfig,
 ) {
     let mut pending_admin: Option<PendingMeshtasticAdmin> = None;
-    // Session passkey received from the last GET response; echo it back in SET
-    // commands as a replay-attack guard (Meshtastic 2.5+, field 101).
+    // Session passkey received from the last admin get-response; required to
+    // authorize admin writes (Meshtastic AdminMessage field 101).
     let mut last_session_passkey: Vec<u8> = Vec::new();
-    // Whether we've pushed the config.toml settings to the device on this
-    // connection. Reset on disconnect so settings re-apply after a reconnect.
+    // Admin writes waiting for a fresh session passkey before they can be sent.
+    let mut deferred_writes: Vec<DeferredWrite> = Vec::new();
+    // True once we've sent a session-key request and are awaiting the passkey.
+    let mut session_requested = false;
+    // Whether we've queued the config.toml auto-apply on this connection.
+    // Reset on disconnect so settings re-apply after a reconnect.
     let mut auto_applied = false;
     // Periodically reap a pending GET whose caller has given up (its oneshot
     // receiver was dropped after the caller's own timeout). Without this, a GET
@@ -587,6 +672,17 @@ async fn event_loop(
                             PendingMeshtasticAdmin::GetSecurity { reply, .. } => { let _ = reply.send(Err(err)); }
                         }
                     }
+                    // Fail any deferred writes whose caller is waiting.
+                    for w in deferred_writes.drain(..) {
+                        let r = match w {
+                            DeferredWrite::Lora { reply, .. } => reply,
+                            DeferredWrite::Owner { reply, .. } => reply,
+                        };
+                        if let Some(r) = r {
+                            let _ = r.send(Err("device disconnected".into()));
+                        }
+                    }
+                    session_requested = false;
                     auto_applied = false;
                     if will_retry {
                         info!("meshtastic: radio disconnected, will retry");
@@ -598,7 +694,9 @@ async fn event_loop(
                 Some(ClientEvent::FromRadio(msg)) => {
                     // Auto-apply config.toml settings once config sync completes.
                     // ConfigCompleteId marks the end of the initial sync, by which
-                    // point MyInfo (node number) has already been received.
+                    // point MyInfo (node number) has already been received. We
+                    // enqueue the writes and request a session key; the writes are
+                    // sent once the passkey arrives (below).
                     if !auto_applied
                         && matches!(
                             msg.payload_variant,
@@ -606,11 +704,36 @@ async fn event_loop(
                         )
                         && auto_apply.has_anything()
                     {
-                        let node_num = state.lock().expect("state mutex poisoned").my_node_num;
-                        if let Some(node_num) = node_num {
-                            apply_config_on_connect(&cmd_tx, node_num, &auto_apply, &packet_counter)
-                                .await;
+                        let node = state.lock().expect("state poisoned").my_node_num;
+                        if let Some(node) = node {
+                            enqueue_auto_apply(&auto_apply, &mut deferred_writes);
+                            request_session_key(
+                                &cmd_tx,
+                                node,
+                                &mut session_requested,
+                                &deferred_writes,
+                            )
+                            .await;
                             auto_applied = true;
+                        }
+                    }
+
+                    // Harvest a session passkey from any admin response and, once
+                    // we have one, flush queued writes.
+                    if let Some(pk) = harvest_session_passkey(&msg) {
+                        last_session_passkey = pk;
+                    }
+                    if !deferred_writes.is_empty() && !last_session_passkey.is_empty() {
+                        let node = state.lock().expect("state poisoned").my_node_num;
+                        if let Some(node) = node {
+                            flush_deferred_writes(
+                                &cmd_tx,
+                                node,
+                                &last_session_passkey,
+                                &mut deferred_writes,
+                            )
+                            .await;
+                            session_requested = false;
                         }
                     }
 
@@ -656,19 +779,24 @@ async fn event_loop(
                     reject_no_num(req);
                     continue;
                 };
-                if pending_admin.is_some() {
-                    // Another admin operation is in flight — reject immediately.
-                    fn reject_busy(req: MeshtasticAdminRequest) {
-                        let e = "another admin operation is already in progress".to_owned();
-                        match req {
-                            MeshtasticAdminRequest::GetLoRaConfig { reply } => { let _ = reply.send(Err(e)); }
-                            MeshtasticAdminRequest::SetLoRaConfig { reply, .. } => { let _ = reply.send(Err(e)); }
-                            MeshtasticAdminRequest::GetOwner { reply } => { let _ = reply.send(Err(e)); }
-                            MeshtasticAdminRequest::SetOwner { reply, .. } => { let _ = reply.send(Err(e)); }
-                            MeshtasticAdminRequest::GetSecurity { reply } => { let _ = reply.send(Err(e)); }
-                        }
+                // Only GET operations use `pending_admin` (one in flight at a
+                // time). SET operations are queued as deferred writes, so they
+                // are not blocked by a pending GET.
+                if pending_admin.is_some()
+                    && matches!(
+                        req,
+                        MeshtasticAdminRequest::GetLoRaConfig { .. }
+                            | MeshtasticAdminRequest::GetOwner { .. }
+                            | MeshtasticAdminRequest::GetSecurity { .. }
+                    )
+                {
+                    let e = "another admin operation is already in progress".to_owned();
+                    match req {
+                        MeshtasticAdminRequest::GetLoRaConfig { reply } => { let _ = reply.send(Err(e)); }
+                        MeshtasticAdminRequest::GetOwner { reply } => { let _ = reply.send(Err(e)); }
+                        MeshtasticAdminRequest::GetSecurity { reply } => { let _ = reply.send(Err(e)); }
+                        _ => unreachable!(),
                     }
-                    reject_busy(req);
                     continue;
                 }
                 match req {
@@ -681,7 +809,6 @@ async fn event_loop(
                         }
                     }
                     MeshtasticAdminRequest::SetLoRaConfig { config, reply } => {
-                        let rid = packet_counter.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
                         let lora = LoRaConfig {
                             use_preset: config.use_preset,
                             modem_preset: config.modem_preset,
@@ -696,17 +823,10 @@ async fn event_loop(
                             channel_num: config.channel_num,
                             override_frequency: config.override_frequency,
                         };
-                        let passkey = last_session_passkey.clone();
-                        // Fire-and-forget: Meshtastic does not send a reliable admin
-                        // response for a config write — it applies it silently (and
-                        // reboots only if a LoRa parameter actually changed). Waiting
-                        // for an ACK would always time out, so report success once
-                        // the command has been handed to the device.
-                        if cmd_tx.send(admin_set_lora_config(my_node_num, rid, lora, passkey)).await.is_err() {
-                            let _ = reply.send(Err("meshtastic client disconnected".into()));
-                        } else {
-                            let _ = reply.send(Ok(()));
-                        }
+                        // Queue the write and request a session key. The write is
+                        // sent (and `reply` completed) once the passkey arrives.
+                        deferred_writes.push(DeferredWrite::Lora { lora, reply: Some(reply) });
+                        request_session_key(&cmd_tx, my_node_num, &mut session_requested, &deferred_writes).await;
                     }
                     MeshtasticAdminRequest::GetOwner { reply } => {
                         let rid = packet_counter.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
@@ -717,26 +837,9 @@ async fn event_loop(
                         }
                     }
                     MeshtasticAdminRequest::SetOwner { long_name, short_name, reply } => {
-                        // Firmware only copies non-empty long_name/short_name from
-                        // the User and never overwrites the PKC public key on a
-                        // SetOwner, so sending empty id/public_key is safe and
-                        // leaves the node identity key intact.
-                        let rid = packet_counter.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-                        let user = User {
-                            id: String::new(),
-                            long_name: long_name.unwrap_or_default(),
-                            short_name: short_name.unwrap_or_default(),
-                            public_key: Vec::new(),
-                        };
-                        let passkey = last_session_passkey.clone();
-                        // Fire-and-forget, consistent with SetLoRaConfig: Meshtastic
-                        // applies the owner change without a reliable admin response.
-                        // Report success once the command has been sent.
-                        if cmd_tx.send(admin_set_owner(my_node_num, rid, user, passkey)).await.is_err() {
-                            let _ = reply.send(Err("meshtastic client disconnected".into()));
-                        } else {
-                            let _ = reply.send(Ok(()));
-                        }
+                        let user = owner_user(long_name.as_deref(), short_name.as_deref());
+                        deferred_writes.push(DeferredWrite::Owner { user, reply: Some(reply) });
+                        request_session_key(&cmd_tx, my_node_num, &mut session_requested, &deferred_writes).await;
                     }
                     MeshtasticAdminRequest::GetSecurity { reply } => {
                         let rid = packet_counter.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
@@ -756,73 +859,59 @@ async fn event_loop(
     }
 }
 
-/// Push the operator's configured radio and node-name settings to the device.
-///
-/// Called once per connection after config sync completes.  Fire-and-forget:
-/// the device applies SetConfig / SetOwner and persists them in flash, so we
-/// don't block on ACKs here.  This is what makes settings configured in setup
-/// or the web UI take effect automatically — no CLI step required.
-///
-/// `SetOwner` is sent with an empty `public_key`; Meshtastic firmware only
-/// copies `long_name`/`short_name` from the message and never overwrites the
-/// node's PKC key from a SetOwner (the key is managed via SecurityConfig), so
-/// the node's identity key is preserved.
-async fn apply_config_on_connect(
-    cmd_tx: &mpsc::Sender<proto::ToRadio>,
-    node_num: u32,
-    cfg: &AutoApplyConfig,
-    packet_counter: &AtomicU32,
-) {
-    use proto::{admin_set_lora_config, admin_set_owner, LoRaConfig, User};
-
-    // Radio config (region + modem preset).
+/// Queue the operator's configured radio and node-name settings as deferred
+/// writes, to be sent once a session passkey is obtained. Called once per
+/// connection after config sync completes — this is what makes settings from
+/// setup or the web UI take effect automatically on connect.
+fn enqueue_auto_apply(cfg: &AutoApplyConfig, deferred: &mut Vec<DeferredWrite>) {
     if let Some(radio) = &cfg.radio {
         if radio.region.is_some() || radio.modem_preset.is_some() {
-            let region = region_str_to_int(radio.region.as_deref().unwrap_or("UNSET"));
-            let preset = preset_str_to_int(radio.modem_preset.as_deref().unwrap_or("LONG_FAST"));
-            let lora = LoRaConfig {
+            let lora = proto::LoRaConfig {
                 use_preset: true,
-                modem_preset: preset,
-                region,
+                modem_preset: preset_str_to_int(
+                    radio.modem_preset.as_deref().unwrap_or("LONG_FAST"),
+                ),
+                region: region_str_to_int(radio.region.as_deref().unwrap_or("UNSET")),
                 ..Default::default()
             };
-            let rid = packet_counter.fetch_add(1, Ordering::Relaxed);
             info!(
                 region = radio.region.as_deref().unwrap_or("UNSET"),
                 modem_preset = radio.modem_preset.as_deref().unwrap_or("LONG_FAST"),
-                "meshtastic: auto-applying radio config from config.toml"
+                "meshtastic: queuing radio config from config.toml for apply-on-connect"
             );
-            if cmd_tx
-                .send(admin_set_lora_config(node_num, rid, lora, Vec::new()))
-                .await
-                .is_err()
-            {
-                warn!("meshtastic: failed to send auto-apply radio config");
-            }
+            deferred.push(DeferredWrite::Lora { lora, reply: None });
         }
     }
-
-    // Node name (long + short).
     if cfg.short_name.is_some() || cfg.long_name.is_some() {
-        let user = User {
-            id: String::new(),
-            long_name: cfg.long_name.clone().unwrap_or_default(),
-            short_name: cfg.short_name.clone().unwrap_or_default(),
-            public_key: Vec::new(),
-        };
-        let rid = packet_counter.fetch_add(1, Ordering::Relaxed);
         info!(
             long_name = cfg.long_name.as_deref().unwrap_or(""),
             short_name = cfg.short_name.as_deref().unwrap_or(""),
-            "meshtastic: auto-applying node name from config.toml"
+            "meshtastic: queuing node name from config.toml for apply-on-connect"
         );
-        if cmd_tx
-            .send(admin_set_owner(node_num, rid, user, Vec::new()))
-            .await
-            .is_err()
-        {
-            warn!("meshtastic: failed to send auto-apply node name");
-        }
+        deferred.push(DeferredWrite::Owner {
+            user: owner_user(cfg.long_name.as_deref(), cfg.short_name.as_deref()),
+            reply: None,
+        });
+    }
+}
+
+/// Request a session key from the device (to authorize queued writes), unless a
+/// request is already outstanding or there is nothing to write.
+async fn request_session_key(
+    cmd_tx: &mpsc::Sender<proto::ToRadio>,
+    node: u32,
+    session_requested: &mut bool,
+    deferred: &[DeferredWrite],
+) {
+    if *session_requested || deferred.is_empty() {
+        return;
+    }
+    if cmd_tx
+        .send(admin_get_session_key(node, random_packet_id()))
+        .await
+        .is_ok()
+    {
+        *session_requested = true;
     }
 }
 
@@ -1030,12 +1119,7 @@ pub async fn apply_radio_from_config(
     baud_override: Option<u32>,
     addr_override: Option<String>,
 ) -> Result<(), String> {
-    use proto::{
-        admin_set_lora_config, from_radio, mesh_packet, want_config, LoRaConfig, PORT_ADMIN_APP,
-    };
-    use std::time::Duration;
-    use stream::ClientEvent;
-    use tokio::time::timeout;
+    use proto::{admin_set_lora_config, LoRaConfig};
 
     let radio_cfg = config.radio.as_ref().ok_or_else(|| {
         "no [plugins.meshtastic.radio] in config.toml — \
@@ -1053,63 +1137,16 @@ pub async fn apply_radio_from_config(
     );
 
     let mut client = make_client(config, port_override, baud_override, addr_override)?;
-
-    timeout(Duration::from_secs(15), async {
-        let cmd_tx = client.sender();
-        let mut my_node_num: Option<u32> = None;
-        let mut sent = false;
-
-        cmd_tx
-            .send(want_config(42))
-            .await
-            .map_err(|_| "send failed".to_owned())?;
-
-        while let Some(event) = client.recv().await {
-            match event {
-                ClientEvent::Connected => {}
-                ClientEvent::Disconnected { .. } => return Err("device disconnected".to_owned()),
-                ClientEvent::FromRadio(msg) => {
-                    if my_node_num.is_none() {
-                        if let Some(from_radio::PayloadVariant::MyInfo(info)) = &msg.payload_variant
-                        {
-                            my_node_num = Some(info.my_node_num);
-                        }
-                    }
-                    if let Some(node_num) = my_node_num {
-                        if !sent {
-                            let lora = LoRaConfig {
-                                use_preset: true,
-                                modem_preset: preset,
-                                region,
-                                ..Default::default()
-                            };
-                            cmd_tx
-                                .send(admin_set_lora_config(node_num, 0x1234_5601, lora, vec![]))
-                                .await
-                                .map_err(|_| "send failed".to_owned())?;
-                            sent = true;
-                        }
-                    }
-                    // Any admin packet after we sent = ACK.
-                    if sent {
-                        if let Some(from_radio::PayloadVariant::Packet(pkt)) = &msg.payload_variant
-                        {
-                            if let Some(mesh_packet::PayloadVariant::Decoded(d)) =
-                                &pkt.payload_variant
-                            {
-                                if d.portnum == PORT_ADMIN_APP {
-                                    return Ok(());
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        }
-        Err("connection closed unexpectedly".to_owned())
+    run_admin_write(&mut client, move |node, passkey| {
+        let lora = LoRaConfig {
+            use_preset: true,
+            modem_preset: preset,
+            region,
+            ..Default::default()
+        };
+        admin_set_lora_config(node, random_packet_id(), lora, passkey)
     })
     .await
-    .map_err(|_| "timed out (15s) — is the device connected and not in use?".to_owned())?
 }
 
 /// Connect to the Meshtastic device and push the node name stored in `config`.
@@ -1122,14 +1159,7 @@ pub async fn apply_owner_from_config(
     baud_override: Option<u32>,
     addr_override: Option<String>,
 ) -> Result<(), String> {
-    use prost::Message as _;
-    use proto::{
-        admin_get_owner, admin_message, admin_set_owner, from_radio, mesh_packet, want_config,
-        AdminMessage, User, PORT_ADMIN_APP,
-    };
-    use std::time::Duration;
-    use stream::ClientEvent;
-    use tokio::time::timeout;
+    use proto::admin_set_owner;
 
     if config.long_name.is_none() && config.short_name.is_none() {
         return Err(
@@ -1140,12 +1170,47 @@ pub async fn apply_owner_from_config(
     }
 
     let mut client = make_client(config, port_override, baud_override, addr_override)?;
+    let user = owner_user(config.long_name.as_deref(), config.short_name.as_deref());
+    eprintln!(
+        "Pushing owner: long_name={:?}, short_name={:?}",
+        user.long_name, user.short_name
+    );
+    run_admin_write(&mut client, move |node, passkey| {
+        admin_set_owner(node, random_packet_id(), user.clone(), passkey)
+    })
+    .await
+}
 
-    timeout(Duration::from_secs(15), async {
+/// Drive a Meshtastic admin WRITE against a freshly-connected device, handling
+/// the full handshake the firmware requires:
+///
+/// 1. `want_config` and wait for `ConfigCompleteId` (the device ignores admin
+///    packets received mid-sync).
+/// 2. Send `get_config_request: SESSIONKEY_CONFIG` and harvest the 8-byte
+///    `session_passkey` the device returns (AdminMessage field 101).
+/// 3. Build the write with that passkey echoed in and send it.
+///
+/// The passkey is what authorizes the write; without it the firmware drops the
+/// admin message. The passkey is valid for ~300 s and must come from a recent
+/// get-response.
+async fn run_admin_write<F>(client: &mut stream::MeshtasticClient, build: F) -> Result<(), String>
+where
+    F: FnOnce(u32, Vec<u8>) -> proto::ToRadio,
+{
+    use prost::Message as _;
+    use proto::{
+        admin_get_session_key, admin_message, from_radio, mesh_packet, want_config, AdminMessage,
+        PORT_ADMIN_APP,
+    };
+    use std::time::Duration;
+    use stream::ClientEvent;
+    use tokio::time::timeout;
+
+    timeout(Duration::from_secs(20), async move {
         let cmd_tx = client.sender();
         let mut my_node_num: Option<u32> = None;
-        let mut existing_owner: Option<User> = None;
-        let mut phase = 0u8; // 0=wait-node-num 1=wait-get-owner-ack 2=wait-set-ack
+        let mut requested_key = false;
+        let sess_req_id = random_packet_id();
 
         cmd_tx
             .send(want_config(42))
@@ -1154,67 +1219,55 @@ pub async fn apply_owner_from_config(
 
         while let Some(event) = client.recv().await {
             match event {
-                ClientEvent::Connected => {}
                 ClientEvent::Disconnected { .. } => return Err("device disconnected".to_owned()),
+                ClientEvent::Connected => {}
                 ClientEvent::FromRadio(msg) => {
-                    if my_node_num.is_none() {
-                        if let Some(from_radio::PayloadVariant::MyInfo(info)) = &msg.payload_variant
-                        {
+                    match &msg.payload_variant {
+                        Some(from_radio::PayloadVariant::MyInfo(info)) => {
                             my_node_num = Some(info.my_node_num);
-                            // Fetch existing owner to preserve public key.
+                        }
+                        Some(from_radio::PayloadVariant::ConfigCompleteId(_)) if !requested_key => {
+                            let Some(node) = my_node_num else {
+                                return Err("config sync completed without a node number".into());
+                            };
+                            // Step 2: request a session key to authorize the write.
                             cmd_tx
-                                .send(admin_get_owner(info.my_node_num, 0x1234_5601))
+                                .send(admin_get_session_key(node, sess_req_id))
                                 .await
                                 .map_err(|_| "send failed".to_owned())?;
-                            phase = 1;
+                            requested_key = true;
                         }
-                    }
-                    if let Some(from_radio::PayloadVariant::Packet(pkt)) = &msg.payload_variant {
-                        if let Some(mesh_packet::PayloadVariant::Decoded(d)) = &pkt.payload_variant
-                        {
-                            if d.portnum == PORT_ADMIN_APP {
-                                if phase == 1 {
+                        Some(from_radio::PayloadVariant::Packet(packet)) if requested_key => {
+                            // Look for the admin response carrying the session passkey.
+                            if let Some(mesh_packet::PayloadVariant::Decoded(d)) =
+                                &packet.payload_variant
+                            {
+                                if d.portnum == PORT_ADMIN_APP {
                                     if let Ok(adm) = AdminMessage::decode(d.payload.as_slice()) {
-                                        if let Some(
-                                            admin_message::PayloadVariant::GetOwnerResponse(u),
-                                        ) = adm.payload_variant
-                                        {
-                                            existing_owner = Some(u);
+                                        // Only act on a get-response (it carries the
+                                        // passkey); ignore our own echoed requests.
+                                        let is_resp = matches!(
+                                            adm.payload_variant,
+                                            Some(admin_message::PayloadVariant::GetConfigResponse(
+                                                _
+                                            ))
+                                        );
+                                        if is_resp || !adm.session_passkey.is_empty() {
+                                            let node = my_node_num.unwrap();
+                                            let pkt = build(node, adm.session_passkey);
+                                            cmd_tx
+                                                .send(pkt)
+                                                .await
+                                                .map_err(|_| "send failed".to_owned())?;
+                                            // Flush before dropping the connection.
+                                            tokio::time::sleep(Duration::from_millis(2000)).await;
+                                            return Ok(());
                                         }
                                     }
-                                    if let Some(owner) = existing_owner.take() {
-                                        let new_user = User {
-                                            id: owner.id,
-                                            long_name: config
-                                                .long_name
-                                                .clone()
-                                                .unwrap_or(owner.long_name),
-                                            short_name: config
-                                                .short_name
-                                                .clone()
-                                                .unwrap_or(owner.short_name),
-                                            public_key: owner.public_key,
-                                        };
-                                        eprintln!(
-                                            "Pushing owner: long_name={:?}, short_name={:?}",
-                                            new_user.long_name, new_user.short_name
-                                        );
-                                        cmd_tx
-                                            .send(admin_set_owner(
-                                                my_node_num.unwrap(),
-                                                0x1234_5602,
-                                                new_user,
-                                                vec![],
-                                            ))
-                                            .await
-                                            .map_err(|_| "send failed".to_owned())?;
-                                        phase = 2;
-                                    }
-                                } else if phase == 2 {
-                                    return Ok(());
                                 }
                             }
                         }
+                        _ => {}
                     }
                 }
             }
@@ -1222,7 +1275,44 @@ pub async fn apply_owner_from_config(
         Err("connection closed unexpectedly".to_owned())
     })
     .await
-    .map_err(|_| "timed out (15s) — is the device connected and not in use?".to_owned())?
+    .map_err(|_| "timed out (20s) — is the device connected and not in use?".to_owned())?
+}
+
+/// Build a Meshtastic owner `User` with firmware-safe field lengths.
+///
+/// The firmware decodes these into fixed buffers — `short_name` is `char[5]`
+/// (max **4** chars + null) and `long_name` is `char[40]` (max **39**). A value
+/// that overflows makes the device reject the *entire* admin message with
+/// `Can't decode protobuf reason='string overflow'`, so we clamp here. `id` and
+/// `public_key` are left empty: firmware ignores them on SetOwner and never
+/// overwrites the node's PKC key from one.
+fn owner_user(long_name: Option<&str>, short_name: Option<&str>) -> proto::User {
+    fn clamp(s: &str, max_chars: usize) -> String {
+        s.chars().take(max_chars).collect()
+    }
+    proto::User {
+        id: String::new(),
+        long_name: long_name.map(|s| clamp(s, 39)).unwrap_or_default(),
+        short_name: short_name.map(|s| clamp(s, 4)).unwrap_or_default(),
+        public_key: Vec::new(),
+    }
+}
+
+/// Generate an unpredictable, non-zero 32-bit packet id.
+///
+/// Meshtastic deduplicates received packets by `(from, id)`. Reusing fixed or
+/// process-restart-repeating ids causes the device to silently discard our
+/// admin packets as duplicates, so each packet needs a fresh, varied id —
+/// exactly what the Meshtastic app does (it uses random ids).
+fn random_packet_id() -> u32 {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.subsec_nanos() ^ (d.as_secs() as u32))
+        .unwrap_or(0);
+    // Mix and ensure non-zero.
+    let id = nanos.wrapping_mul(2_654_435_761).rotate_left(13) ^ 0x9E37_79B9;
+    id | 1
 }
 
 /// Build a [`MeshtasticClient`] from config + optional CLI overrides.
@@ -1784,6 +1874,7 @@ serial_port = "/dev/ttyAMA0"
             via_mqtt: false,
             hop_start: 0,
             public_key: Vec::new(),
+            pki_encrypted: false,
         };
         assert_eq!(text_payload(&packet), Some("hello".to_owned()));
     }

--- a/crates/bbs-meshtastic/src/lib.rs
+++ b/crates/bbs-meshtastic/src/lib.rs
@@ -523,6 +523,16 @@ enum PendingMeshtasticAdmin {
     },
 }
 
+/// True when the caller waiting on a pending GET has dropped its receiver
+/// (i.e. timed out and given up), so the pending op can be safely discarded.
+fn pending_reply_abandoned(op: &PendingMeshtasticAdmin) -> bool {
+    match op {
+        PendingMeshtasticAdmin::GetLora { reply, .. } => reply.is_closed(),
+        PendingMeshtasticAdmin::GetOwner { reply, .. } => reply.is_closed(),
+        PendingMeshtasticAdmin::GetSecurity { reply, .. } => reply.is_closed(),
+    }
+}
+
 #[allow(clippy::too_many_arguments)]
 async fn event_loop(
     mut client: MeshtasticClient,
@@ -547,9 +557,21 @@ async fn event_loop(
     // Whether we've pushed the config.toml settings to the device on this
     // connection. Reset on disconnect so settings re-apply after a reconnect.
     let mut auto_applied = false;
+    // Periodically reap a pending GET whose caller has given up (its oneshot
+    // receiver was dropped after the caller's own timeout). Without this, a GET
+    // that never gets a device response would leave `pending_admin` set forever
+    // and block every later admin operation with "another operation in progress".
+    let mut reap = tokio::time::interval(Duration::from_secs(2));
+    reap.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
 
     loop {
         tokio::select! {
+            _ = reap.tick() => {
+                if pending_admin.as_ref().is_some_and(pending_reply_abandoned) {
+                    warn!("meshtastic: clearing abandoned pending admin GET (no device response)");
+                    pending_admin = None;
+                }
+            }
             event = client.recv() => match event {
                 Some(ClientEvent::Connected) => {
                     info!("meshtastic: connected to radio");

--- a/crates/bbs-meshtastic/src/lib.rs
+++ b/crates/bbs-meshtastic/src/lib.rs
@@ -835,6 +835,301 @@ fn hex_encode(bytes: &[u8]) -> String {
         })
 }
 
+// ── CLI helpers — direct device config push ───────────────────────────────────
+
+fn region_str_to_int(name: &str) -> i32 {
+    match name {
+        "US" => 1,
+        "EU_433" => 2,
+        "EU_868" => 3,
+        "CN" => 4,
+        "JP" => 5,
+        "ANZ" => 6,
+        "KR" => 7,
+        "TW" => 8,
+        "RU" => 9,
+        "IN" => 10,
+        "NZ_865" => 11,
+        "TH" => 12,
+        "LORA_24" => 13,
+        "UA_433" => 14,
+        "UA_868" => 15,
+        "MY_433" => 16,
+        "MY_919" => 17,
+        "SG_923" => 18,
+        _ => 0, // UNSET
+    }
+}
+
+fn preset_str_to_int(name: &str) -> i32 {
+    match name {
+        "LONG_FAST" => 0,
+        "LONG_SLOW" => 1,
+        "VERY_LONG_SLOW" => 2,
+        "MEDIUM_SLOW" => 3,
+        "MEDIUM_FAST" => 4,
+        "SHORT_SLOW" => 5,
+        "SHORT_FAST" => 6,
+        "LONG_MODERATE" => 7,
+        "SHORT_TURBO" => 8,
+        "LONG_TURBO" => 9,
+        "LITE_FAST" => 10,
+        "LITE_SLOW" => 11,
+        "NARROW_FAST" => 12,
+        "NARROW_SLOW" => 13,
+        _ => 0, // LONG_FAST
+    }
+}
+
+/// Connect to the Meshtastic device and push the LoRa radio config stored in
+/// `config`.  Returns `Ok(())` on success or an error string.
+///
+/// Resolves the connection parameters in order: flag overrides → config values.
+/// The BBS must **not** be running on the same port when this is called.
+pub async fn apply_radio_from_config(
+    config: &MeshtasticConfig,
+    port_override: Option<String>,
+    baud_override: Option<u32>,
+    addr_override: Option<String>,
+) -> Result<(), String> {
+    use proto::{
+        admin_set_lora_config, from_radio, mesh_packet, want_config, LoRaConfig, PORT_ADMIN_APP,
+    };
+    use std::time::Duration;
+    use stream::ClientEvent;
+    use tokio::time::timeout;
+
+    let radio_cfg = config.radio.as_ref().ok_or_else(|| {
+        "no [plugins.meshtastic.radio] in config.toml — \
+         run 'supply-drop-bbs setup' to configure"
+            .to_owned()
+    })?;
+    let region = region_str_to_int(radio_cfg.region.as_deref().unwrap_or("UNSET"));
+    let preset = preset_str_to_int(radio_cfg.modem_preset.as_deref().unwrap_or("LONG_FAST"));
+    eprintln!(
+        "Pushing radio config: region={} ({}), modem_preset={} ({})",
+        region,
+        radio_cfg.region.as_deref().unwrap_or("UNSET"),
+        preset,
+        radio_cfg.modem_preset.as_deref().unwrap_or("LONG_FAST"),
+    );
+
+    let mut client = make_client(config, port_override, baud_override, addr_override)?;
+
+    timeout(Duration::from_secs(15), async {
+        let cmd_tx = client.sender();
+        let mut my_node_num: Option<u32> = None;
+        let mut sent = false;
+
+        cmd_tx
+            .send(want_config(42))
+            .await
+            .map_err(|_| "send failed".to_owned())?;
+
+        while let Some(event) = client.recv().await {
+            match event {
+                ClientEvent::Connected => {}
+                ClientEvent::Disconnected { .. } => return Err("device disconnected".to_owned()),
+                ClientEvent::FromRadio(msg) => {
+                    if my_node_num.is_none() {
+                        if let Some(from_radio::PayloadVariant::MyInfo(info)) = &msg.payload_variant
+                        {
+                            my_node_num = Some(info.my_node_num);
+                        }
+                    }
+                    if let Some(node_num) = my_node_num {
+                        if !sent {
+                            let lora = LoRaConfig {
+                                use_preset: true,
+                                modem_preset: preset,
+                                region,
+                                ..Default::default()
+                            };
+                            cmd_tx
+                                .send(admin_set_lora_config(node_num, 0x1234_5601, lora, vec![]))
+                                .await
+                                .map_err(|_| "send failed".to_owned())?;
+                            sent = true;
+                        }
+                    }
+                    // Any admin packet after we sent = ACK.
+                    if sent {
+                        if let Some(from_radio::PayloadVariant::Packet(pkt)) = &msg.payload_variant
+                        {
+                            if let Some(mesh_packet::PayloadVariant::Decoded(d)) =
+                                &pkt.payload_variant
+                            {
+                                if d.portnum == PORT_ADMIN_APP {
+                                    return Ok(());
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        Err("connection closed unexpectedly".to_owned())
+    })
+    .await
+    .map_err(|_| "timed out (15s) — is the device connected and not in use?".to_owned())?
+}
+
+/// Connect to the Meshtastic device and push the node name stored in `config`.
+///
+/// Fetches the existing owner first to preserve the PKC public key, then
+/// merges in `long_name` and `short_name` from config and sends `SetOwner`.
+pub async fn apply_owner_from_config(
+    config: &MeshtasticConfig,
+    port_override: Option<String>,
+    baud_override: Option<u32>,
+    addr_override: Option<String>,
+) -> Result<(), String> {
+    use prost::Message as _;
+    use proto::{
+        admin_get_owner, admin_message, admin_set_owner, from_radio, mesh_packet, want_config,
+        AdminMessage, User, PORT_ADMIN_APP,
+    };
+    use std::time::Duration;
+    use stream::ClientEvent;
+    use tokio::time::timeout;
+
+    if config.long_name.is_none() && config.short_name.is_none() {
+        return Err(
+            "neither long_name nor short_name is set in [plugins.meshtastic] — \
+             run 'supply-drop-bbs setup' or add them manually to config.toml"
+                .to_owned(),
+        );
+    }
+
+    let mut client = make_client(config, port_override, baud_override, addr_override)?;
+
+    timeout(Duration::from_secs(15), async {
+        let cmd_tx = client.sender();
+        let mut my_node_num: Option<u32> = None;
+        let mut existing_owner: Option<User> = None;
+        let mut phase = 0u8; // 0=wait-node-num 1=wait-get-owner-ack 2=wait-set-ack
+
+        cmd_tx
+            .send(want_config(42))
+            .await
+            .map_err(|_| "send failed".to_owned())?;
+
+        while let Some(event) = client.recv().await {
+            match event {
+                ClientEvent::Connected => {}
+                ClientEvent::Disconnected { .. } => return Err("device disconnected".to_owned()),
+                ClientEvent::FromRadio(msg) => {
+                    if my_node_num.is_none() {
+                        if let Some(from_radio::PayloadVariant::MyInfo(info)) = &msg.payload_variant
+                        {
+                            my_node_num = Some(info.my_node_num);
+                            // Fetch existing owner to preserve public key.
+                            cmd_tx
+                                .send(admin_get_owner(info.my_node_num, 0x1234_5601))
+                                .await
+                                .map_err(|_| "send failed".to_owned())?;
+                            phase = 1;
+                        }
+                    }
+                    if let Some(from_radio::PayloadVariant::Packet(pkt)) = &msg.payload_variant {
+                        if let Some(mesh_packet::PayloadVariant::Decoded(d)) = &pkt.payload_variant
+                        {
+                            if d.portnum == PORT_ADMIN_APP {
+                                if phase == 1 {
+                                    if let Ok(adm) = AdminMessage::decode(d.payload.as_slice()) {
+                                        if let Some(
+                                            admin_message::PayloadVariant::GetOwnerResponse(u),
+                                        ) = adm.payload_variant
+                                        {
+                                            existing_owner = Some(u);
+                                        }
+                                    }
+                                    if let Some(owner) = existing_owner.take() {
+                                        let new_user = User {
+                                            id: owner.id,
+                                            long_name: config
+                                                .long_name
+                                                .clone()
+                                                .unwrap_or(owner.long_name),
+                                            short_name: config
+                                                .short_name
+                                                .clone()
+                                                .unwrap_or(owner.short_name),
+                                            public_key: owner.public_key,
+                                        };
+                                        eprintln!(
+                                            "Pushing owner: long_name={:?}, short_name={:?}",
+                                            new_user.long_name, new_user.short_name
+                                        );
+                                        cmd_tx
+                                            .send(admin_set_owner(
+                                                my_node_num.unwrap(),
+                                                0x1234_5602,
+                                                new_user,
+                                                vec![],
+                                            ))
+                                            .await
+                                            .map_err(|_| "send failed".to_owned())?;
+                                        phase = 2;
+                                    }
+                                } else if phase == 2 {
+                                    return Ok(());
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        Err("connection closed unexpectedly".to_owned())
+    })
+    .await
+    .map_err(|_| "timed out (15s) — is the device connected and not in use?".to_owned())?
+}
+
+/// Build a [`MeshtasticClient`] from config + optional CLI overrides.
+fn make_client(
+    config: &MeshtasticConfig,
+    port_override: Option<String>,
+    baud_override: Option<u32>,
+    addr_override: Option<String>,
+) -> Result<stream::MeshtasticClient, String> {
+    use std::time::Duration;
+    use stream::{SerialConfig, TcpConfig};
+
+    match config.connection_type {
+        MeshtasticConnectionType::Serial | MeshtasticConnectionType::Hat => {
+            let port = port_override
+                .or_else(|| config.serial_port.clone())
+                .ok_or_else(|| {
+                    "no serial port — use --port or set serial_port in \
+                     [plugins.meshtastic] in config.toml"
+                        .to_owned()
+                })?;
+            let baud = baud_override.unwrap_or(config.baud_rate);
+            eprintln!("Connecting to {port} at {baud} baud…");
+            Ok(stream::MeshtasticClient::connect_serial(SerialConfig {
+                port,
+                baud_rate: baud,
+                reconnect_delay_initial: Duration::from_secs(1),
+                reconnect_delay_max: Duration::from_secs(1),
+            }))
+        }
+        MeshtasticConnectionType::Tcp => {
+            let addr_str = addr_override.unwrap_or_else(|| config.addr.to_string());
+            let addr: std::net::SocketAddr = addr_str
+                .parse()
+                .map_err(|e| format!("invalid TCP address '{addr_str}': {e}"))?;
+            eprintln!("Connecting to {addr}…");
+            Ok(stream::MeshtasticClient::connect_tcp(TcpConfig {
+                addr,
+                reconnect_delay_initial: Duration::from_secs(1),
+                reconnect_delay_max: Duration::from_secs(1),
+            }))
+        }
+    }
+}
+
 #[allow(clippy::too_many_arguments)]
 async fn handle_from_radio(
     msg: proto::FromRadio,

--- a/crates/bbs-meshtastic/src/proto.rs
+++ b/crates/bbs-meshtastic/src/proto.rs
@@ -402,16 +402,25 @@ fn admin_packet(to_node: u32, request_id: u32, admin: AdminMessage) -> ToRadio {
                 portnum: PORT_ADMIN_APP,
                 payload: admin.encode_to_vec(),
                 want_response: true,
-                dest: to_node,
-                source: to_node,
-                request_id,
+                // dest/source/request_id/reply_id must be 0 on an outbound
+                // request — they are only populated on *responses*. Setting
+                // source/dest to the node's own number makes the firmware treat
+                // the packet as self-originated and silently ignore it (no admin
+                // response, and SET commands never apply). The response is
+                // correlated via the MeshPacket `id` below, which the device
+                // echoes back in the response's `request_id`.
+                dest: 0,
+                source: 0,
+                request_id: 0,
                 reply_id: 0,
             })),
             id: request_id,
             rx_time: 0,
             rx_snr: 0.0,
             hop_limit: 0,
-            want_ack: false,
+            // Request a delivery ack as well, matching the Meshtastic app's
+            // admin-message behavior.
+            want_ack: true,
             priority: PRIORITY_RELIABLE,
             rx_rssi: 0,
             via_mqtt: false,

--- a/crates/bbs-meshtastic/src/proto.rs
+++ b/crates/bbs-meshtastic/src/proto.rs
@@ -174,14 +174,22 @@ pub struct NodeInfo {
     pub last_heard: u32,
 }
 
+/// Meshtastic node owner/user info (`mesh.proto User`).
+///
+/// Used in `NodeInfo` (received during config sync) and in admin owner
+/// get/set operations (`AdminMessage` fields 3/4/32).
 #[derive(Clone, PartialEq, Message)]
 pub struct User {
+    /// Unique node ID string, e.g. `"!aabbccdd"` (hex of the 32-bit node number).
     #[prost(string, tag = "1")]
     pub id: String,
+    /// Full display name (~39 chars max in firmware).
     #[prost(string, tag = "2")]
     pub long_name: String,
+    /// Short display name shown on OLED/mesh maps. Firmware enforces ≤ 4 chars.
     #[prost(string, tag = "3")]
     pub short_name: String,
+    /// Node's Curve25519 public key (32 bytes), broadcast on the mesh for PKC DMs.
     #[prost(bytes = "vec", tag = "8")]
     pub public_key: Vec<u8>,
 }
@@ -271,29 +279,71 @@ pub fn synthetic_pubkey(node_num: u32) -> [u8; 32] {
 }
 
 pub const PORT_ADMIN_APP: i32 = 67;
+/// `config_type` for `GetConfigRequest` — LoRa radio config (`Config.lora`, field 6).
+pub const CONFIG_TYPE_LORA: i32 = 5;
+/// `config_type` for `GetConfigRequest` — Security / PKC config (`Config.security`, field 8).
+pub const CONFIG_TYPE_SECURITY: i32 = 7;
 
+// ── Admin proto types (admin.proto + mesh.proto, subset) ──────────────────────
+// Note: `User` is already defined above (re-used for NodeInfo; same fields).
+
+/// Meshtastic security config (`config.proto Config.SecurityConfig`, subset).
+#[derive(Clone, PartialEq, Message)]
+pub struct SecurityConfig {
+    /// Node's Curve25519 public key — shared with mesh peers.
+    #[prost(bytes = "vec", tag = "1")]
+    pub public_key: Vec<u8>,
+    /// Node's Curve25519 private key (on-device; only visible if serial is enabled).
+    #[prost(bytes = "vec", tag = "2")]
+    pub private_key: Vec<u8>,
+    /// Allow admin commands over the legacy unencrypted admin channel.
+    #[prost(bool, tag = "8")]
+    pub admin_channel_enabled: bool,
+}
+
+/// Meshtastic admin message (`admin.proto AdminMessage`).
+///
+/// Field numbers match the current Meshtastic admin.proto.  The `session_passkey`
+/// (field 101) is a replay-attack guard: the device returns it in every GET
+/// response and the client must echo it back in SET commands within 300 s.
 #[derive(Clone, PartialEq, Message)]
 pub struct AdminMessage {
-    #[prost(oneof = "admin_message::PayloadVariant", tags = "6, 11, 13")]
+    #[prost(oneof = "admin_message::PayloadVariant", tags = "3, 4, 5, 6, 32, 34")]
     pub payload_variant: Option<admin_message::PayloadVariant>,
+    /// Replay-attack guard — echo back in all SET commands.
+    #[prost(bytes = "vec", tag = "101")]
+    pub session_passkey: Vec<u8>,
 }
 
 pub mod admin_message {
     use super::*;
     #[derive(Clone, PartialEq, Oneof)]
     pub enum PayloadVariant {
+        /// Request the node's owner/user info (send `true`).
+        #[prost(bool, tag = "3")]
+        GetOwnerRequest(bool),
+        /// Node's owner/user info (response to `GetOwnerRequest`).
+        #[prost(message, tag = "4")]
+        GetOwnerResponse(super::User),
+        /// Request a config type (`ConfigType` enum: 5 = LoRa, 7 = Security).
+        #[prost(int32, tag = "5")]
+        GetConfigRequest(i32),
+        /// Config payload (response to `GetConfigRequest`).
         #[prost(message, tag = "6")]
         GetConfigResponse(super::MtConfig),
-        #[prost(message, tag = "11")]
+        /// Update the node's owner/user info.
+        #[prost(message, tag = "32")]
+        SetOwner(super::User),
+        /// Update a config section.
+        #[prost(message, tag = "34")]
         SetConfig(super::MtConfig),
-        #[prost(int32, tag = "13")]
-        GetConfigRequest(i32),
     }
 }
 
+/// Subset of Meshtastic `Config` (`config.proto Config`).
 #[derive(Clone, PartialEq, Message)]
 pub struct MtConfig {
-    #[prost(oneof = "mt_config::PayloadVariant", tags = "3")]
+    #[prost(oneof = "mt_config::PayloadVariant", tags = "6, 8")]
     pub payload_variant: Option<mt_config::PayloadVariant>,
 }
 
@@ -301,8 +351,12 @@ pub mod mt_config {
     use super::*;
     #[derive(Clone, PartialEq, Oneof)]
     pub enum PayloadVariant {
-        #[prost(message, tag = "3")]
+        /// `Config.lora` — LoRa radio parameters (field 6 in Config oneof).
+        #[prost(message, tag = "6")]
         Lora(super::LoRaConfig),
+        /// `Config.security` — PKC / key settings (field 8 in Config oneof).
+        #[prost(message, tag = "8")]
+        Security(super::SecurityConfig),
     }
 }
 
@@ -334,16 +388,11 @@ pub struct LoRaConfig {
     pub override_frequency: f32,
 }
 
-/// CONFIG_TYPE_LORA = 5
-pub const CONFIG_TYPE_LORA: i32 = 5;
+// ── Admin packet helpers ──────────────────────────────────────────────────────
 
-pub fn admin_get_lora_config(to_node: u32, request_id: u32) -> ToRadio {
+/// Wrap an encoded `AdminMessage` in a `ToRadio` admin packet.
+fn admin_packet(to_node: u32, request_id: u32, admin: AdminMessage) -> ToRadio {
     use prost::Message as _;
-    let admin = AdminMessage {
-        payload_variant: Some(admin_message::PayloadVariant::GetConfigRequest(
-            CONFIG_TYPE_LORA,
-        )),
-    };
     ToRadio {
         payload_variant: Some(to_radio::PayloadVariant::Packet(MeshPacket {
             from: 0,
@@ -372,39 +421,80 @@ pub fn admin_get_lora_config(to_node: u32, request_id: u32) -> ToRadio {
     }
 }
 
-pub fn admin_set_lora_config(to_node: u32, request_id: u32, config: LoRaConfig) -> ToRadio {
-    use prost::Message as _;
-    let admin = AdminMessage {
-        payload_variant: Some(admin_message::PayloadVariant::SetConfig(MtConfig {
-            payload_variant: Some(mt_config::PayloadVariant::Lora(config)),
-        })),
-    };
-    ToRadio {
-        payload_variant: Some(to_radio::PayloadVariant::Packet(MeshPacket {
-            from: 0,
-            to: to_node,
-            channel: 0,
-            payload_variant: Some(mesh_packet::PayloadVariant::Decoded(Data {
-                portnum: PORT_ADMIN_APP,
-                payload: admin.encode_to_vec(),
-                want_response: true,
-                dest: to_node,
-                source: to_node,
-                request_id,
-                reply_id: 0,
+/// Build a `GetConfigRequest` for the LoRa config.
+pub fn admin_get_lora_config(to_node: u32, request_id: u32) -> ToRadio {
+    admin_packet(
+        to_node,
+        request_id,
+        AdminMessage {
+            payload_variant: Some(admin_message::PayloadVariant::GetConfigRequest(
+                CONFIG_TYPE_LORA,
+            )),
+            session_passkey: Vec::new(),
+        },
+    )
+}
+
+/// Build a `SetConfig` for the LoRa config, echoing back the session passkey.
+pub fn admin_set_lora_config(
+    to_node: u32,
+    request_id: u32,
+    config: LoRaConfig,
+    session_passkey: Vec<u8>,
+) -> ToRadio {
+    admin_packet(
+        to_node,
+        request_id,
+        AdminMessage {
+            payload_variant: Some(admin_message::PayloadVariant::SetConfig(MtConfig {
+                payload_variant: Some(mt_config::PayloadVariant::Lora(config)),
             })),
-            id: request_id,
-            rx_time: 0,
-            rx_snr: 0.0,
-            hop_limit: 0,
-            want_ack: false,
-            priority: PRIORITY_RELIABLE,
-            rx_rssi: 0,
-            via_mqtt: false,
-            hop_start: 0,
-            public_key: Vec::new(),
-        })),
-    }
+            session_passkey,
+        },
+    )
+}
+
+/// Build a `GetOwnerRequest`.
+pub fn admin_get_owner(to_node: u32, request_id: u32) -> ToRadio {
+    admin_packet(
+        to_node,
+        request_id,
+        AdminMessage {
+            payload_variant: Some(admin_message::PayloadVariant::GetOwnerRequest(true)),
+            session_passkey: Vec::new(),
+        },
+    )
+}
+
+/// Build a `SetOwner` command, echoing back the session passkey.
+pub fn admin_set_owner(
+    to_node: u32,
+    request_id: u32,
+    user: User,
+    session_passkey: Vec<u8>,
+) -> ToRadio {
+    admin_packet(
+        to_node,
+        request_id,
+        AdminMessage {
+            payload_variant: Some(admin_message::PayloadVariant::SetOwner(user)),
+            session_passkey,
+        },
+    )
+}
+
+/// Build a `GetConfigRequest` for the Security config.
+pub fn admin_get_security_config(to_node: u32, request_id: u32) -> ToRadio {
+    admin_packet(
+        to_node,
+        request_id,
+        AdminMessage {
+            payload_variant: Some(admin_message::PayloadVariant::GetConfigRequest(
+                CONFIG_TYPE_SECURITY,
+            )),
+            session_passkey: Vec::new(),
+        },
+    )
 }
 
 #[cfg(test)]

--- a/crates/bbs-meshtastic/src/proto.rs
+++ b/crates/bbs-meshtastic/src/proto.rs
@@ -270,6 +270,143 @@ pub fn synthetic_pubkey(node_num: u32) -> [u8; 32] {
     key
 }
 
+pub const PORT_ADMIN_APP: i32 = 67;
+
+#[derive(Clone, PartialEq, Message)]
+pub struct AdminMessage {
+    #[prost(oneof = "admin_message::PayloadVariant", tags = "6, 11, 13")]
+    pub payload_variant: Option<admin_message::PayloadVariant>,
+}
+
+pub mod admin_message {
+    use super::*;
+    #[derive(Clone, PartialEq, Oneof)]
+    pub enum PayloadVariant {
+        #[prost(message, tag = "6")]
+        GetConfigResponse(super::MtConfig),
+        #[prost(message, tag = "11")]
+        SetConfig(super::MtConfig),
+        #[prost(int32, tag = "13")]
+        GetConfigRequest(i32),
+    }
+}
+
+#[derive(Clone, PartialEq, Message)]
+pub struct MtConfig {
+    #[prost(oneof = "mt_config::PayloadVariant", tags = "3")]
+    pub payload_variant: Option<mt_config::PayloadVariant>,
+}
+
+pub mod mt_config {
+    use super::*;
+    #[derive(Clone, PartialEq, Oneof)]
+    pub enum PayloadVariant {
+        #[prost(message, tag = "3")]
+        Lora(super::LoRaConfig),
+    }
+}
+
+#[derive(Clone, PartialEq, Message)]
+pub struct LoRaConfig {
+    #[prost(bool, tag = "1")]
+    pub use_preset: bool,
+    #[prost(int32, tag = "2")]
+    pub modem_preset: i32,
+    #[prost(uint32, tag = "3")]
+    pub bandwidth: u32,
+    #[prost(uint32, tag = "4")]
+    pub spread_factor: u32,
+    #[prost(uint32, tag = "5")]
+    pub coding_rate: u32,
+    #[prost(float, tag = "6")]
+    pub frequency_offset: f32,
+    #[prost(int32, tag = "7")]
+    pub region: i32,
+    #[prost(uint32, tag = "8")]
+    pub hop_limit: u32,
+    #[prost(bool, tag = "9")]
+    pub tx_enabled: bool,
+    #[prost(int32, tag = "10")]
+    pub tx_power: i32,
+    #[prost(uint32, tag = "11")]
+    pub channel_num: u32,
+    #[prost(float, tag = "14")]
+    pub override_frequency: f32,
+}
+
+/// CONFIG_TYPE_LORA = 5
+pub const CONFIG_TYPE_LORA: i32 = 5;
+
+pub fn admin_get_lora_config(to_node: u32, request_id: u32) -> ToRadio {
+    use prost::Message as _;
+    let admin = AdminMessage {
+        payload_variant: Some(admin_message::PayloadVariant::GetConfigRequest(
+            CONFIG_TYPE_LORA,
+        )),
+    };
+    ToRadio {
+        payload_variant: Some(to_radio::PayloadVariant::Packet(MeshPacket {
+            from: 0,
+            to: to_node,
+            channel: 0,
+            payload_variant: Some(mesh_packet::PayloadVariant::Decoded(Data {
+                portnum: PORT_ADMIN_APP,
+                payload: admin.encode_to_vec(),
+                want_response: true,
+                dest: to_node,
+                source: to_node,
+                request_id,
+                reply_id: 0,
+            })),
+            id: request_id,
+            rx_time: 0,
+            rx_snr: 0.0,
+            hop_limit: 0,
+            want_ack: false,
+            priority: PRIORITY_RELIABLE,
+            rx_rssi: 0,
+            via_mqtt: false,
+            hop_start: 0,
+            public_key: Vec::new(),
+        })),
+    }
+}
+
+pub fn admin_set_lora_config(to_node: u32, request_id: u32, config: LoRaConfig) -> ToRadio {
+    use prost::Message as _;
+    let admin = AdminMessage {
+        payload_variant: Some(admin_message::PayloadVariant::SetConfig(MtConfig {
+            payload_variant: Some(mt_config::PayloadVariant::Lora(config)),
+        })),
+    };
+    ToRadio {
+        payload_variant: Some(to_radio::PayloadVariant::Packet(MeshPacket {
+            from: 0,
+            to: to_node,
+            channel: 0,
+            payload_variant: Some(mesh_packet::PayloadVariant::Decoded(Data {
+                portnum: PORT_ADMIN_APP,
+                payload: admin.encode_to_vec(),
+                want_response: true,
+                dest: to_node,
+                source: to_node,
+                request_id,
+                reply_id: 0,
+            })),
+            id: request_id,
+            rx_time: 0,
+            rx_snr: 0.0,
+            hop_limit: 0,
+            want_ack: false,
+            priority: PRIORITY_RELIABLE,
+            rx_rssi: 0,
+            via_mqtt: false,
+            hop_start: 0,
+            public_key: Vec::new(),
+        })),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/bbs-meshtastic/src/proto.rs
+++ b/crates/bbs-meshtastic/src/proto.rs
@@ -90,6 +90,12 @@ pub struct MeshPacket {
     pub hop_start: u32,
     #[prost(bytes = "vec", tag = "16")]
     pub public_key: Vec<u8>,
+    /// Marks the packet as using public-key cryptography. The Meshtastic app
+    /// sets this on admin messages to the local node; firmware with PKC enabled
+    /// and the legacy admin channel disabled requires it, otherwise the admin
+    /// request is silently dropped.
+    #[prost(bool, tag = "17")]
+    pub pki_encrypted: bool,
 }
 
 pub mod mesh_packet {
@@ -261,6 +267,7 @@ pub fn direct_text_packet(
             via_mqtt: false,
             hop_start: 0,
             public_key: Vec::new(),
+            pki_encrypted: false,
         })),
     }
 }
@@ -278,11 +285,19 @@ pub fn synthetic_pubkey(node_num: u32) -> [u8; 32] {
     key
 }
 
-pub const PORT_ADMIN_APP: i32 = 67;
+/// Meshtastic `PortNum::ADMIN_APP`. This is **6**, not 67 — 67 is
+/// `TELEMETRY_APP`. Sending admin messages on 67 makes the device's telemetry
+/// module consume them and the admin module never processes them.
+pub const PORT_ADMIN_APP: i32 = 6;
 /// `config_type` for `GetConfigRequest` — LoRa radio config (`Config.lora`, field 6).
 pub const CONFIG_TYPE_LORA: i32 = 5;
 /// `config_type` for `GetConfigRequest` — Security / PKC config (`Config.security`, field 8).
 pub const CONFIG_TYPE_SECURITY: i32 = 7;
+/// `config_type` for `GetConfigRequest` — session key. Requesting this opens the
+/// admin session for the connection; current Meshtastic firmware silently drops
+/// admin *writes* that aren't preceded by it. The Meshtastic app sends this
+/// before every admin set.
+pub const CONFIG_TYPE_SESSIONKEY: i32 = 8;
 
 // ── Admin proto types (admin.proto + mesh.proto, subset) ──────────────────────
 // Note: `User` is already defined above (re-used for NodeInfo; same fields).
@@ -417,15 +432,18 @@ fn admin_packet(to_node: u32, request_id: u32, admin: AdminMessage) -> ToRadio {
             id: request_id,
             rx_time: 0,
             rx_snr: 0.0,
-            hop_limit: 0,
-            // Request a delivery ack as well, matching the Meshtastic app's
-            // admin-message behavior.
+            hop_limit: 3,
             want_ack: true,
             priority: PRIORITY_RELIABLE,
             rx_rssi: 0,
             via_mqtt: false,
             hop_start: 0,
             public_key: Vec::new(),
+            // Plaintext local-serial admin. Must be false: with it set, the
+            // firmware tries to PKI-decrypt our plaintext payload into garbage
+            // ("Can't decode protobuf"). The local trusted path (from==0) needs
+            // no encryption.
+            pki_encrypted: false,
         })),
     }
 }
@@ -500,6 +518,22 @@ pub fn admin_get_security_config(to_node: u32, request_id: u32) -> ToRadio {
         AdminMessage {
             payload_variant: Some(admin_message::PayloadVariant::GetConfigRequest(
                 CONFIG_TYPE_SECURITY,
+            )),
+            session_passkey: Vec::new(),
+        },
+    )
+}
+
+/// Build a session-key `GetConfigRequest`. Send this immediately before an
+/// admin write to open the admin session — firmware drops writes that aren't
+/// preceded by it.
+pub fn admin_get_session_key(to_node: u32, request_id: u32) -> ToRadio {
+    admin_packet(
+        to_node,
+        request_id,
+        AdminMessage {
+            payload_variant: Some(admin_message::PayloadVariant::GetConfigRequest(
+                CONFIG_TYPE_SESSIONKEY,
             )),
             session_passkey: Vec::new(),
         },

--- a/crates/bbs-meshtastic/src/stream.rs
+++ b/crates/bbs-meshtastic/src/stream.rs
@@ -187,7 +187,7 @@ where
         tokio::select! {
             frame = read_from_radio(reader) => match frame {
                 Ok(frame) => {
-                    debug!("meshtastic: rx FromRadio");
+                    debug!(frame = %describe_from_radio(&frame), "meshtastic: rx FromRadio");
                     if event_tx.send(ClientEvent::FromRadio(frame)).await.is_err() {
                         return SessionOutcome::Shutdown;
                     }
@@ -237,6 +237,34 @@ async fn write_to_radio<W: AsyncWrite + Unpin>(writer: &mut W, msg: &ToRadio) ->
         ));
     }
     writer.write_all(&wire).await
+}
+
+/// One-line human description of a `FromRadio` frame for debug logging.
+///
+/// For packets it includes the portnum and request_id/reply_id so that admin
+/// responses (portnum 67) and their correlation IDs are visible in the log —
+/// essential for diagnosing whether the device answers admin GET requests.
+fn describe_from_radio(frame: &FromRadio) -> String {
+    use crate::proto::{from_radio::PayloadVariant as P, mesh_packet::PayloadVariant as MP};
+    match &frame.payload_variant {
+        Some(P::MyInfo(i)) => format!("MyInfo(node=0x{:08x})", i.my_node_num),
+        Some(P::NodeInfo(_)) => "NodeInfo".to_owned(),
+        Some(P::ConfigCompleteId(id)) => format!("ConfigCompleteId({id})"),
+        Some(P::Rebooted(_)) => "Rebooted".to_owned(),
+        Some(P::Packet(p)) => match &p.payload_variant {
+            Some(MP::Decoded(d)) => format!(
+                "Packet(port={}, from=0x{:08x}, req_id={}, reply_id={}, {}B)",
+                d.portnum,
+                p.from,
+                d.request_id,
+                d.reply_id,
+                d.payload.len()
+            ),
+            Some(MP::Encrypted(_)) => "Packet(encrypted)".to_owned(),
+            None => "Packet(empty)".to_owned(),
+        },
+        None => "<empty>".to_owned(),
+    }
 }
 
 pub async fn read_from_radio<R: AsyncRead + Unpin>(reader: &mut R) -> io::Result<FromRadio> {

--- a/crates/bbs-plugin-api/src/admin.rs
+++ b/crates/bbs-plugin-api/src/admin.rs
@@ -254,6 +254,33 @@ pub struct MeshtasticLoRaConfig {
     pub override_frequency: f32,
 }
 
+/// Meshtastic node owner / identity info.
+///
+/// Returned by [`crate::host::Host::admin_get_meshtastic_owner`].
+/// The public key is hex-encoded (64 lower-case hex chars for 32 bytes).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MeshtasticOwnerInfo {
+    /// Unique node ID string, e.g. `"!aabbccdd"`.
+    pub id: String,
+    /// Full display name.
+    pub long_name: String,
+    /// Short display name (≤ 4 chars on hardware).
+    pub short_name: String,
+    /// Curve25519 public key, hex-encoded (64 chars = 32 bytes).
+    pub public_key_hex: String,
+}
+
+/// Meshtastic security / PKC configuration.
+///
+/// Returned by [`crate::host::Host::admin_get_meshtastic_security`].
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MeshtasticSecurityInfo {
+    /// Node's Curve25519 public key, hex-encoded (64 chars).
+    pub public_key_hex: String,
+    /// Whether the legacy insecure admin channel is enabled.
+    pub admin_channel_enabled: bool,
+}
+
 /// One entry in the durable audit log.
 ///
 /// Written whenever a privileged action is performed: ban, unban, validate,

--- a/crates/bbs-plugin-api/src/admin.rs
+++ b/crates/bbs-plugin-api/src/admin.rs
@@ -210,6 +210,50 @@ pub struct AdminAccessPolicy {
     pub guest_room_id: Option<i64>,
 }
 
+/// Radio parameters applied to a MeshCore companion device.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MeshRadioParams {
+    /// Centre frequency in Hz (e.g. 910_525_000 for 910.525 MHz).
+    pub frequency_hz: u32,
+    /// Channel bandwidth in Hz (e.g. 62_500 for 62.5 kHz).
+    pub bandwidth_hz: u32,
+    /// LoRa spreading factor (7–12).
+    pub spreading_factor: u8,
+    /// Coding rate denominator (5–8, meaning 4/5 through 4/8).
+    pub coding_rate: u8,
+    /// Transmit power in dBm.
+    pub tx_power_dbm: i8,
+}
+
+/// Meshtastic LoRa radio configuration.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MeshtasticLoRaConfig {
+    /// Whether to use a built-in modem preset instead of custom parameters.
+    pub use_preset: bool,
+    /// Meshtastic modem preset enum value (used when `use_preset` is true).
+    pub modem_preset: i32,
+    /// Channel bandwidth (device-specific units).
+    pub bandwidth: u32,
+    /// LoRa spreading factor (7–12).
+    pub spread_factor: u32,
+    /// Coding rate denominator (5–8).
+    pub coding_rate: u32,
+    /// Frequency offset in MHz.
+    pub frequency_offset: f32,
+    /// Meshtastic region enum value.
+    pub region: i32,
+    /// Maximum number of hops for mesh routing.
+    pub hop_limit: u32,
+    /// Whether the transmitter is enabled.
+    pub tx_enabled: bool,
+    /// Transmit power in dBm.
+    pub tx_power: i32,
+    /// LoRa channel number (0 = use frequency directly).
+    pub channel_num: u32,
+    /// Override frequency in MHz (0 = use region default).
+    pub override_frequency: f32,
+}
+
 /// One entry in the durable audit log.
 ///
 /// Written whenever a privileged action is performed: ban, unban, validate,

--- a/crates/bbs-plugin-api/src/host.rs
+++ b/crates/bbs-plugin-api/src/host.rs
@@ -38,11 +38,35 @@ pub enum MeshKeyRequest {
         /// One-shot channel to deliver the result back to the caller.
         reply: tokio::sync::oneshot::Sender<Result<(), String>>,
     },
+    /// Apply LoRa radio parameters to the companion device.
+    ApplyRadio {
+        /// The radio parameters to apply.
+        params: crate::admin::MeshRadioParams,
+        /// One-shot channel to deliver the result back to the caller.
+        reply: tokio::sync::oneshot::Sender<Result<(), String>>,
+    },
+}
+
+/// Request sent from [`Host`] to the Meshtastic transport's admin channel.
+pub enum MeshtasticAdminRequest {
+    /// Fetch the current LoRa radio config from the device.
+    GetLoRaConfig {
+        /// One-shot channel to deliver the result back to the caller.
+        reply: tokio::sync::oneshot::Sender<Result<crate::admin::MeshtasticLoRaConfig, String>>,
+    },
+    /// Push a new LoRa radio config to the device.
+    SetLoRaConfig {
+        /// The LoRa config to write to the device.
+        config: crate::admin::MeshtasticLoRaConfig,
+        /// One-shot channel to deliver the result back to the caller.
+        reply: tokio::sync::oneshot::Sender<Result<(), String>>,
+    },
 }
 
 use crate::admin::{
     AdminAccessPolicy, AdminAuditEntry, AdminBackupRecord, AdminMessageRecord, AdminReports,
-    AdminRoomSummary, AdminSessionInfo, AdminStats, AdminUserInfo,
+    AdminRoomSummary, AdminSessionInfo, AdminStats, AdminUserInfo, MeshRadioParams,
+    MeshtasticLoRaConfig,
 };
 use crate::advert::AdvertBus;
 use crate::command::{Command, Response};
@@ -428,6 +452,34 @@ pub trait Host: Send + Sync {
     async fn admin_import_node_key(&self, hex: String) -> Result<(), HostError> {
         let _ = hex;
         Err(HostError::NotSupported("admin_import_node_key".into()))
+    }
+
+    /// Apply LoRa radio parameters to the MeshCore companion device.
+    /// Requires the mesh transport to be connected.
+    async fn admin_apply_mesh_radio(&self, params: MeshRadioParams) -> Result<(), HostError> {
+        let _ = params;
+        Err(HostError::NotSupported("admin_apply_mesh_radio".into()))
+    }
+
+    /// Register the Meshtastic transport's admin command channel.
+    fn register_meshtastic_admin_ops(
+        &self,
+        _sender: tokio::sync::mpsc::Sender<MeshtasticAdminRequest>,
+    ) {
+    }
+
+    /// Fetch the current LoRa radio config from the Meshtastic device.
+    async fn admin_get_meshtastic_lora(&self) -> Result<MeshtasticLoRaConfig, HostError> {
+        Err(HostError::NotSupported("admin_get_meshtastic_lora".into()))
+    }
+
+    /// Push a new LoRa radio config to the Meshtastic device.
+    async fn admin_set_meshtastic_lora(
+        &self,
+        config: MeshtasticLoRaConfig,
+    ) -> Result<(), HostError> {
+        let _ = config;
+        Err(HostError::NotSupported("admin_set_meshtastic_lora".into()))
     }
 
     // ── Mesh node credentials ────────────────────────────────────────────────────

--- a/crates/bbs-plugin-api/src/host.rs
+++ b/crates/bbs-plugin-api/src/host.rs
@@ -61,12 +61,31 @@ pub enum MeshtasticAdminRequest {
         /// One-shot channel to deliver the result back to the caller.
         reply: tokio::sync::oneshot::Sender<Result<(), String>>,
     },
+    /// Fetch the node's owner/user info (long name, short name, public key).
+    GetOwner {
+        /// One-shot channel to deliver the result back to the caller.
+        reply: tokio::sync::oneshot::Sender<Result<crate::admin::MeshtasticOwnerInfo, String>>,
+    },
+    /// Update the node's owner/user info.
+    SetOwner {
+        /// New long name, or `None` to leave unchanged.
+        long_name: Option<String>,
+        /// New short name (≤ 4 chars), or `None` to leave unchanged.
+        short_name: Option<String>,
+        /// One-shot channel to deliver the result back to the caller.
+        reply: tokio::sync::oneshot::Sender<Result<(), String>>,
+    },
+    /// Fetch the device's security / PKC configuration.
+    GetSecurity {
+        /// One-shot channel to deliver the result back to the caller.
+        reply: tokio::sync::oneshot::Sender<Result<crate::admin::MeshtasticSecurityInfo, String>>,
+    },
 }
 
 use crate::admin::{
     AdminAccessPolicy, AdminAuditEntry, AdminBackupRecord, AdminMessageRecord, AdminReports,
     AdminRoomSummary, AdminSessionInfo, AdminStats, AdminUserInfo, MeshRadioParams,
-    MeshtasticLoRaConfig,
+    MeshtasticLoRaConfig, MeshtasticOwnerInfo, MeshtasticSecurityInfo,
 };
 use crate::advert::AdvertBus;
 use crate::command::{Command, Response};
@@ -480,6 +499,32 @@ pub trait Host: Send + Sync {
     ) -> Result<(), HostError> {
         let _ = config;
         Err(HostError::NotSupported("admin_set_meshtastic_lora".into()))
+    }
+
+    /// Fetch the Meshtastic device's owner/user info (long name, short name,
+    /// public key).
+    async fn admin_get_meshtastic_owner(&self) -> Result<MeshtasticOwnerInfo, HostError> {
+        Err(HostError::NotSupported("admin_get_meshtastic_owner".into()))
+    }
+
+    /// Update the Meshtastic device's owner/user info.
+    ///
+    /// Pass `None` for any field that should not be changed.  The implementation
+    /// fetches the current owner first, merges the new values, then writes back.
+    async fn admin_set_meshtastic_owner(
+        &self,
+        long_name: Option<String>,
+        short_name: Option<String>,
+    ) -> Result<(), HostError> {
+        let _ = (long_name, short_name);
+        Err(HostError::NotSupported("admin_set_meshtastic_owner".into()))
+    }
+
+    /// Fetch the Meshtastic device's security / PKC configuration.
+    async fn admin_get_meshtastic_security(&self) -> Result<MeshtasticSecurityInfo, HostError> {
+        Err(HostError::NotSupported(
+            "admin_get_meshtastic_security".into(),
+        ))
     }
 
     // ── Mesh node credentials ────────────────────────────────────────────────────

--- a/crates/bbs-plugin-api/src/lib.rs
+++ b/crates/bbs-plugin-api/src/lib.rs
@@ -53,7 +53,7 @@ pub use admin::{
     AdminAccessPolicy, AdminAuditEntry, AdminBackupRecord, AdminDailyVolume, AdminHourlyActivity,
     AdminMessageRecord, AdminReports, AdminRoomSummary, AdminSessionInfo, AdminStaleRoom,
     AdminStats, AdminTopRoom, AdminTopSender, AdminUserInfo, AdminWeeklySignups, MeshRadioParams,
-    MeshtasticLoRaConfig,
+    MeshtasticLoRaConfig, MeshtasticOwnerInfo, MeshtasticSecurityInfo,
 };
 pub use advert::{AdvertBus, AdvertRecord};
 pub use command::{Command, Response};

--- a/crates/bbs-plugin-api/src/lib.rs
+++ b/crates/bbs-plugin-api/src/lib.rs
@@ -52,13 +52,14 @@ pub mod transport;
 pub use admin::{
     AdminAccessPolicy, AdminAuditEntry, AdminBackupRecord, AdminDailyVolume, AdminHourlyActivity,
     AdminMessageRecord, AdminReports, AdminRoomSummary, AdminSessionInfo, AdminStaleRoom,
-    AdminStats, AdminTopRoom, AdminTopSender, AdminUserInfo, AdminWeeklySignups,
+    AdminStats, AdminTopRoom, AdminTopSender, AdminUserInfo, AdminWeeklySignups, MeshRadioParams,
+    MeshtasticLoRaConfig,
 };
 pub use advert::{AdvertBus, AdvertRecord};
 pub use command::{Command, Response};
 pub use error::{HostError, PluginError, TransportError};
 pub use event::{DomainEvent, MessageRecipient, Notification, NotifyOutcome};
-pub use host::{Host, MeshKeyRequest};
+pub use host::{Host, MeshKeyRequest, MeshtasticAdminRequest};
 pub use identity::{SessionId, Username};
 pub use permissions::{PermissionCtx, PermissionLevel};
 pub use plugin::Plugin;

--- a/crates/bbs-web/src/lib.rs
+++ b/crates/bbs-web/src/lib.rs
@@ -558,6 +558,11 @@ fn build_router(state: Arc<AppState>) -> Router {
             "/radio-config",
             get(api_get_radio_config).patch(api_patch_radio_config),
         )
+        .route("/radio-config/apply", post(api_apply_radio_config))
+        .route(
+            "/meshtastic-radio-config",
+            get(api_get_meshtastic_radio_config).patch(api_patch_meshtastic_radio_config),
+        )
         .route("/node-identity", get(api_get_node_identity))
         .route("/node-identity/export-key", post(api_export_node_key))
         .route("/node-identity/import-key", post(api_import_node_key))
@@ -2514,6 +2519,92 @@ async fn api_patch_radio_config(
         presets: RADIO_PRESETS.to_vec(),
     })
     .into_response()
+}
+
+// ── Radio config apply (MeshCore) ────────────────────────────────────────────
+
+#[derive(Debug, Deserialize)]
+struct ApplyRadioBody {
+    frequency_hz: u32,
+    bandwidth_hz: u32,
+    spreading_factor: u8,
+    coding_rate: u8,
+    tx_power_dbm: i8,
+}
+
+async fn api_apply_radio_config(
+    State(state): State<Arc<AppState>>,
+    Extension(user): Extension<CurrentUser>,
+    Json(body): Json<ApplyRadioBody>,
+) -> Response {
+    if user.permission_level < 100 {
+        return (StatusCode::FORBIDDEN, Json(json_error("sysop required"))).into_response();
+    }
+    let params = bbs_plugin_api::MeshRadioParams {
+        frequency_hz: body.frequency_hz,
+        bandwidth_hz: body.bandwidth_hz,
+        spreading_factor: body.spreading_factor,
+        coding_rate: body.coding_rate,
+        tx_power_dbm: body.tx_power_dbm,
+    };
+    match state.host.admin_apply_mesh_radio(params).await {
+        Ok(()) => Json(serde_json::json!({ "ok": true })).into_response(),
+        Err(e) => {
+            let status = match &e {
+                HostError::Internal(_) => StatusCode::SERVICE_UNAVAILABLE,
+                HostError::NotSupported(_) => StatusCode::SERVICE_UNAVAILABLE,
+                _ => StatusCode::INTERNAL_SERVER_ERROR,
+            };
+            (status, Json(json_error(&format!("{e}")))).into_response()
+        }
+    }
+}
+
+// ── Meshtastic radio config ───────────────────────────────────────────────────
+
+async fn api_get_meshtastic_radio_config(
+    State(state): State<Arc<AppState>>,
+    Extension(user): Extension<CurrentUser>,
+) -> Response {
+    if user.permission_level < 100 {
+        return (StatusCode::FORBIDDEN, Json(json_error("sysop required"))).into_response();
+    }
+    match state.host.admin_get_meshtastic_lora().await {
+        Ok(config) => Json(config).into_response(),
+        Err(HostError::NotSupported(_)) | Err(HostError::Internal(_)) => (
+            StatusCode::SERVICE_UNAVAILABLE,
+            Json(json_error("Meshtastic transport not connected")),
+        )
+            .into_response(),
+        Err(e) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(json_error(&format!("{e}"))),
+        )
+            .into_response(),
+    }
+}
+
+async fn api_patch_meshtastic_radio_config(
+    State(state): State<Arc<AppState>>,
+    Extension(user): Extension<CurrentUser>,
+    Json(config): Json<bbs_plugin_api::MeshtasticLoRaConfig>,
+) -> Response {
+    if user.permission_level < 100 {
+        return (StatusCode::FORBIDDEN, Json(json_error("sysop required"))).into_response();
+    }
+    match state.host.admin_set_meshtastic_lora(config).await {
+        Ok(()) => Json(serde_json::json!({ "ok": true })).into_response(),
+        Err(HostError::NotSupported(_)) | Err(HostError::Internal(_)) => (
+            StatusCode::SERVICE_UNAVAILABLE,
+            Json(json_error("Meshtastic transport not connected")),
+        )
+            .into_response(),
+        Err(e) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(json_error(&format!("{e}"))),
+        )
+            .into_response(),
+    }
 }
 
 // ── Node identity ─────────────────────────────────────────────────────────────

--- a/crates/bbs-web/src/lib.rs
+++ b/crates/bbs-web/src/lib.rs
@@ -2565,6 +2565,157 @@ async fn api_apply_radio_config(
     }
 }
 
+// ── Meshtastic config.toml helpers ───────────────────────────────────────────
+
+fn meshtastic_region_name(n: i32) -> &'static str {
+    match n {
+        1 => "US",
+        2 => "EU_433",
+        3 => "EU_868",
+        4 => "CN",
+        5 => "JP",
+        6 => "ANZ",
+        7 => "KR",
+        8 => "TW",
+        9 => "RU",
+        10 => "IN",
+        11 => "NZ_865",
+        12 => "TH",
+        13 => "LORA_24",
+        14 => "UA_433",
+        15 => "UA_868",
+        16 => "MY_433",
+        17 => "MY_919",
+        18 => "SG_923",
+        _ => "UNSET",
+    }
+}
+
+fn meshtastic_preset_name(n: i32) -> &'static str {
+    match n {
+        0 => "LONG_FAST",
+        1 => "LONG_SLOW",
+        2 => "VERY_LONG_SLOW",
+        3 => "MEDIUM_SLOW",
+        4 => "MEDIUM_FAST",
+        5 => "SHORT_SLOW",
+        6 => "SHORT_FAST",
+        7 => "LONG_MODERATE",
+        8 => "SHORT_TURBO",
+        9 => "LONG_TURBO",
+        10 => "LITE_FAST",
+        11 => "LITE_SLOW",
+        12 => "NARROW_FAST",
+        13 => "NARROW_SLOW",
+        _ => "LONG_FAST",
+    }
+}
+
+/// Write region and modem_preset strings into `[plugins.meshtastic.radio]`
+/// in the operator config file.  Returns `Ok(true)` when written,
+/// `Ok(false)` when no config path is configured.
+fn save_meshtastic_radio_to_config(
+    config_path: &Option<String>,
+    region_int: i32,
+    preset_int: i32,
+) -> Result<bool, String> {
+    let path = match config_path {
+        Some(p) if !p.is_empty() => std::path::PathBuf::from(p),
+        _ => return Ok(false),
+    };
+    let raw = std::fs::read_to_string(&path).unwrap_or_default();
+    let mut doc = raw
+        .parse::<toml_edit::DocumentMut>()
+        .map_err(|e| format!("config parse error: {e}"))?;
+
+    // Ensure [plugins.meshtastic.radio] table path exists.
+    if doc.get("plugins").is_none() {
+        doc["plugins"] = toml_edit::Item::Table(toml_edit::Table::new());
+    }
+    let plugins = doc["plugins"].as_table_mut().unwrap();
+    if plugins.get("meshtastic").is_none() {
+        plugins.insert(
+            "meshtastic",
+            toml_edit::Item::Table(toml_edit::Table::new()),
+        );
+    }
+    let mt = plugins
+        .get_mut("meshtastic")
+        .unwrap()
+        .as_table_mut()
+        .unwrap();
+    if mt.get("radio").is_none() {
+        mt.insert("radio", toml_edit::Item::Table(toml_edit::Table::new()));
+    }
+    let radio = mt.get_mut("radio").unwrap().as_table_mut().unwrap();
+
+    if region_int != 0 {
+        radio.insert(
+            "region",
+            toml_edit::Item::Value(toml_edit::Value::from(meshtastic_region_name(region_int))),
+        );
+    }
+    radio.insert(
+        "modem_preset",
+        toml_edit::Item::Value(toml_edit::Value::from(meshtastic_preset_name(preset_int))),
+    );
+
+    std::fs::write(&path, doc.to_string()).map_err(|e| format!("write error: {e}"))?;
+    Ok(true)
+}
+
+/// Write short_name and/or long_name into `[plugins.meshtastic]`
+/// in the operator config file.
+fn save_meshtastic_owner_to_config(
+    config_path: &Option<String>,
+    short_name: Option<&str>,
+    long_name: Option<&str>,
+) -> Result<bool, String> {
+    let path = match config_path {
+        Some(p) if !p.is_empty() => std::path::PathBuf::from(p),
+        _ => return Ok(false),
+    };
+    if short_name.is_none() && long_name.is_none() {
+        return Ok(true);
+    }
+    let raw = std::fs::read_to_string(&path).unwrap_or_default();
+    let mut doc = raw
+        .parse::<toml_edit::DocumentMut>()
+        .map_err(|e| format!("config parse error: {e}"))?;
+
+    if doc.get("plugins").is_none() {
+        doc["plugins"] = toml_edit::Item::Table(toml_edit::Table::new());
+    }
+    let plugins = doc["plugins"].as_table_mut().unwrap();
+    if plugins.get("meshtastic").is_none() {
+        plugins.insert(
+            "meshtastic",
+            toml_edit::Item::Table(toml_edit::Table::new()),
+        );
+    }
+    let mt = plugins
+        .get_mut("meshtastic")
+        .unwrap()
+        .as_table_mut()
+        .unwrap();
+
+    if let Some(sn) = short_name {
+        mt.insert(
+            "short_name",
+            toml_edit::Item::Value(toml_edit::Value::from(sn)),
+        );
+    }
+    if let Some(ln) = long_name {
+        mt.insert(
+            "long_name",
+            toml_edit::Item::Value(toml_edit::Value::from(ln)),
+        );
+    }
+
+    std::fs::write(&path, doc.to_string()).map_err(|e| format!("write error: {e}"))?;
+    Ok(true)
+}
+
 // ── Meshtastic radio config ───────────────────────────────────────────────────
 
 async fn api_get_meshtastic_radio_config(
@@ -2597,13 +2748,44 @@ async fn api_patch_meshtastic_radio_config(
     if user.permission_level < 100 {
         return (StatusCode::FORBIDDEN, Json(json_error("sysop required"))).into_response();
     }
+
+    // Always save region + modem_preset to config.toml first.
+    let config_path = &state.config.config_path;
+    let saved = save_meshtastic_radio_to_config(config_path, config.region, config.modem_preset);
+    if let Err(ref e) = saved {
+        tracing::warn!("meshtastic radio: could not save to config.toml: {e}");
+    }
+
+    // Then try to push to the live device via the transport.
     match state.host.admin_set_meshtastic_lora(config).await {
-        Ok(()) => Json(serde_json::json!({ "ok": true })).into_response(),
-        Err(HostError::NotSupported(_)) | Err(HostError::Internal(_)) => (
-            StatusCode::SERVICE_UNAVAILABLE,
-            Json(json_error("Meshtastic transport not connected")),
-        )
-            .into_response(),
+        Ok(()) => Json(serde_json::json!({
+            "ok": true,
+            "saved": saved.is_ok(),
+            "applied": true,
+        }))
+        .into_response(),
+        Err(HostError::NotSupported(_)) | Err(HostError::Internal(_)) => {
+            // Transport not connected — that's OK if we saved to config.
+            if saved.unwrap_or(false) {
+                Json(serde_json::json!({
+                    "ok": true,
+                    "saved": true,
+                    "applied": false,
+                    "message": "Saved to config.toml. Settings will not take effect on the \
+                                device until you run: supply-drop-bbs node set-meshtastic-radio \
+                                (while the BBS is stopped).",
+                }))
+                .into_response()
+            } else {
+                (
+                    StatusCode::SERVICE_UNAVAILABLE,
+                    Json(json_error(
+                        "Meshtastic transport not connected and no config path configured",
+                    )),
+                )
+                    .into_response()
+            }
+        }
         Err(e) => (
             StatusCode::INTERNAL_SERVER_ERROR,
             Json(json_error(&format!("{e}"))),
@@ -2650,17 +2832,51 @@ async fn api_patch_meshtastic_owner(
     if user.permission_level < 100 {
         return (StatusCode::FORBIDDEN, Json(json_error("sysop required"))).into_response();
     }
+
+    // Always save short/long name to config.toml first.
+    let config_path = &state.config.config_path;
+    let saved = save_meshtastic_owner_to_config(
+        config_path,
+        body.short_name.as_deref(),
+        body.long_name.as_deref(),
+    );
+    if let Err(ref e) = saved {
+        tracing::warn!("meshtastic owner: could not save to config.toml: {e}");
+    }
+
+    // Then try to push to the live device via the transport.
     match state
         .host
         .admin_set_meshtastic_owner(body.long_name, body.short_name)
         .await
     {
-        Ok(()) => Json(serde_json::json!({ "ok": true })).into_response(),
-        Err(HostError::NotSupported(_)) => (
-            StatusCode::SERVICE_UNAVAILABLE,
-            Json(json_error("Meshtastic transport not connected")),
-        )
-            .into_response(),
+        Ok(()) => Json(serde_json::json!({
+            "ok": true,
+            "saved": saved.is_ok(),
+            "applied": true,
+        }))
+        .into_response(),
+        Err(HostError::NotSupported(_)) => {
+            if saved.unwrap_or(false) {
+                Json(serde_json::json!({
+                    "ok": true,
+                    "saved": true,
+                    "applied": false,
+                    "message": "Saved to config.toml. Settings will not take effect on the \
+                                device until you run: supply-drop-bbs node set-meshtastic-owner \
+                                (while the BBS is stopped).",
+                }))
+                .into_response()
+            } else {
+                (
+                    StatusCode::SERVICE_UNAVAILABLE,
+                    Json(json_error(
+                        "Meshtastic transport not connected and no config path configured",
+                    )),
+                )
+                    .into_response()
+            }
+        }
         Err(e) => (
             StatusCode::INTERNAL_SERVER_ERROR,
             Json(json_error(&format!("{e}"))),

--- a/crates/bbs-web/src/lib.rs
+++ b/crates/bbs-web/src/lib.rs
@@ -2771,9 +2771,9 @@ async fn api_patch_meshtastic_radio_config(
                     "ok": true,
                     "saved": true,
                     "applied": false,
-                    "message": "Saved to config.toml. Settings will not take effect on the \
-                                device until you run: supply-drop-bbs node set-meshtastic-radio \
-                                (while the BBS is stopped).",
+                    "message": "Saved to config.toml. The device is not connected right now; \
+                                these settings will be applied automatically the next time the \
+                                BBS connects to it.",
                 }))
                 .into_response()
             } else {
@@ -2862,9 +2862,9 @@ async fn api_patch_meshtastic_owner(
                     "ok": true,
                     "saved": true,
                     "applied": false,
-                    "message": "Saved to config.toml. Settings will not take effect on the \
-                                device until you run: supply-drop-bbs node set-meshtastic-owner \
-                                (while the BBS is stopped).",
+                    "message": "Saved to config.toml. The device is not connected right now; \
+                                this name will be applied automatically the next time the BBS \
+                                connects to it.",
                 }))
                 .into_response()
             } else {

--- a/crates/bbs-web/src/lib.rs
+++ b/crates/bbs-web/src/lib.rs
@@ -563,6 +563,11 @@ fn build_router(state: Arc<AppState>) -> Router {
             "/meshtastic-radio-config",
             get(api_get_meshtastic_radio_config).patch(api_patch_meshtastic_radio_config),
         )
+        .route(
+            "/meshtastic-owner",
+            get(api_get_meshtastic_owner).patch(api_patch_meshtastic_owner),
+        )
+        .route("/meshtastic-security", get(api_get_meshtastic_security))
         .route("/node-identity", get(api_get_node_identity))
         .route("/node-identity/export-key", post(api_export_node_key))
         .route("/node-identity/import-key", post(api_import_node_key))
@@ -2595,6 +2600,87 @@ async fn api_patch_meshtastic_radio_config(
     match state.host.admin_set_meshtastic_lora(config).await {
         Ok(()) => Json(serde_json::json!({ "ok": true })).into_response(),
         Err(HostError::NotSupported(_)) | Err(HostError::Internal(_)) => (
+            StatusCode::SERVICE_UNAVAILABLE,
+            Json(json_error("Meshtastic transport not connected")),
+        )
+            .into_response(),
+        Err(e) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(json_error(&format!("{e}"))),
+        )
+            .into_response(),
+    }
+}
+
+// ── Meshtastic owner / user info ──────────────────────────────────────────────
+
+#[derive(Debug, Deserialize)]
+struct PatchMeshtasticOwnerBody {
+    long_name: Option<String>,
+    short_name: Option<String>,
+}
+
+async fn api_get_meshtastic_owner(
+    State(state): State<Arc<AppState>>,
+    Extension(user): Extension<CurrentUser>,
+) -> Response {
+    if user.permission_level < 100 {
+        return (StatusCode::FORBIDDEN, Json(json_error("sysop required"))).into_response();
+    }
+    match state.host.admin_get_meshtastic_owner().await {
+        Ok(info) => Json(info).into_response(),
+        Err(HostError::NotSupported(_)) => (
+            StatusCode::SERVICE_UNAVAILABLE,
+            Json(json_error("Meshtastic transport not connected")),
+        )
+            .into_response(),
+        Err(e) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(json_error(&format!("{e}"))),
+        )
+            .into_response(),
+    }
+}
+
+async fn api_patch_meshtastic_owner(
+    State(state): State<Arc<AppState>>,
+    Extension(user): Extension<CurrentUser>,
+    Json(body): Json<PatchMeshtasticOwnerBody>,
+) -> Response {
+    if user.permission_level < 100 {
+        return (StatusCode::FORBIDDEN, Json(json_error("sysop required"))).into_response();
+    }
+    match state
+        .host
+        .admin_set_meshtastic_owner(body.long_name, body.short_name)
+        .await
+    {
+        Ok(()) => Json(serde_json::json!({ "ok": true })).into_response(),
+        Err(HostError::NotSupported(_)) => (
+            StatusCode::SERVICE_UNAVAILABLE,
+            Json(json_error("Meshtastic transport not connected")),
+        )
+            .into_response(),
+        Err(e) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(json_error(&format!("{e}"))),
+        )
+            .into_response(),
+    }
+}
+
+// ── Meshtastic security / PKC info ────────────────────────────────────────────
+
+async fn api_get_meshtastic_security(
+    State(state): State<Arc<AppState>>,
+    Extension(user): Extension<CurrentUser>,
+) -> Response {
+    if user.permission_level < 100 {
+        return (StatusCode::FORBIDDEN, Json(json_error("sysop required"))).into_response();
+    }
+    match state.host.admin_get_meshtastic_security().await {
+        Ok(info) => Json(info).into_response(),
+        Err(HostError::NotSupported(_)) => (
             StatusCode::SERVICE_UNAVAILABLE,
             Json(json_error("Meshtastic transport not connected")),
         )

--- a/crates/bbs-web/web/src/pages/SettingsPage.vue
+++ b/crates/bbs-web/web/src/pages/SettingsPage.vue
@@ -430,11 +430,108 @@ async function saveRadioConfig() {
     }
     const updated = await api.patch<RadioConfigData>('/api/v1/radio-config', patch)
     radioConfig.value = updated
-    radioSaveOk.value = 'Radio config saved to config.toml. Run: sudo supply-drop-bbs node set-radio — to push to the device (only needed when parameters change).'
+    radioSaveOk.value = 'Radio config saved to config.toml.'
   } catch (e: any) {
     radioSaveError.value = e?.message ?? 'failed to save radio config'
   } finally {
     radioSaving.value = false
+  }
+}
+
+const radioApplying = ref(false)
+const radioApplyOk = ref<string | null>(null)
+const radioApplyError = ref<string | null>(null)
+
+async function applyRadioConfig() {
+  radioApplying.value  = true
+  radioApplyOk.value   = null
+  radioApplyError.value = null
+  try {
+    await api.post('/api/v1/radio-config/apply', {
+      frequency_hz:     radioFrequencyHz.value     ? parseInt(radioFrequencyHz.value, 10)     : 0,
+      bandwidth_hz:     radioBandwidthHz.value     ? parseInt(radioBandwidthHz.value, 10)     : 0,
+      spreading_factor: radioSpreadingFactor.value ? parseInt(radioSpreadingFactor.value, 10) : 0,
+      coding_rate:      radioCodingRate.value      ? parseInt(radioCodingRate.value, 10)      : 0,
+      tx_power_dbm:     radioTxPowerDbm.value      ? parseInt(radioTxPowerDbm.value, 10)      : 0,
+    })
+    radioApplyOk.value = 'Radio parameters applied to device.'
+  } catch (e: any) {
+    radioApplyError.value = e?.message ?? 'failed to apply radio config'
+  } finally {
+    radioApplying.value = false
+  }
+}
+
+// ── Meshtastic radio ──────────────────────────────────────────────────────────
+
+const meshtasticRadioLoading = ref(false)
+const meshtasticRadioSaving = ref(false)
+const meshtasticRadioError = ref<string | null>(null)
+const meshtasticRadioOk = ref<string | null>(null)
+
+const meshtasticUsePreset = ref(false)
+const meshtasticModemPreset = ref(0)
+const meshtasticBandwidth = ref(0)
+const meshtasticSpreadFactor = ref(11)
+const meshtasticCodingRate = ref(8)
+const meshtasticFrequencyOffset = ref(0)
+const meshtasticRegion = ref(0)
+const meshtasticHopLimit = ref(3)
+const meshtasticTxEnabled = ref(true)
+const meshtasticTxPower = ref(17)
+const meshtasticChannelNum = ref(0)
+const meshtasticOverrideFrequency = ref(0)
+
+async function loadMeshtasticRadio() {
+  meshtasticRadioLoading.value = true
+  meshtasticRadioError.value = null
+  meshtasticRadioOk.value = null
+  try {
+    const r = await api.get<any>('/api/v1/meshtastic-radio-config')
+    meshtasticUsePreset.value         = r.use_preset ?? false
+    meshtasticModemPreset.value       = r.modem_preset ?? 0
+    meshtasticBandwidth.value         = r.bandwidth ?? 0
+    meshtasticSpreadFactor.value      = r.spread_factor ?? 11
+    meshtasticCodingRate.value        = r.coding_rate ?? 8
+    meshtasticFrequencyOffset.value   = r.frequency_offset ?? 0
+    meshtasticRegion.value            = r.region ?? 0
+    meshtasticHopLimit.value          = r.hop_limit ?? 3
+    meshtasticTxEnabled.value         = r.tx_enabled ?? true
+    meshtasticTxPower.value           = r.tx_power ?? 17
+    meshtasticChannelNum.value        = r.channel_num ?? 0
+    meshtasticOverrideFrequency.value = r.override_frequency ?? 0
+    meshtasticRadioOk.value = 'Loaded from device.'
+  } catch (e: any) {
+    meshtasticRadioError.value = e?.message ?? 'failed to load meshtastic radio config'
+  } finally {
+    meshtasticRadioLoading.value = false
+  }
+}
+
+async function saveMeshtasticRadio() {
+  meshtasticRadioSaving.value = true
+  meshtasticRadioError.value = null
+  meshtasticRadioOk.value = null
+  try {
+    await api.patch('/api/v1/meshtastic-radio-config', {
+      use_preset:         meshtasticUsePreset.value,
+      modem_preset:       meshtasticModemPreset.value,
+      bandwidth:          meshtasticBandwidth.value,
+      spread_factor:      meshtasticSpreadFactor.value,
+      coding_rate:        meshtasticCodingRate.value,
+      frequency_offset:   meshtasticFrequencyOffset.value,
+      region:             meshtasticRegion.value,
+      hop_limit:          meshtasticHopLimit.value,
+      tx_enabled:         meshtasticTxEnabled.value,
+      tx_power:           meshtasticTxPower.value,
+      channel_num:        meshtasticChannelNum.value,
+      override_frequency: meshtasticOverrideFrequency.value,
+    })
+    meshtasticRadioOk.value = 'Radio config saved to device.'
+  } catch (e: any) {
+    meshtasticRadioError.value = e?.message ?? 'failed to save meshtastic radio config'
+  } finally {
+    meshtasticRadioSaving.value = false
   }
 }
 
@@ -799,24 +896,21 @@ chmod g+w {{ configFile }}</pre>
         </div>
       </section>
 
-      <!-- MeshCore Radio — USB serial only -->
-      <!-- Pi HAT and TCP connections have their radio managed by pymc-companion;
-           node set-radio speaks directly to the USB serial device and is not
-           applicable to those connection types. -->
-      <section v-if="radioConfig?.connection_type === 'serial'" class="card">
+      <!-- MeshCore Radio — shown for all MeshCore connection types -->
+      <section v-if="radioConfig" class="card">
         <h2>MeshCore radio</h2>
         <p class="hint">
-          LoRa parameters for the USB MeshCore companion device
-          <span v-if="radioConfig.serial_port">(<code>{{ radioConfig.serial_port }}</code>)</span>.
-          Save here to record them in config.toml, then push to the device once with
-          <code>sudo supply-drop-bbs node set-radio</code>.
-          The device stores these settings in its own flash — you only need to run that
-          command when you change the parameters, not on every restart.
+          LoRa parameters for the MeshCore companion device.
+          Save here to record them in config.toml. Use <strong>Apply to device</strong>
+          to push the current values directly to the live companion device over the
+          existing connection.
         </p>
 
         <div v-if="radioError" class="notice error-notice">{{ radioError }}</div>
         <div v-if="radioSaveOk" class="notice ok-notice">{{ radioSaveOk }}</div>
         <div v-if="radioSaveError" class="notice error-notice">{{ radioSaveError }}</div>
+        <div v-if="radioApplyOk" class="notice ok-notice">{{ radioApplyOk }}</div>
+        <div v-if="radioApplyError" class="notice error-notice">{{ radioApplyError }}</div>
 
         <div class="field">
           <label>Region preset</label>
@@ -859,7 +953,80 @@ chmod g+w {{ configFile }}</pre>
           <button type="button" :disabled="radioSaving || radioLoading || !writable" @click="saveRadioConfig">
             {{ radioSaving ? 'saving…' : 'save radio config' }}
           </button>
+          <button type="button" :disabled="radioApplying || radioLoading || !radioConfig" @click="applyRadioConfig">
+            {{ radioApplying ? 'applying…' : 'apply to device' }}
+          </button>
           <span v-if="!writable" class="hint">config file is not writable</span>
+        </div>
+      </section>
+
+      <!-- Meshtastic radio -->
+      <section class="card">
+        <h2>Meshtastic radio</h2>
+        <p class="hint">
+          LoRa radio configuration for the connected Meshtastic device.
+          Use <strong>Load from device</strong> to read the current settings,
+          edit them, then <strong>Save to device</strong> to push them back.
+        </p>
+
+        <div v-if="meshtasticRadioError" class="notice error-notice">{{ meshtasticRadioError }}</div>
+        <div v-if="meshtasticRadioOk" class="notice ok-notice">{{ meshtasticRadioOk }}</div>
+
+        <div class="field-row">
+          <div class="field">
+            <label>Spread factor</label>
+            <input v-model.number="meshtasticSpreadFactor" type="number" min="7" max="12" :disabled="meshtasticRadioLoading" />
+          </div>
+          <div class="field">
+            <label>Bandwidth</label>
+            <input v-model.number="meshtasticBandwidth" type="number" min="0" :disabled="meshtasticRadioLoading" />
+          </div>
+          <div class="field">
+            <label>TX power (dBm)</label>
+            <input v-model.number="meshtasticTxPower" type="number" :disabled="meshtasticRadioLoading" />
+          </div>
+        </div>
+        <div class="field-row">
+          <div class="field">
+            <label>Region</label>
+            <input v-model.number="meshtasticRegion" type="number" min="0" :disabled="meshtasticRadioLoading" />
+            <p class="hint">Meshtastic region enum value</p>
+          </div>
+          <div class="field">
+            <label>Hop limit</label>
+            <input v-model.number="meshtasticHopLimit" type="number" min="0" max="7" :disabled="meshtasticRadioLoading" />
+          </div>
+          <div class="field">
+            <label>Modem preset</label>
+            <input v-model.number="meshtasticModemPreset" type="number" min="0" :disabled="meshtasticRadioLoading || meshtasticUsePreset" />
+          </div>
+        </div>
+        <div class="field-row">
+          <div class="field">
+            <label>Override frequency (MHz)</label>
+            <input v-model.number="meshtasticOverrideFrequency" type="number" step="0.001" :disabled="meshtasticRadioLoading" />
+          </div>
+          <div class="field">
+            <label style="display:flex;align-items:center;gap:0.5rem;">
+              <input type="checkbox" v-model="meshtasticUsePreset" :disabled="meshtasticRadioLoading" />
+              Use preset
+            </label>
+          </div>
+          <div class="field">
+            <label style="display:flex;align-items:center;gap:0.5rem;">
+              <input type="checkbox" v-model="meshtasticTxEnabled" :disabled="meshtasticRadioLoading" />
+              TX enabled
+            </label>
+          </div>
+        </div>
+
+        <div class="actions">
+          <button type="button" :disabled="meshtasticRadioLoading" @click="loadMeshtasticRadio">
+            {{ meshtasticRadioLoading ? 'loading…' : 'load from device' }}
+          </button>
+          <button type="button" :disabled="meshtasticRadioLoading || meshtasticRadioSaving" @click="saveMeshtasticRadio">
+            {{ meshtasticRadioSaving ? 'saving…' : 'save to device' }}
+          </button>
         </div>
       </section>
 

--- a/crates/bbs-web/web/src/pages/SettingsPage.vue
+++ b/crates/bbs-web/web/src/pages/SettingsPage.vue
@@ -462,6 +462,46 @@ async function applyRadioConfig() {
   }
 }
 
+// ── Meshtastic region / modem preset constants ────────────────────────────────
+
+const MESHTASTIC_REGIONS = [
+  { value: 0,  label: 'UNSET — not configured' },
+  { value: 1,  label: 'US — United States (902–928 MHz)' },
+  { value: 2,  label: 'EU_433 — Europe 433 MHz' },
+  { value: 3,  label: 'EU_868 — Europe 868 MHz' },
+  { value: 4,  label: 'CN — China 470–510 MHz' },
+  { value: 5,  label: 'JP — Japan 920–923 MHz' },
+  { value: 6,  label: 'ANZ — Australia/New Zealand 915–928 MHz' },
+  { value: 7,  label: 'KR — South Korea 920–923 MHz' },
+  { value: 8,  label: 'TW — Taiwan 920–925 MHz' },
+  { value: 9,  label: 'RU — Russia 868 MHz' },
+  { value: 10, label: 'IN — India 865–867 MHz' },
+  { value: 11, label: 'NZ_865 — New Zealand 865 MHz' },
+  { value: 12, label: 'TH — Thailand 920–925 MHz' },
+  { value: 13, label: 'LORA_24 — 2.4 GHz (SX128x)' },
+  { value: 14, label: 'UA_433 — Ukraine 433 MHz' },
+  { value: 15, label: 'UA_868 — Ukraine 868 MHz' },
+  { value: 16, label: 'MY_433 — Malaysia 433 MHz' },
+  { value: 17, label: 'MY_919 — Malaysia 919 MHz' },
+  { value: 18, label: 'SG_923 — Singapore 923 MHz' },
+]
+
+const MESHTASTIC_PRESETS = [
+  { value: 0, label: 'LONG_FAST — long range, fast (default)' },
+  { value: 1, label: 'LONG_SLOW — long range, slow (deprecated in 2.7)' },
+  { value: 3, label: 'MEDIUM_SLOW — medium range, slow' },
+  { value: 4, label: 'MEDIUM_FAST — medium range, fast' },
+  { value: 5, label: 'SHORT_SLOW — short range, slow' },
+  { value: 6, label: 'SHORT_FAST — short range, fast' },
+  { value: 7, label: 'LONG_MODERATE — long range, moderate (125 kHz)' },
+  { value: 8, label: 'SHORT_TURBO — fastest (500 kHz, not legal everywhere)' },
+  { value: 9, label: 'LONG_TURBO — long range, 500 kHz' },
+  { value: 10, label: 'LITE_FAST — EU_866 compliant, ~MEDIUM_FAST range' },
+  { value: 11, label: 'LITE_SLOW — EU_866 compliant, ~LONG_FAST range' },
+  { value: 12, label: 'NARROW_FAST — EU_868 62.5 kHz, ~SHORT_SLOW range' },
+  { value: 13, label: 'NARROW_SLOW — EU_868 62.5 kHz, ~LONG_FAST range' },
+]
+
 // ── Meshtastic radio ──────────────────────────────────────────────────────────
 
 const meshtasticRadioLoading = ref(false)
@@ -532,6 +572,80 @@ async function saveMeshtasticRadio() {
     meshtasticRadioError.value = e?.message ?? 'failed to save meshtastic radio config'
   } finally {
     meshtasticRadioSaving.value = false
+  }
+}
+
+// ── Meshtastic device (owner + security) ─────────────────────────────────────
+
+interface MeshtasticOwnerData {
+  id: string
+  long_name: string
+  short_name: string
+  public_key_hex: string
+}
+
+interface MeshtasticSecurityData {
+  public_key_hex: string
+  admin_channel_enabled: boolean
+}
+
+const meshtasticOwnerLoading = ref(false)
+const meshtasticOwnerSaving = ref(false)
+const meshtasticOwnerError = ref<string | null>(null)
+const meshtasticOwnerOk = ref<string | null>(null)
+const meshtasticOwner = ref<MeshtasticOwnerData | null>(null)
+const meshtasticLongName = ref('')
+const meshtasticShortName = ref('')
+
+const meshtasticSecurityLoading = ref(false)
+const meshtasticSecurityError = ref<string | null>(null)
+const meshtasticSecurity = ref<MeshtasticSecurityData | null>(null)
+
+async function loadMeshtasticOwner() {
+  meshtasticOwnerLoading.value = true
+  meshtasticOwnerError.value = null
+  meshtasticOwnerOk.value = null
+  try {
+    const r = await api.get<MeshtasticOwnerData>('/api/v1/meshtastic-owner')
+    meshtasticOwner.value = r
+    meshtasticLongName.value = r.long_name
+    meshtasticShortName.value = r.short_name
+    meshtasticOwnerOk.value = 'Loaded from device.'
+  } catch (e: any) {
+    meshtasticOwnerError.value = e?.message ?? 'failed to load device owner info'
+  } finally {
+    meshtasticOwnerLoading.value = false
+  }
+}
+
+async function saveMeshtasticOwner() {
+  meshtasticOwnerSaving.value = true
+  meshtasticOwnerError.value = null
+  meshtasticOwnerOk.value = null
+  try {
+    await api.patch('/api/v1/meshtastic-owner', {
+      long_name: meshtasticLongName.value || null,
+      short_name: meshtasticShortName.value || null,
+    })
+    meshtasticOwnerOk.value = 'Device owner info updated.'
+    await loadMeshtasticOwner()
+  } catch (e: any) {
+    meshtasticOwnerError.value = e?.message ?? 'failed to save device owner info'
+  } finally {
+    meshtasticOwnerSaving.value = false
+  }
+}
+
+async function loadMeshtasticSecurity() {
+  meshtasticSecurityLoading.value = true
+  meshtasticSecurityError.value = null
+  try {
+    const r = await api.get<MeshtasticSecurityData>('/api/v1/meshtastic-security')
+    meshtasticSecurity.value = r
+  } catch (e: any) {
+    meshtasticSecurityError.value = e?.message ?? 'failed to load security config'
+  } finally {
+    meshtasticSecurityLoading.value = false
   }
 }
 
@@ -972,14 +1086,35 @@ chmod g+w {{ configFile }}</pre>
         <div v-if="meshtasticRadioError" class="notice error-notice">{{ meshtasticRadioError }}</div>
         <div v-if="meshtasticRadioOk" class="notice ok-notice">{{ meshtasticRadioOk }}</div>
 
+        <!-- Region and modem preset — dropdowns -->
+        <div class="field-row">
+          <div class="field">
+            <label>Region</label>
+            <select v-model.number="meshtasticRegion" :disabled="meshtasticRadioLoading">
+              <option v-for="r in MESHTASTIC_REGIONS" :key="r.value" :value="r.value">
+                {{ r.label }}
+              </option>
+            </select>
+          </div>
+          <div class="field">
+            <label>Modem preset</label>
+            <select v-model.number="meshtasticModemPreset" :disabled="meshtasticRadioLoading || !meshtasticUsePreset">
+              <option v-for="p in MESHTASTIC_PRESETS" :key="p.value" :value="p.value">
+                {{ p.label }}
+              </option>
+            </select>
+            <p class="hint">Only used when "Use preset" is enabled.</p>
+          </div>
+        </div>
+        <!-- Custom LoRa parameters — visible when not using preset -->
         <div class="field-row">
           <div class="field">
             <label>Spread factor</label>
-            <input v-model.number="meshtasticSpreadFactor" type="number" min="7" max="12" :disabled="meshtasticRadioLoading" />
+            <input v-model.number="meshtasticSpreadFactor" type="number" min="7" max="12" :disabled="meshtasticRadioLoading || meshtasticUsePreset" />
           </div>
           <div class="field">
-            <label>Bandwidth</label>
-            <input v-model.number="meshtasticBandwidth" type="number" min="0" :disabled="meshtasticRadioLoading" />
+            <label>Bandwidth (kHz units)</label>
+            <input v-model.number="meshtasticBandwidth" type="number" min="0" :disabled="meshtasticRadioLoading || meshtasticUsePreset" />
           </div>
           <div class="field">
             <label>TX power (dBm)</label>
@@ -988,31 +1123,18 @@ chmod g+w {{ configFile }}</pre>
         </div>
         <div class="field-row">
           <div class="field">
-            <label>Region</label>
-            <input v-model.number="meshtasticRegion" type="number" min="0" :disabled="meshtasticRadioLoading" />
-            <p class="hint">Meshtastic region enum value</p>
-          </div>
-          <div class="field">
             <label>Hop limit</label>
             <input v-model.number="meshtasticHopLimit" type="number" min="0" max="7" :disabled="meshtasticRadioLoading" />
           </div>
           <div class="field">
-            <label>Modem preset</label>
-            <input v-model.number="meshtasticModemPreset" type="number" min="0" :disabled="meshtasticRadioLoading || meshtasticUsePreset" />
-          </div>
-        </div>
-        <div class="field-row">
-          <div class="field">
             <label>Override frequency (MHz)</label>
             <input v-model.number="meshtasticOverrideFrequency" type="number" step="0.001" :disabled="meshtasticRadioLoading" />
           </div>
-          <div class="field">
+          <div class="field" style="display:flex;flex-direction:column;gap:0.5rem;justify-content:flex-end;">
             <label style="display:flex;align-items:center;gap:0.5rem;">
               <input type="checkbox" v-model="meshtasticUsePreset" :disabled="meshtasticRadioLoading" />
               Use preset
             </label>
-          </div>
-          <div class="field">
             <label style="display:flex;align-items:center;gap:0.5rem;">
               <input type="checkbox" v-model="meshtasticTxEnabled" :disabled="meshtasticRadioLoading" />
               TX enabled
@@ -1030,15 +1152,89 @@ chmod g+w {{ configFile }}</pre>
         </div>
       </section>
 
+      <!-- Meshtastic device — owner info and PKC key -->
+      <section class="card">
+        <h2>Meshtastic device <span class="badge">Meshtastic</span></h2>
+        <p class="hint">
+          Node identity and PKC (public-key cryptography) settings for the connected
+          Meshtastic radio. The public key is derived from the device's private key and is
+          broadcast on the mesh so other nodes can send you encrypted direct messages.
+        </p>
+
+        <!-- Owner / node name -->
+        <h3 style="margin: 1rem 0 0.5rem">Node name</h3>
+        <div v-if="meshtasticOwnerError" class="notice error-notice">{{ meshtasticOwnerError }}</div>
+        <div v-if="meshtasticOwnerOk" class="notice ok-notice">{{ meshtasticOwnerOk }}</div>
+
+        <div v-if="meshtasticOwner" class="field-row">
+          <div class="field">
+            <label>Node ID</label>
+            <code style="display:block;padding:0.3rem 0;">{{ meshtasticOwner.id }}</code>
+          </div>
+          <div class="field">
+            <label>Long name</label>
+            <input v-model="meshtasticLongName" type="text" maxlength="39" :disabled="meshtasticOwnerLoading" />
+          </div>
+          <div class="field">
+            <label>Short name <span class="hint" style="display:inline">(≤ 4 chars)</span></label>
+            <input v-model="meshtasticShortName" type="text" maxlength="4" :disabled="meshtasticOwnerLoading" />
+          </div>
+        </div>
+        <div v-else class="muted" style="margin:0.5rem 0;">
+          {{ meshtasticOwnerLoading ? 'Loading…' : 'Not loaded — click "Load from device" to read.' }}
+        </div>
+
+        <div class="actions" style="margin-top:0.75rem;">
+          <button type="button" :disabled="meshtasticOwnerLoading" @click="loadMeshtasticOwner">
+            {{ meshtasticOwnerLoading ? 'loading…' : 'load from device' }}
+          </button>
+          <button type="button" :disabled="meshtasticOwnerLoading || meshtasticOwnerSaving || !meshtasticOwner" @click="saveMeshtasticOwner">
+            {{ meshtasticOwnerSaving ? 'saving…' : 'save to device' }}
+          </button>
+        </div>
+
+        <!-- PKC public key -->
+        <h3 style="margin: 1.5rem 0 0.5rem">Public key (PKC)</h3>
+        <div v-if="meshtasticSecurityError" class="notice error-notice">{{ meshtasticSecurityError }}</div>
+
+        <div v-if="meshtasticSecurity" class="field">
+          <label>Public key (Curve25519, hex)</label>
+          <div class="key-display">
+            <code class="key-hex">{{ meshtasticSecurity.public_key_hex || '(not set)' }}</code>
+            <button
+              v-if="meshtasticSecurity.public_key_hex"
+              type="button"
+              class="icon-btn"
+              title="Copy public key"
+              @click="copyToClipboard(meshtasticSecurity.public_key_hex)"
+            >⎘</button>
+          </div>
+          <p class="hint" style="margin-top:0.3rem;">
+            Admin channel: <strong>{{ meshtasticSecurity.admin_channel_enabled ? 'enabled' : 'disabled' }}</strong>.
+            To manage the private key or admin keys, use the Meshtastic app or meshtasticd CLI.
+          </p>
+        </div>
+        <div v-else class="muted" style="margin:0.5rem 0;">
+          {{ meshtasticSecurityLoading ? 'Loading…' : 'Not loaded — click "Load security config" to read.' }}
+        </div>
+
+        <div class="actions" style="margin-top:0.75rem;">
+          <button type="button" :disabled="meshtasticSecurityLoading" @click="loadMeshtasticSecurity">
+            {{ meshtasticSecurityLoading ? 'loading…' : 'load security config' }}
+          </button>
+        </div>
+      </section>
+
       <!-- Node identity -->
       <section class="card">
-        <h2>Node identity</h2>
+        <h2>Node identity <span class="badge">MeshCore</span></h2>
         <p class="hint">
-          The MeshCore companion device's identity keypair. The public key identifies
-          your node on the mesh network and is shared with other stations to contact you.
-          Use <strong>Set node key</strong> to paste a known 64-character hex key (e.g. when
-          migrating to new hardware). Export the private key for backup before a firmware
-          flash. <strong>Keep the private key secret.</strong>
+          The <strong>MeshCore</strong> companion device's identity keypair. The public key
+          identifies your node on the MeshCore mesh network and is shared with other stations
+          to contact you. Use <strong>Set node key</strong> to paste a known 64-character hex
+          key (e.g. when migrating to new hardware). Export the private key for backup before a
+          firmware flash. <strong>Keep the private key secret.</strong>
+          For Meshtastic PKC keys, see the <em>Meshtastic device</em> section below.
         </p>
 
         <div v-if="nodeIdentityError" class="notice error-notice">{{ nodeIdentityError }}</div>

--- a/crates/bbs-web/web/src/pages/SettingsPage.vue
+++ b/crates/bbs-web/web/src/pages/SettingsPage.vue
@@ -568,7 +568,7 @@ async function saveMeshtasticRadio() {
       override_frequency: meshtasticOverrideFrequency.value,
     })
     if (res?.applied === false && res?.saved) {
-      meshtasticRadioOk.value = 'Saved to config.toml. Device not connected — settings will apply next time you run: supply-drop-bbs node set-meshtastic-radio'
+      meshtasticRadioOk.value = 'Saved. The device is not connected right now — these settings will be applied automatically the next time the BBS connects to it.'
     } else {
       meshtasticRadioOk.value = 'Radio config saved and applied to device.'
     }
@@ -632,7 +632,7 @@ async function saveMeshtasticOwner() {
       short_name: meshtasticShortName.value || null,
     })
     if (res?.applied === false && res?.saved) {
-      meshtasticOwnerOk.value = 'Saved to config.toml. Device not connected — settings will apply next time you run: supply-drop-bbs node set-meshtastic-owner'
+      meshtasticOwnerOk.value = 'Saved. The device is not connected right now — this name will be applied automatically the next time the BBS connects to it.'
     } else {
       meshtasticOwnerOk.value = 'Node name saved and applied to device.'
       await loadMeshtasticOwner()

--- a/crates/bbs-web/web/src/pages/SettingsPage.vue
+++ b/crates/bbs-web/web/src/pages/SettingsPage.vue
@@ -430,7 +430,7 @@ async function saveRadioConfig() {
     }
     const updated = await api.patch<RadioConfigData>('/api/v1/radio-config', patch)
     radioConfig.value = updated
-    radioSaveOk.value = 'Radio config saved. Apply to device with: sudo supply-drop-bbs node set-radio'
+    radioSaveOk.value = 'Radio config saved to config.toml. Run: sudo supply-drop-bbs node set-radio — to push to the device (only needed when parameters change).'
   } catch (e: any) {
     radioSaveError.value = e?.message ?? 'failed to save radio config'
   } finally {
@@ -799,26 +799,19 @@ chmod g+w {{ configFile }}</pre>
         </div>
       </section>
 
-      <!-- MeshCore Radio -->
-      <section class="card">
+      <!-- MeshCore Radio — USB serial only -->
+      <!-- Pi HAT and TCP connections have their radio managed by pymc-companion;
+           node set-radio speaks directly to the USB serial device and is not
+           applicable to those connection types. -->
+      <section v-if="radioConfig?.connection_type === 'serial'" class="card">
         <h2>MeshCore radio</h2>
         <p class="hint">
-          LoRa parameters for the MeshCore companion device
-          <span v-if="radioConfig?.connection_type === 'serial' && radioConfig?.serial_port">
-            (<code>{{ radioConfig.serial_port }}</code>)
-          </span>
-          <span v-else-if="radioConfig?.connection_type === 'hat'">
-            (Pi HAT via pymc-companion)
-          </span>
-          <span v-else-if="radioConfig?.connection_type === 'tcp'">
-            (TCP — pymc-companion)
-          </span>.
-          Saved to <code>[plugins.mesh.radio]</code> in config.toml.
-          Settings are <strong>not</strong> applied automatically — after saving, run:
-          <code>sudo supply-drop-bbs node set-radio</code>
-        </p>
-        <p class="hint" style="margin-top: 0.3rem">
-          Using Meshtastic? Radio parameters are configured in the Meshtastic app — they are not managed here.
+          LoRa parameters for the USB MeshCore companion device
+          <span v-if="radioConfig.serial_port">(<code>{{ radioConfig.serial_port }}</code>)</span>.
+          Save here to record them in config.toml, then push to the device once with
+          <code>sudo supply-drop-bbs node set-radio</code>.
+          The device stores these settings in its own flash — you only need to run that
+          command when you change the parameters, not on every restart.
         </p>
 
         <div v-if="radioError" class="notice error-notice">{{ radioError }}</div>

--- a/crates/bbs-web/web/src/pages/SettingsPage.vue
+++ b/crates/bbs-web/web/src/pages/SettingsPage.vue
@@ -553,7 +553,7 @@ async function saveMeshtasticRadio() {
   meshtasticRadioError.value = null
   meshtasticRadioOk.value = null
   try {
-    await api.patch('/api/v1/meshtastic-radio-config', {
+    const res = await api.patch<any>('/api/v1/meshtastic-radio-config', {
       use_preset:         meshtasticUsePreset.value,
       modem_preset:       meshtasticModemPreset.value,
       bandwidth:          meshtasticBandwidth.value,
@@ -567,7 +567,11 @@ async function saveMeshtasticRadio() {
       channel_num:        meshtasticChannelNum.value,
       override_frequency: meshtasticOverrideFrequency.value,
     })
-    meshtasticRadioOk.value = 'Radio config saved to device.'
+    if (res?.applied === false && res?.saved) {
+      meshtasticRadioOk.value = 'Saved to config.toml. Device not connected — settings will apply next time you run: supply-drop-bbs node set-meshtastic-radio'
+    } else {
+      meshtasticRadioOk.value = 'Radio config saved and applied to device.'
+    }
   } catch (e: any) {
     meshtasticRadioError.value = e?.message ?? 'failed to save meshtastic radio config'
   } finally {
@@ -623,12 +627,16 @@ async function saveMeshtasticOwner() {
   meshtasticOwnerError.value = null
   meshtasticOwnerOk.value = null
   try {
-    await api.patch('/api/v1/meshtastic-owner', {
+    const res = await api.patch<any>('/api/v1/meshtastic-owner', {
       long_name: meshtasticLongName.value || null,
       short_name: meshtasticShortName.value || null,
     })
-    meshtasticOwnerOk.value = 'Device owner info updated.'
-    await loadMeshtasticOwner()
+    if (res?.applied === false && res?.saved) {
+      meshtasticOwnerOk.value = 'Saved to config.toml. Device not connected — settings will apply next time you run: supply-drop-bbs node set-meshtastic-owner'
+    } else {
+      meshtasticOwnerOk.value = 'Node name saved and applied to device.'
+      await loadMeshtasticOwner()
+    }
   } catch (e: any) {
     meshtasticOwnerError.value = e?.message ?? 'failed to save device owner info'
   } finally {

--- a/src/main.rs
+++ b/src/main.rs
@@ -360,6 +360,52 @@ enum NodeAction {
         #[arg(long)]
         list_presets: bool,
     },
+
+    /// Apply Meshtastic LoRa radio configuration from config.toml to the device.
+    ///
+    /// Reads `[plugins.meshtastic.radio]` (region and modem preset) and pushes
+    /// them to the connected Meshtastic radio.  The device stores the settings
+    /// in its own flash so they survive power cycles.
+    ///
+    /// The BBS service must **not** be running on the same port when you run this.
+    ///
+    /// Example:
+    ///   supply-drop-bbs node set-meshtastic-radio
+    #[cfg(feature = "transport-meshtastic")]
+    SetMeshtasticRadio {
+        /// Serial port (e.g. /dev/ttyUSB0, COM3). Defaults to serial_port in config.toml.
+        #[arg(long)]
+        port: Option<String>,
+        /// Baud rate. Defaults to the value in config.toml or 115200.
+        #[arg(long)]
+        baud: Option<u32>,
+        /// TCP address for meshtasticd (e.g. 127.0.0.1:4403). Defaults to addr in config.toml.
+        #[arg(long)]
+        addr: Option<String>,
+    },
+
+    /// Apply Meshtastic node name (long name + short name) from config.toml to the device.
+    ///
+    /// Reads `[plugins.meshtastic]` `long_name` and `short_name` and pushes them
+    /// to the connected Meshtastic radio.  The existing PKC public key is
+    /// preserved by fetching owner info from the device first.
+    ///
+    /// The BBS service must **not** be running on the same port when you run this.
+    ///
+    /// Example:
+    ///   supply-drop-bbs node set-meshtastic-owner
+    #[cfg(feature = "transport-meshtastic")]
+    SetMeshtasticOwner {
+        /// Serial port. Defaults to serial_port in config.toml.
+        #[arg(long)]
+        port: Option<String>,
+        /// Baud rate. Defaults to the value in config.toml or 115200.
+        #[arg(long)]
+        baud: Option<u32>,
+        /// TCP address. Defaults to addr in config.toml.
+        #[arg(long)]
+        addr: Option<String>,
+    },
 }
 
 // ── Entry point ───────────────────────────────────────────────────────────────
@@ -1872,7 +1918,56 @@ fn save_radio_config(config_path: Option<&std::path::Path>, r: &ResolvedRadio) {
     }
 }
 
+// ── Meshtastic node command handler ──────────────────────────────────────────
+
+#[cfg(feature = "transport-meshtastic")]
+async fn cmd_node_meshtastic(config_path: Option<&std::path::Path>, action: NodeAction) {
+    let cfg = config::load(config_path).unwrap_or_default();
+    let mt_cfg = &cfg.plugins.meshtastic;
+
+    let (port_flag, baud_flag, addr_flag, is_set_radio) = match &action {
+        NodeAction::SetMeshtasticRadio { port, baud, addr } => {
+            (port.clone(), *baud, addr.clone(), true)
+        }
+        NodeAction::SetMeshtasticOwner { port, baud, addr } => {
+            (port.clone(), *baud, addr.clone(), false)
+        }
+        _ => unreachable!(),
+    };
+
+    let result = if is_set_radio {
+        bbs_meshtastic::apply_radio_from_config(mt_cfg, port_flag, baud_flag, addr_flag).await
+    } else {
+        bbs_meshtastic::apply_owner_from_config(mt_cfg, port_flag, baud_flag, addr_flag).await
+    };
+
+    match result {
+        Ok(()) => {
+            if is_set_radio {
+                eprintln!("Meshtastic radio config applied successfully.");
+            } else {
+                eprintln!("Meshtastic owner info applied successfully.");
+            }
+        }
+        Err(e) => {
+            eprintln!("error: {e}");
+            std::process::exit(1);
+        }
+    }
+}
+
 async fn cmd_node(config_path: Option<&std::path::Path>, action: NodeAction) {
+    // ── Meshtastic node commands ──────────────────────────────────────────────
+    #[cfg(feature = "transport-meshtastic")]
+    match &action {
+        NodeAction::SetMeshtasticRadio { .. } | NodeAction::SetMeshtasticOwner { .. } => {
+            cmd_node_meshtastic(config_path, action).await;
+            return;
+        }
+        _ => {}
+    }
+
+    // ── MeshCore node commands ────────────────────────────────────────────────
     #[cfg(feature = "transport-mesh")]
     {
         use meshcore_companion::{
@@ -1913,6 +2008,8 @@ async fn cmd_node(config_path: Option<&std::path::Path>, action: NodeAction) {
             NodeAction::ExportKey { port, baud } => (port.clone(), *baud),
             NodeAction::ImportKey { port, baud, .. } => (port.clone(), *baud),
             NodeAction::SetRadio { port, baud, .. } => (port.clone(), *baud),
+            // Meshtastic commands are intercepted and returned-from early above.
+            _ => unreachable!("Meshtastic commands should have been handled above"),
         };
 
         let port = match port_flag.or_else(|| {
@@ -2022,6 +2119,8 @@ async fn cmd_node(config_path: Option<&std::path::Path>, action: NodeAction) {
                 // Placeholder — the actual send is handled specially below.
                 OutboundFrame::GetBattAndStorage
             }
+            // Meshtastic commands are handled before this block — unreachable here.
+            _ => unreachable!("Meshtastic commands should have been handled above"),
         };
 
         let serial_cfg = SerialConfig {

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -1169,6 +1169,59 @@ pub fn run_wizard(config_out: Option<&Path>) {
         println!("HAT config written to {}.", yaml_path.display());
     }
 
+    // ── Apply Meshtastic settings to device ───────────────────────────────────
+    //
+    // The device is connected right now (user just configured the serial port),
+    // so we push the settings immediately.  If the push fails (device not
+    // present, wrong port, etc.) we warn and continue — the user can run the
+    // CLI commands later.
+    #[cfg(feature = "transport-meshtastic")]
+    if use_meshtastic {
+        let has_radio = meshtastic_radio_region.is_some() || meshtastic_radio_preset.is_some();
+        let has_owner = meshtastic_short_name.is_some() || meshtastic_long_name.is_some();
+        if has_radio || has_owner {
+            section("Applying Meshtastic settings to device");
+            // Load the config we just wrote so the push functions see the
+            // correct connection type, serial port, baud rate, etc.
+            let loaded = crate::config::load(Some(&out_path)).unwrap_or_default();
+            let mt_cfg = &loaded.plugins.meshtastic;
+
+            if has_radio {
+                println!("Pushing radio config (region / modem preset)…");
+                let result = tokio::task::block_in_place(|| {
+                    tokio::runtime::Handle::current().block_on(
+                        bbs_meshtastic::apply_radio_from_config(mt_cfg, None, None, None),
+                    )
+                });
+                match result {
+                    Ok(()) => println!("  ✓  Radio configuration applied."),
+                    Err(e) => {
+                        println!("  ✗  Could not apply radio config: {e}");
+                        println!("     Run later with: supply-drop-bbs node set-meshtastic-radio");
+                    }
+                }
+                println!();
+            }
+
+            if has_owner {
+                println!("Pushing node name…");
+                let result = tokio::task::block_in_place(|| {
+                    tokio::runtime::Handle::current().block_on(
+                        bbs_meshtastic::apply_owner_from_config(mt_cfg, None, None, None),
+                    )
+                });
+                match result {
+                    Ok(()) => println!("  ✓  Node name applied."),
+                    Err(e) => {
+                        println!("  ✗  Could not apply node name: {e}");
+                        println!("     Run later with: supply-drop-bbs node set-meshtastic-owner");
+                    }
+                }
+                println!();
+            }
+        }
+    }
+
     // ── Next steps ────────────────────────────────────────────────────────────
     section("Next steps");
     print_next_steps(

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -41,6 +41,8 @@ struct Existing {
     meshtastic_connection_type: String,
     meshtastic_serial_port: Option<String>,
     meshtastic_baud_rate: u32,
+    meshtastic_radio_region: Option<String>,
+    meshtastic_radio_preset: Option<String>,
     // Web
     web_enabled: bool,
     web_bind: String,
@@ -136,6 +138,16 @@ fn load_existing(out_path: &Path) -> Existing {
         .and_then(|v| v.as_integer())
         .map(|v| v as u32)
         .unwrap_or(115_200);
+    let meshtastic_radio_region = meshtastic
+        .and_then(|m| m.get("radio"))
+        .and_then(|r| r.get("region"))
+        .and_then(|v| v.as_str())
+        .map(str::to_owned);
+    let meshtastic_radio_preset = meshtastic
+        .and_then(|m| m.get("radio"))
+        .and_then(|r| r.get("modem_preset"))
+        .and_then(|v| v.as_str())
+        .map(str::to_owned);
 
     // Web
     let web_enabled = web
@@ -234,6 +246,8 @@ fn load_existing(out_path: &Path) -> Existing {
         meshtastic_connection_type,
         meshtastic_serial_port,
         meshtastic_baud_rate,
+        meshtastic_radio_region,
+        meshtastic_radio_preset,
         web_enabled,
         web_bind,
         web_backup_dir,
@@ -741,6 +755,108 @@ pub fn run_wizard(config_out: Option<&Path>) {
         meshtastic_addr = None;
     }
 
+    // ── Meshtastic radio parameters ───────────────────────────────────────────
+
+    /// (code, display label)
+    const MESHTASTIC_REGIONS: &[(&str, &str)] = &[
+        ("US", "United States"),
+        ("EU_433", "Europe 433 MHz"),
+        ("EU_868", "Europe 868 MHz"),
+        ("ANZ", "Australia / New Zealand"),
+        ("JP", "Japan"),
+        ("CN", "China"),
+        ("KR", "South Korea"),
+        ("TW", "Taiwan"),
+        ("RU", "Russia"),
+        ("IN", "India"),
+        ("NZ_865", "New Zealand 865 MHz"),
+        ("TH", "Thailand"),
+        ("LORA_24", "2.4 GHz LoRa"),
+        ("UA_433", "Ukraine 433 MHz"),
+        ("UA_868", "Ukraine 868 MHz"),
+        ("MY_433", "Malaysia 433 MHz"),
+        ("MY_919", "Malaysia 919 MHz"),
+        ("SG_923", "Singapore 923 MHz"),
+    ];
+
+    /// (code, display label)
+    const MESHTASTIC_PRESETS: &[(&str, &str)] = &[
+        (
+            "LONG_FAST",
+            "Long range, fast      (default — good starting point)",
+        ),
+        ("LONG_MODERATE", "Long range, moderate"),
+        ("MEDIUM_SLOW", "Medium range, slow"),
+        ("MEDIUM_FAST", "Medium range, fast"),
+        ("SHORT_SLOW", "Short range, slow"),
+        ("SHORT_FAST", "Short range, fast"),
+        ("LONG_SLOW", "Long range, slow      (very slow data rate)"),
+        (
+            "MAX_RANGE",
+            "Maximum range         (extremely slow data rate)",
+        ),
+        ("SHORT_TURBO", "Short range, turbo    (high data rate)"),
+    ];
+
+    let (meshtastic_radio_region, meshtastic_radio_preset): (Option<String>, Option<String>) =
+        if use_meshtastic {
+            section("Meshtastic radio parameters");
+
+            println!("Select the region and modem preset for your Meshtastic device.");
+            println!("These are saved to config.toml and can be pushed to the device");
+            println!("at any time via the web admin (Settings → Meshtastic radio).");
+            println!("Skip if the device is already configured correctly.");
+            println!();
+
+            let configure = Confirm::with_theme(&theme)
+                .with_prompt("Configure Meshtastic radio parameters now?")
+                .default(ex.meshtastic_radio_region.is_some())
+                .interact()
+                .unwrap_or_else(|_| cancelled());
+
+            if configure {
+                let region_labels: Vec<String> = MESHTASTIC_REGIONS
+                    .iter()
+                    .map(|(code, name)| format!("{code:<10} {name}"))
+                    .collect();
+                let default_region = ex
+                    .meshtastic_radio_region
+                    .as_deref()
+                    .and_then(|r| MESHTASTIC_REGIONS.iter().position(|(c, _)| *c == r))
+                    .unwrap_or(0); // US
+                let region_choice =
+                    prompt_select(&theme, "Select your region", &region_labels, default_region);
+                let region = MESHTASTIC_REGIONS[region_choice].0.to_owned();
+
+                println!();
+                let preset_labels: Vec<String> = MESHTASTIC_PRESETS
+                    .iter()
+                    .map(|(_, d)| d.to_string())
+                    .collect();
+                let default_preset = ex
+                    .meshtastic_radio_preset
+                    .as_deref()
+                    .and_then(|p| MESHTASTIC_PRESETS.iter().position(|(c, _)| *c == p))
+                    .unwrap_or(0); // LONG_FAST
+                let preset_choice = prompt_select(
+                    &theme,
+                    "Select modem preset",
+                    &preset_labels,
+                    default_preset,
+                );
+                let preset = MESHTASTIC_PRESETS[preset_choice].0.to_owned();
+
+                (Some(region), Some(preset))
+            } else {
+                (
+                    ex.meshtastic_radio_region.clone(),
+                    ex.meshtastic_radio_preset.clone(),
+                )
+            }
+        } else {
+            (None, None)
+        };
+
     // ── Web admin ─────────────────────────────────────────────────────────────
     section("Web admin UI");
 
@@ -877,6 +993,8 @@ pub fn run_wizard(config_out: Option<&Path>) {
         meshtastic_serial_port: meshtastic_serial_port.as_deref(),
         meshtastic_baud_rate,
         meshtastic_addr: meshtastic_addr.as_deref(),
+        meshtastic_radio_region: meshtastic_radio_region.as_deref(),
+        meshtastic_radio_preset: meshtastic_radio_preset.as_deref(),
         web_enabled,
         web_bind: web_bind.as_deref(),
         web_backup_dir: web_backup_dir.as_deref(),
@@ -1520,6 +1638,8 @@ struct TomlParams<'a> {
     meshtastic_serial_port: Option<&'a str>,
     meshtastic_baud_rate: Option<u32>,
     meshtastic_addr: Option<&'a str>,
+    meshtastic_radio_region: Option<&'a str>,
+    meshtastic_radio_preset: Option<&'a str>,
     // Web
     web_enabled: bool,
     web_bind: Option<&'a str>,
@@ -1655,6 +1775,20 @@ fn build_toml(p: &TomlParams<'_>) -> String {
             }
         }
     }
+    // [plugins.meshtastic.radio] — only when Meshtastic is enabled and params chosen
+    #[cfg(feature = "transport-meshtastic")]
+    if p.use_meshtastic
+        && (p.meshtastic_radio_region.is_some() || p.meshtastic_radio_preset.is_some())
+    {
+        writeln!(s, "\n[plugins.meshtastic.radio]").unwrap();
+        if let Some(region) = p.meshtastic_radio_region {
+            writeln!(s, "region       = {}", toml_str(region)).unwrap();
+        }
+        if let Some(preset) = p.meshtastic_radio_preset {
+            writeln!(s, "modem_preset = {}", toml_str(preset)).unwrap();
+        }
+    }
+
     // Suppress unused-variable warnings when feature is off.
     #[cfg(not(feature = "transport-meshtastic"))]
     {
@@ -1664,6 +1798,8 @@ fn build_toml(p: &TomlParams<'_>) -> String {
             p.meshtastic_serial_port,
             p.meshtastic_baud_rate,
             p.meshtastic_addr,
+            p.meshtastic_radio_region,
+            p.meshtastic_radio_preset,
         );
     }
 

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -43,6 +43,8 @@ struct Existing {
     meshtastic_baud_rate: u32,
     meshtastic_radio_region: Option<String>,
     meshtastic_radio_preset: Option<String>,
+    meshtastic_short_name: Option<String>,
+    meshtastic_long_name: Option<String>,
     // Web
     web_enabled: bool,
     web_bind: String,
@@ -148,6 +150,14 @@ fn load_existing(out_path: &Path) -> Existing {
         .and_then(|r| r.get("modem_preset"))
         .and_then(|v| v.as_str())
         .map(str::to_owned);
+    let meshtastic_short_name = meshtastic
+        .and_then(|m| m.get("short_name"))
+        .and_then(|v| v.as_str())
+        .map(str::to_owned);
+    let meshtastic_long_name = meshtastic
+        .and_then(|m| m.get("long_name"))
+        .and_then(|v| v.as_str())
+        .map(str::to_owned);
 
     // Web
     let web_enabled = web
@@ -248,6 +258,8 @@ fn load_existing(out_path: &Path) -> Existing {
         meshtastic_baud_rate,
         meshtastic_radio_region,
         meshtastic_radio_preset,
+        meshtastic_short_name,
+        meshtastic_long_name,
         web_enabled,
         web_bind,
         web_backup_dir,
@@ -857,6 +869,56 @@ pub fn run_wizard(config_out: Option<&Path>) {
             (None, None)
         };
 
+    // ── Meshtastic node name ──────────────────────────────────────────────────
+
+    let (meshtastic_short_name, meshtastic_long_name): (Option<String>, Option<String>) =
+        if use_meshtastic {
+            section("Meshtastic node name");
+
+            println!("Set the long name (full display name) and short name (≤ 4 chars,");
+            println!("shown on mesh maps). These are saved to config.toml and can be");
+            println!("pushed to the device via the web admin UI at any time.");
+            println!();
+
+            let configure = Confirm::with_theme(&theme)
+                .with_prompt("Configure Meshtastic node name?")
+                .default(ex.meshtastic_short_name.is_some() || ex.meshtastic_long_name.is_some())
+                .interact()
+                .unwrap_or_else(|_| cancelled());
+
+            if configure {
+                let long: String = Input::with_theme(&theme)
+                    .with_prompt("Long name (full display name)")
+                    .default(ex.meshtastic_long_name.clone().unwrap_or_default())
+                    .interact_text()
+                    .unwrap_or_else(|_| cancelled());
+
+                let short: String = Input::with_theme(&theme)
+                    .with_prompt("Short name (≤ 4 chars, shown on maps)")
+                    .default(ex.meshtastic_short_name.clone().unwrap_or_default())
+                    .validate_with(|v: &String| {
+                        if v.chars().count() <= 4 {
+                            Ok(())
+                        } else {
+                            Err("Short name must be 4 characters or fewer")
+                        }
+                    })
+                    .interact_text()
+                    .unwrap_or_else(|_| cancelled());
+
+                let ln = if long.is_empty() { None } else { Some(long) };
+                let sn = if short.is_empty() { None } else { Some(short) };
+                (sn, ln)
+            } else {
+                (
+                    ex.meshtastic_short_name.clone(),
+                    ex.meshtastic_long_name.clone(),
+                )
+            }
+        } else {
+            (None, None)
+        };
+
     // ── Web admin ─────────────────────────────────────────────────────────────
     section("Web admin UI");
 
@@ -995,6 +1057,8 @@ pub fn run_wizard(config_out: Option<&Path>) {
         meshtastic_addr: meshtastic_addr.as_deref(),
         meshtastic_radio_region: meshtastic_radio_region.as_deref(),
         meshtastic_radio_preset: meshtastic_radio_preset.as_deref(),
+        meshtastic_short_name: meshtastic_short_name.as_deref(),
+        meshtastic_long_name: meshtastic_long_name.as_deref(),
         web_enabled,
         web_bind: web_bind.as_deref(),
         web_backup_dir: web_backup_dir.as_deref(),
@@ -1640,6 +1704,8 @@ struct TomlParams<'a> {
     meshtastic_addr: Option<&'a str>,
     meshtastic_radio_region: Option<&'a str>,
     meshtastic_radio_preset: Option<&'a str>,
+    meshtastic_short_name: Option<&'a str>,
+    meshtastic_long_name: Option<&'a str>,
     // Web
     web_enabled: bool,
     web_bind: Option<&'a str>,
@@ -1773,6 +1839,12 @@ fn build_toml(p: &TomlParams<'_>) -> String {
                 }
                 _ => {}
             }
+            if let Some(sn) = p.meshtastic_short_name {
+                writeln!(s, "short_name = {}", toml_str(sn)).unwrap();
+            }
+            if let Some(ln) = p.meshtastic_long_name {
+                writeln!(s, "long_name  = {}", toml_str(ln)).unwrap();
+            }
         }
     }
     // [plugins.meshtastic.radio] — only when Meshtastic is enabled and params chosen
@@ -1800,6 +1872,8 @@ fn build_toml(p: &TomlParams<'_>) -> String {
             p.meshtastic_addr,
             p.meshtastic_radio_region,
             p.meshtastic_radio_preset,
+            p.meshtastic_short_name,
+            p.meshtastic_long_name,
         );
     }
 

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -386,6 +386,31 @@ pub fn run_wizard(config_out: Option<&Path>) {
 
     let ex = load_existing(&out_path);
 
+    // ── BBS identity ──────────────────────────────────────────────────────────
+    //
+    // Collected first so it is clear there is exactly one BBS instance.
+    // All radio transports (MeshCore, Meshtastic, …) configured below are
+    // simply different ways to reach the same BBS — they do not have
+    // separate identities.
+    section("BBS identity");
+
+    let bbs_name: String = Input::with_theme(&theme)
+        .with_prompt("BBS name")
+        .default(ex.bbs_name.clone())
+        .interact_text()
+        .unwrap_or_else(|_| cancelled());
+
+    // ── Data storage ──────────────────────────────────────────────────────────
+    section("Data storage");
+
+    let data_dir_str: String = Input::with_theme(&theme)
+        .with_prompt("Data directory")
+        .default(ex.data_dir.clone())
+        .interact_text()
+        .unwrap_or_else(|_| cancelled());
+
+    let data_dir = PathBuf::from(&data_dir_str);
+
     // ── Protocol selection ────────────────────────────────────────────────────
     //
     // Which protocols appear here is determined by compiled-in features:
@@ -715,26 +740,6 @@ pub fn run_wizard(config_out: Option<&Path>) {
         meshtastic_baud_rate = None;
         meshtastic_addr = None;
     }
-
-    // ── BBS identity ──────────────────────────────────────────────────────────
-    section("BBS identity");
-
-    let bbs_name: String = Input::with_theme(&theme)
-        .with_prompt("BBS name")
-        .default(ex.bbs_name.clone())
-        .interact_text()
-        .unwrap_or_else(|_| cancelled());
-
-    // ── Data storage ──────────────────────────────────────────────────────────
-    section("Data storage");
-
-    let data_dir_str: String = Input::with_theme(&theme)
-        .with_prompt("Data directory")
-        .default(ex.data_dir.clone())
-        .interact_text()
-        .unwrap_or_else(|_| cancelled());
-
-    let data_dir = PathBuf::from(&data_dir_str);
 
     // ── Web admin ─────────────────────────────────────────────────────────────
     section("Web admin UI");

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -1169,58 +1169,10 @@ pub fn run_wizard(config_out: Option<&Path>) {
         println!("HAT config written to {}.", yaml_path.display());
     }
 
-    // ── Apply Meshtastic settings to device ───────────────────────────────────
-    //
-    // The device is connected right now (user just configured the serial port),
-    // so we push the settings immediately.  If the push fails (device not
-    // present, wrong port, etc.) we warn and continue — the user can run the
-    // CLI commands later.
-    #[cfg(feature = "transport-meshtastic")]
-    if use_meshtastic {
-        let has_radio = meshtastic_radio_region.is_some() || meshtastic_radio_preset.is_some();
-        let has_owner = meshtastic_short_name.is_some() || meshtastic_long_name.is_some();
-        if has_radio || has_owner {
-            section("Applying Meshtastic settings to device");
-            // Load the config we just wrote so the push functions see the
-            // correct connection type, serial port, baud rate, etc.
-            let loaded = crate::config::load(Some(&out_path)).unwrap_or_default();
-            let mt_cfg = &loaded.plugins.meshtastic;
-
-            if has_radio {
-                println!("Pushing radio config (region / modem preset)…");
-                let result = tokio::task::block_in_place(|| {
-                    tokio::runtime::Handle::current().block_on(
-                        bbs_meshtastic::apply_radio_from_config(mt_cfg, None, None, None),
-                    )
-                });
-                match result {
-                    Ok(()) => println!("  ✓  Radio configuration applied."),
-                    Err(e) => {
-                        println!("  ✗  Could not apply radio config: {e}");
-                        println!("     Run later with: supply-drop-bbs node set-meshtastic-radio");
-                    }
-                }
-                println!();
-            }
-
-            if has_owner {
-                println!("Pushing node name…");
-                let result = tokio::task::block_in_place(|| {
-                    tokio::runtime::Handle::current().block_on(
-                        bbs_meshtastic::apply_owner_from_config(mt_cfg, None, None, None),
-                    )
-                });
-                match result {
-                    Ok(()) => println!("  ✓  Node name applied."),
-                    Err(e) => {
-                        println!("  ✗  Could not apply node name: {e}");
-                        println!("     Run later with: supply-drop-bbs node set-meshtastic-owner");
-                    }
-                }
-                println!();
-            }
-        }
-    }
+    // Meshtastic radio and node-name settings are applied to the device
+    // automatically by the transport when the BBS connects (see the
+    // auto-apply-on-connect logic in bbs-meshtastic).  No setup-time push is
+    // needed — the operator just starts the BBS and the settings take effect.
 
     // ── Next steps ────────────────────────────────────────────────────────────
     section("Next steps");
@@ -2082,17 +2034,14 @@ fn print_next_steps(
         println!();
     }
 
-    // Meshtastic settings push hint
+    // Meshtastic settings note
     if use_meshtastic {
         println!("Meshtastic radio and node settings:");
         println!();
         println!("  The region, modem preset, and node name were saved to config.toml.");
-        println!("  To push them to the device now (BBS must NOT be running):");
-        println!();
-        println!("    supply-drop-bbs node set-meshtastic-radio");
-        println!("    supply-drop-bbs node set-meshtastic-owner");
-        println!();
-        println!("  Or push them later from Settings in the web admin UI.");
+        println!("  They are applied to the device automatically when the BBS connects —");
+        println!("  just start the BBS and they take effect. You can change them any time");
+        println!("  from Settings in the web admin UI (also applied automatically).");
         println!();
     }
 

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -2029,6 +2029,20 @@ fn print_next_steps(
         println!();
     }
 
+    // Meshtastic settings push hint
+    if use_meshtastic {
+        println!("Meshtastic radio and node settings:");
+        println!();
+        println!("  The region, modem preset, and node name were saved to config.toml.");
+        println!("  To push them to the device now (BBS must NOT be running):");
+        println!();
+        println!("    supply-drop-bbs node set-meshtastic-radio");
+        println!("    supply-drop-bbs node set-meshtastic-owner");
+        println!();
+        println!("  Or push them later from Settings in the web admin UI.");
+        println!();
+    }
+
     if cfg!(target_os = "linux") {
         println!("To run Supply Drop BBS as a systemd service:");
         println!();


### PR DESCRIPTION
## Summary

Addresses four issues found during local testing of the Meshtastic integration:

### 1. Node identity card clarified as MeshCore-only
The "Node identity" card now has a **MeshCore** badge and explicitly notes that Meshtastic PKC keys are in the separate "Meshtastic device" section.

### 2. Region and modem preset as named dropdowns
The Meshtastic radio card now shows all 19 regions and 13 modem presets as human-readable dropdowns instead of raw integers. Custom LoRa fields are disabled when "Use preset" is active.

### 3. Short name + long name — setup wizard, config, and web UI
- `MeshtasticConfig` gains `short_name` and `long_name` fields stored in `[plugins.meshtastic]`
- Setup wizard gains a "Meshtastic node name" section
- New **Meshtastic device** card in Settings: editable long name + short name, push to device via `PATCH /api/v1/meshtastic-owner`

### 4. Meshtastic public key display
- Same card shows the device's Curve25519 public key (hex) via `GET /api/v1/meshtastic-security`
- Admin channel status shown; private key management directed to Meshtastic app

### Proto corrections (important — previous implementation had wrong field numbers)
| What | Old tag | Correct tag |
|------|---------|-------------|
| `get_config_request` | 13 | **5** |
| `set_config` | 11 | **34** |
| `Config.lora` | 3 | **6** |
| `session_passkey` | — | **101** (new) |
| `get_owner_request` | — | **3** (new) |
| `set_owner` | — | **32** (new) |

## New API endpoints
| Method | Path | Description |
|--------|------|-------------|
| `GET` | `/api/v1/meshtastic-owner` | Fetch owner info from device |
| `PATCH` | `/api/v1/meshtastic-owner` | Update long/short name on device |
| `GET` | `/api/v1/meshtastic-security` | Fetch security/PKC config from device |

## Test plan
- [ ] Meshtastic radio: Region and modem preset dropdowns show named values
- [ ] Meshtastic device card: "Load from device" populates long name, short name, node ID
- [ ] Meshtastic device card: Edit names → "Save to device" pushes to device
- [ ] Meshtastic device card: "Load security config" shows Curve25519 public key (hex)
- [ ] Node identity card shows "(MeshCore)" badge
- [ ] Setup wizard: "Meshtastic node name" section saves short/long name to config.toml
- [ ] No regression on MeshCore admin operations (key export/import/apply-radio)

🤖 Generated with [Claude Code](https://claude.com/claude-code)