### PR TITLE
Meshtastic device management, advert list, settings UX, and service-restart fixes

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -238,6 +238,22 @@
 # reconnect_delay_initial_ms = 1000
 # reconnect_delay_max_ms = 60000
 
+# Node name shown on the mesh (long ≤ 39 chars, short ≤ 4 chars).
+# long_name = "Supply Drop BBS"
+# short_name = "SDB"
+
+# Radio settings pushed to the device on connect (skip-if-unchanged, so the
+# radio only reboots when a value actually changes). On connect the BBS also
+# syncs the device clock, sets a fixed position from [location], and sets the
+# device's node_info_broadcast_secs to 1h so the node re-announces hourly.
+# [plugins.meshtastic.radio]
+# region          = "US"          # e.g. US, EU_868, ANZ; omit to keep current
+# modem_preset    = "LONG_FAST"   # e.g. LONG_FAST, MEDIUM_SLOW
+# hops            = 3             # max hops for packets we originate
+# rx_boosted_gain = true          # SX126x RX boosted gain
+# ignore_mqtt     = true          # ignore MQTT-sourced packets
+# tx_enabled      = true          # radio transmitter enabled
+
 
 # ─── Plugin: web admin ────────────────────────────────────────────
 #

--- a/crates/bbs-core/src/host.rs
+++ b/crates/bbs-core/src/host.rs
@@ -688,6 +688,96 @@ impl Host for BbsHost {
             .map_err(bbs_plugin_api::HostError::Internal)
     }
 
+    async fn admin_get_meshtastic_owner(
+        &self,
+    ) -> Result<bbs_plugin_api::MeshtasticOwnerInfo, bbs_plugin_api::HostError> {
+        let tx = self
+            .meshtastic_admin_tx
+            .read()
+            .expect("meshtastic_admin_tx poisoned")
+            .clone()
+            .ok_or_else(|| {
+                bbs_plugin_api::HostError::Internal("meshtastic transport not connected".into())
+            })?;
+        let (reply_tx, reply_rx) = tokio::sync::oneshot::channel();
+        tx.send(bbs_plugin_api::MeshtasticAdminRequest::GetOwner { reply: reply_tx })
+            .await
+            .map_err(|_| {
+                bbs_plugin_api::HostError::Internal("meshtastic transport disconnected".into())
+            })?;
+        tokio::time::timeout(std::time::Duration::from_secs(10), reply_rx)
+            .await
+            .map_err(|_| {
+                bbs_plugin_api::HostError::Internal("meshtastic owner get timed out".into())
+            })?
+            .map_err(|_| {
+                bbs_plugin_api::HostError::Internal("meshtastic owner get cancelled".into())
+            })?
+            .map_err(bbs_plugin_api::HostError::Internal)
+    }
+
+    async fn admin_set_meshtastic_owner(
+        &self,
+        long_name: Option<String>,
+        short_name: Option<String>,
+    ) -> Result<(), bbs_plugin_api::HostError> {
+        let tx = self
+            .meshtastic_admin_tx
+            .read()
+            .expect("meshtastic_admin_tx poisoned")
+            .clone()
+            .ok_or_else(|| {
+                bbs_plugin_api::HostError::Internal("meshtastic transport not connected".into())
+            })?;
+        let (reply_tx, reply_rx) = tokio::sync::oneshot::channel();
+        tx.send(bbs_plugin_api::MeshtasticAdminRequest::SetOwner {
+            long_name,
+            short_name,
+            reply: reply_tx,
+        })
+        .await
+        .map_err(|_| {
+            bbs_plugin_api::HostError::Internal("meshtastic transport disconnected".into())
+        })?;
+        tokio::time::timeout(std::time::Duration::from_secs(10), reply_rx)
+            .await
+            .map_err(|_| {
+                bbs_plugin_api::HostError::Internal("meshtastic owner set timed out".into())
+            })?
+            .map_err(|_| {
+                bbs_plugin_api::HostError::Internal("meshtastic owner set cancelled".into())
+            })?
+            .map_err(bbs_plugin_api::HostError::Internal)
+    }
+
+    async fn admin_get_meshtastic_security(
+        &self,
+    ) -> Result<bbs_plugin_api::MeshtasticSecurityInfo, bbs_plugin_api::HostError> {
+        let tx = self
+            .meshtastic_admin_tx
+            .read()
+            .expect("meshtastic_admin_tx poisoned")
+            .clone()
+            .ok_or_else(|| {
+                bbs_plugin_api::HostError::Internal("meshtastic transport not connected".into())
+            })?;
+        let (reply_tx, reply_rx) = tokio::sync::oneshot::channel();
+        tx.send(bbs_plugin_api::MeshtasticAdminRequest::GetSecurity { reply: reply_tx })
+            .await
+            .map_err(|_| {
+                bbs_plugin_api::HostError::Internal("meshtastic transport disconnected".into())
+            })?;
+        tokio::time::timeout(std::time::Duration::from_secs(10), reply_rx)
+            .await
+            .map_err(|_| {
+                bbs_plugin_api::HostError::Internal("meshtastic security get timed out".into())
+            })?
+            .map_err(|_| {
+                bbs_plugin_api::HostError::Internal("meshtastic security get cancelled".into())
+            })?
+            .map_err(bbs_plugin_api::HostError::Internal)
+    }
+
     // ── Admin / web-UI operations ─────────────────────────────────────────────
 
     async fn admin_verify_credentials(

--- a/crates/bbs-core/src/host.rs
+++ b/crates/bbs-core/src/host.rs
@@ -218,6 +218,11 @@ pub struct BbsHost {
     /// None when the mesh transport has not registered itself.
     mesh_key_tx:
         std::sync::RwLock<Option<tokio::sync::mpsc::Sender<bbs_plugin_api::MeshKeyRequest>>>,
+    /// Sending half of the Meshtastic admin channel.
+    /// None when the Meshtastic transport has not registered itself.
+    meshtastic_admin_tx: std::sync::RwLock<
+        Option<tokio::sync::mpsc::Sender<bbs_plugin_api::MeshtasticAdminRequest>>,
+    >,
 }
 
 impl BbsHost {
@@ -255,6 +260,7 @@ impl BbsHost {
             config_path,
             node_pubkey: std::sync::RwLock::new(None),
             mesh_key_tx: std::sync::RwLock::new(None),
+            meshtastic_admin_tx: std::sync::RwLock::new(None),
         }
     }
 
@@ -583,6 +589,102 @@ impl Host for BbsHost {
         reply_rx
             .await
             .map_err(|_| bbs_plugin_api::HostError::Internal("key op cancelled".into()))?
+            .map_err(bbs_plugin_api::HostError::Internal)
+    }
+
+    async fn admin_apply_mesh_radio(
+        &self,
+        params: bbs_plugin_api::MeshRadioParams,
+    ) -> Result<(), bbs_plugin_api::HostError> {
+        let tx = self
+            .mesh_key_tx
+            .read()
+            .expect("mesh_key_tx poisoned")
+            .clone()
+            .ok_or_else(|| {
+                bbs_plugin_api::HostError::Internal("mesh transport not connected".into())
+            })?;
+        let (reply_tx, reply_rx) = tokio::sync::oneshot::channel();
+        tx.send(bbs_plugin_api::MeshKeyRequest::ApplyRadio {
+            params,
+            reply: reply_tx,
+        })
+        .await
+        .map_err(|_| bbs_plugin_api::HostError::Internal("mesh transport disconnected".into()))?;
+        tokio::time::timeout(std::time::Duration::from_secs(10), reply_rx)
+            .await
+            .map_err(|_| bbs_plugin_api::HostError::Internal("radio apply timed out".into()))?
+            .map_err(|_| bbs_plugin_api::HostError::Internal("radio apply cancelled".into()))?
+            .map_err(bbs_plugin_api::HostError::Internal)
+    }
+
+    fn register_meshtastic_admin_ops(
+        &self,
+        sender: tokio::sync::mpsc::Sender<bbs_plugin_api::MeshtasticAdminRequest>,
+    ) {
+        *self
+            .meshtastic_admin_tx
+            .write()
+            .expect("meshtastic_admin_tx poisoned") = Some(sender);
+    }
+
+    async fn admin_get_meshtastic_lora(
+        &self,
+    ) -> Result<bbs_plugin_api::MeshtasticLoRaConfig, bbs_plugin_api::HostError> {
+        let tx = self
+            .meshtastic_admin_tx
+            .read()
+            .expect("meshtastic_admin_tx poisoned")
+            .clone()
+            .ok_or_else(|| {
+                bbs_plugin_api::HostError::Internal("meshtastic transport not connected".into())
+            })?;
+        let (reply_tx, reply_rx) = tokio::sync::oneshot::channel();
+        tx.send(bbs_plugin_api::MeshtasticAdminRequest::GetLoRaConfig { reply: reply_tx })
+            .await
+            .map_err(|_| {
+                bbs_plugin_api::HostError::Internal("meshtastic transport disconnected".into())
+            })?;
+        tokio::time::timeout(std::time::Duration::from_secs(10), reply_rx)
+            .await
+            .map_err(|_| {
+                bbs_plugin_api::HostError::Internal("meshtastic lora get timed out".into())
+            })?
+            .map_err(|_| {
+                bbs_plugin_api::HostError::Internal("meshtastic lora get cancelled".into())
+            })?
+            .map_err(bbs_plugin_api::HostError::Internal)
+    }
+
+    async fn admin_set_meshtastic_lora(
+        &self,
+        config: bbs_plugin_api::MeshtasticLoRaConfig,
+    ) -> Result<(), bbs_plugin_api::HostError> {
+        let tx = self
+            .meshtastic_admin_tx
+            .read()
+            .expect("meshtastic_admin_tx poisoned")
+            .clone()
+            .ok_or_else(|| {
+                bbs_plugin_api::HostError::Internal("meshtastic transport not connected".into())
+            })?;
+        let (reply_tx, reply_rx) = tokio::sync::oneshot::channel();
+        tx.send(bbs_plugin_api::MeshtasticAdminRequest::SetLoRaConfig {
+            config,
+            reply: reply_tx,
+        })
+        .await
+        .map_err(|_| {
+            bbs_plugin_api::HostError::Internal("meshtastic transport disconnected".into())
+        })?;
+        tokio::time::timeout(std::time::Duration::from_secs(10), reply_rx)
+            .await
+            .map_err(|_| {
+                bbs_plugin_api::HostError::Internal("meshtastic lora set timed out".into())
+            })?
+            .map_err(|_| {
+                bbs_plugin_api::HostError::Internal("meshtastic lora set cancelled".into())
+            })?
             .map_err(bbs_plugin_api::HostError::Internal)
     }
 

--- a/crates/bbs-core/src/host.rs
+++ b/crates/bbs-core/src/host.rs
@@ -778,6 +778,35 @@ impl Host for BbsHost {
             .map_err(bbs_plugin_api::HostError::Internal)
     }
 
+    async fn admin_get_meshtastic_snapshot(
+        &self,
+    ) -> Result<bbs_plugin_api::MeshtasticDeviceSnapshot, bbs_plugin_api::HostError> {
+        let tx = self
+            .meshtastic_admin_tx
+            .read()
+            .expect("meshtastic_admin_tx poisoned")
+            .clone()
+            .ok_or_else(|| {
+                bbs_plugin_api::HostError::Internal("meshtastic transport not connected".into())
+            })?;
+        let (reply_tx, reply_rx) = tokio::sync::oneshot::channel();
+        tx.send(bbs_plugin_api::MeshtasticAdminRequest::GetSnapshot { reply: reply_tx })
+            .await
+            .map_err(|_| {
+                bbs_plugin_api::HostError::Internal("meshtastic transport disconnected".into())
+            })?;
+        // The snapshot is served from cache, so this resolves near-instantly.
+        tokio::time::timeout(std::time::Duration::from_secs(5), reply_rx)
+            .await
+            .map_err(|_| {
+                bbs_plugin_api::HostError::Internal("meshtastic snapshot timed out".into())
+            })?
+            .map_err(|_| {
+                bbs_plugin_api::HostError::Internal("meshtastic snapshot cancelled".into())
+            })?
+            .map_err(bbs_plugin_api::HostError::Internal)
+    }
+
     // ── Admin / web-UI operations ─────────────────────────────────────────────
 
     async fn admin_verify_credentials(

--- a/crates/bbs-core/src/host.rs
+++ b/crates/bbs-core/src/host.rs
@@ -807,6 +807,31 @@ impl Host for BbsHost {
             .map_err(bbs_plugin_api::HostError::Internal)
     }
 
+    async fn admin_reboot_meshtastic(&self, seconds: i32) -> Result<(), bbs_plugin_api::HostError> {
+        let tx = self
+            .meshtastic_admin_tx
+            .read()
+            .expect("meshtastic_admin_tx poisoned")
+            .clone()
+            .ok_or_else(|| {
+                bbs_plugin_api::HostError::Internal("meshtastic transport not connected".into())
+            })?;
+        let (reply_tx, reply_rx) = tokio::sync::oneshot::channel();
+        tx.send(bbs_plugin_api::MeshtasticAdminRequest::Reboot {
+            seconds,
+            reply: reply_tx,
+        })
+        .await
+        .map_err(|_| {
+            bbs_plugin_api::HostError::Internal("meshtastic transport disconnected".into())
+        })?;
+        tokio::time::timeout(std::time::Duration::from_secs(10), reply_rx)
+            .await
+            .map_err(|_| bbs_plugin_api::HostError::Internal("meshtastic reboot timed out".into()))?
+            .map_err(|_| bbs_plugin_api::HostError::Internal("meshtastic reboot cancelled".into()))?
+            .map_err(bbs_plugin_api::HostError::Internal)
+    }
+
     // ── Admin / web-UI operations ─────────────────────────────────────────────
 
     async fn admin_verify_credentials(

--- a/crates/bbs-mesh/src/transport.rs
+++ b/crates/bbs-mesh/src/transport.rs
@@ -484,6 +484,13 @@ enum PendingKeyOp {
     Import {
         reply: tokio::sync::oneshot::Sender<Result<(), String>>,
     },
+    ApplyRadio {
+        reply: tokio::sync::oneshot::Sender<Result<(), String>>,
+        /// true = waiting for SetRadioParams Ok; false = waiting for SetRadioTxPower Ok
+        waiting_for_params: bool,
+        /// tx_power to send after params Ok arrives
+        tx_power_dbm: i8,
+    },
 }
 
 /// Background task: receive [`ClientEvent`]s and dispatch them.
@@ -597,6 +604,7 @@ async fn event_loop(
                             match op {
                                 PendingKeyOp::Export { reply } => { let _ = reply.send(Err(err)); }
                                 PendingKeyOp::Import { reply } => { let _ = reply.send(Err(err)); }
+                                PendingKeyOp::ApplyRadio { reply, .. } => { let _ = reply.send(Err(err)); }
                             }
                         }
                         if will_retry {
@@ -620,11 +628,30 @@ async fn event_loop(
                                 }
                             }
                             InboundFrame::Ok => {
-                                if let Some(PendingKeyOp::Import { reply }) = pending_key_op.take() {
-                                    let _ = reply.send(Ok(()));
-                                    true
-                                } else {
-                                    false
+                                match pending_key_op.take() {
+                                    Some(PendingKeyOp::Import { reply }) => {
+                                        let _ = reply.send(Ok(()));
+                                        true
+                                    }
+                                    Some(PendingKeyOp::ApplyRadio { reply, waiting_for_params: true, tx_power_dbm }) => {
+                                        // Params acknowledged — now send TX power
+                                        let _ = cmd_tx.send(OutboundFrame::SetRadioTxPower { power_dbm: tx_power_dbm }).await;
+                                        pending_key_op = Some(PendingKeyOp::ApplyRadio {
+                                            reply,
+                                            waiting_for_params: false,
+                                            tx_power_dbm,
+                                        });
+                                        true
+                                    }
+                                    Some(PendingKeyOp::ApplyRadio { reply, waiting_for_params: false, .. }) => {
+                                        // TX power acknowledged — done
+                                        let _ = reply.send(Ok(()));
+                                        true
+                                    }
+                                    other => {
+                                        pending_key_op = other;
+                                        false
+                                    }
                                 }
                             }
                             // Device returned an error frame while a key op was in
@@ -635,6 +662,7 @@ async fn event_loop(
                                     match op {
                                         PendingKeyOp::Export { reply } => { let _ = reply.send(Err(msg)); }
                                         PendingKeyOp::Import { reply } => { let _ = reply.send(Err(msg)); }
+                                        PendingKeyOp::ApplyRadio { reply, .. } => { let _ = reply.send(Err(msg)); }
                                     }
                                     true
                                 } else {
@@ -666,6 +694,23 @@ async fn event_loop(
                         } else {
                             let _ = cmd_tx.send(OutboundFrame::ImportPrivateKey { key }).await;
                             pending_key_op = Some(PendingKeyOp::Import { reply });
+                        }
+                    }
+                    MeshKeyRequest::ApplyRadio { params, reply } => {
+                        if pending_key_op.is_some() {
+                            let _ = reply.send(Err("another device operation is already in progress".into()));
+                        } else {
+                            let _ = cmd_tx.send(OutboundFrame::SetRadioParams {
+                                frequency_hz: params.frequency_hz,
+                                bandwidth_hz: params.bandwidth_hz,
+                                spreading_factor: params.spreading_factor,
+                                coding_rate: params.coding_rate,
+                            }).await;
+                            pending_key_op = Some(PendingKeyOp::ApplyRadio {
+                                reply,
+                                waiting_for_params: true,
+                                tx_power_dbm: params.tx_power_dbm,
+                            });
                         }
                     }
                 }

--- a/crates/bbs-mesh/src/transport.rs
+++ b/crates/bbs-mesh/src/transport.rs
@@ -49,6 +49,10 @@ use meshcore_companion::{
 /// Wire layout: `[prefix:1][len:2][CMD:1][txt_type:1][attempt:1][timestamp:4][prefix:6][text:N]`
 /// = 16 bytes of overhead.  Total frame must not exceed `MAX_FRAME_SIZE`.
 const MAX_REPLY_BYTES: usize = MAX_FRAME_SIZE - 16;
+
+/// Transport name recorded on advert records so the web UI can show which
+/// radio network each node was heard on.
+const TRANSPORT_NAME: &str = "meshcore";
 use tokio::sync::{mpsc, watch};
 use tracing::{debug, error, info, warn};
 
@@ -542,6 +546,7 @@ async fn event_loop(
                                 info.adv_type,
                                 info.latitude,
                                 info.longitude,
+                                TRANSPORT_NAME,
                             );
                             // Record our own pubkey so the NewAdvert handler can
                             // detect self-advert echoes and preserve configured GPS.
@@ -566,6 +571,7 @@ async fn event_loop(
                                     info.adv_type,
                                     lat_1e6,
                                     lon_1e6,
+                                    TRANSPORT_NAME,
                                 );
                             }
                         } else {
@@ -802,7 +808,7 @@ async fn handle_frame(
         // Record in the shared advert bus so the web UI can display them.
         // Sessions are minted on first DM, not on advert.
         InboundFrame::Advert { pubkey } => {
-            host.advert_bus().upsert_short(pubkey);
+            host.advert_bus().upsert_short(pubkey, TRANSPORT_NAME);
             debug!(prefix = ?&pubkey[..6], "mesh: short advert received");
         }
         InboundFrame::NewAdvert(contact) => {
@@ -824,6 +830,7 @@ async fn handle_frame(
                 contact.adv_type,
                 gps_lat,
                 gps_lon,
+                TRANSPORT_NAME,
             );
             // Record the full pubkey so we can send ResetPath after delivers.
             let prefix: [u8; 6] = contact.pubkey[..6].try_into().expect("pubkey is 32 bytes");
@@ -851,6 +858,7 @@ async fn handle_frame(
                 contact.gps_lat,
                 contact.gps_lon,
                 contact.last_advert_timestamp as i64,
+                TRANSPORT_NAME,
             );
             // Record the full pubkey mapping so ResetPath can find the node.
             let prefix: [u8; 6] = contact.pubkey[..6].try_into().expect("pubkey is 32 bytes");

--- a/crates/bbs-meshtastic/src/lib.rs
+++ b/crates/bbs-meshtastic/src/lib.rs
@@ -1093,14 +1093,18 @@ fn enqueue_auto_apply(
                     "meshtastic: radio config already matches device, skipping write (no reboot)"
                 );
             } else {
+                // Log exactly which fields differ so a spurious reboot-on-every-
+                // connect can be diagnosed (the device may not report a field we
+                // force, making the compare always fail).
                 info!(
-                    region = radio.region.as_deref().unwrap_or("(unchanged)"),
-                    modem_preset = radio.modem_preset.as_deref().unwrap_or("(unchanged)"),
-                    hops = radio.hops,
-                    tx_enabled = radio.tx_enabled,
-                    rx_boosted_gain = radio.rx_boosted_gain,
-                    ignore_mqtt = radio.ignore_mqtt,
-                    "meshtastic: queuing radio config from config.toml for apply-on-connect"
+                    use_preset = ?(current.use_preset, desired.use_preset),
+                    region = ?(current.region, desired.region),
+                    modem_preset = ?(current.modem_preset, desired.modem_preset),
+                    hop_limit = ?(current.hop_limit, desired.hop_limit),
+                    tx_enabled = ?(current.tx_enabled, desired.tx_enabled),
+                    rx_boosted_gain = ?(current.sx126x_rx_boosted_gain, desired.sx126x_rx_boosted_gain),
+                    ignore_mqtt = ?(current.ignore_mqtt, desired.ignore_mqtt),
+                    "meshtastic: queuing radio config — fields differ (current, desired)"
                 );
                 deferred.push(DeferredWrite::Lora {
                     lora: desired,
@@ -1130,9 +1134,12 @@ fn enqueue_auto_apply(
             );
         } else {
             info!(
-                long_name = %user.long_name,
-                short_name = %user.short_name,
-                "meshtastic: queuing node name from config.toml for apply-on-connect"
+                captured = device_owner.is_some(),
+                device_long = device_owner.map(|u| u.long_name.as_str()).unwrap_or("<not captured>"),
+                device_short = device_owner.map(|u| u.short_name.as_str()).unwrap_or("<not captured>"),
+                config_long = %user.long_name,
+                config_short = %user.short_name,
+                "meshtastic: queuing node name — differs from device (or device owner not captured)"
             );
             deferred.push(DeferredWrite::Owner { user, reply: None });
         }

--- a/crates/bbs-meshtastic/src/lib.rs
+++ b/crates/bbs-meshtastic/src/lib.rs
@@ -33,10 +33,11 @@ use bbs_plugin_api::MeshtasticAdminRequest;
 use crate::{
     command::{format_response, parse_command, render_notification, truncate_utf8},
     proto::{
-        admin_get_lora_config, admin_message, admin_set_lora_config, direct_text_packet,
-        from_radio, mesh_packet, mt_config, node_key, synthetic_pubkey, AdminMessage, Data,
-        LoRaConfig, MeshPacket, MtConfig, NodeInfo, BROADCAST_ADDR, PORT_ADMIN_APP,
-        PORT_NODEINFO_APP, PORT_TEXT_MESSAGE_APP,
+        admin_get_lora_config, admin_get_owner, admin_get_security_config, admin_message,
+        admin_set_lora_config, admin_set_owner, direct_text_packet, from_radio, mesh_packet,
+        mt_config, node_key, synthetic_pubkey, AdminMessage, Data, LoRaConfig, MeshPacket,
+        MtConfig, NodeInfo, User, BROADCAST_ADDR, PORT_ADMIN_APP, PORT_NODEINFO_APP,
+        PORT_TEXT_MESSAGE_APP,
     },
     session::SessionState,
     stream::{ClientEvent, MeshtasticClient, SerialConfig, TcpConfig},
@@ -155,6 +156,21 @@ pub struct MeshtasticConfig {
     /// ```
     #[serde(default)]
     pub radio: Option<MeshtasticRadioConfig>,
+
+    /// Short node name shown on OLED maps and mesh UIs (≤ 4 chars).
+    ///
+    /// Stored here for reference.  Push to the device via the web admin UI
+    /// (Settings → Meshtastic device → Node name → Save to device) or by
+    /// running `supply-drop-bbs node set-meshtastic-owner` once that CLI
+    /// command is available.
+    #[serde(default)]
+    pub short_name: Option<String>,
+
+    /// Full node display name shown in Meshtastic apps.
+    ///
+    /// Stored alongside `short_name`; applied on demand via the web admin UI.
+    #[serde(default)]
+    pub long_name: Option<String>,
 }
 
 impl Default for MeshtasticConfig {
@@ -174,6 +190,8 @@ impl Default for MeshtasticConfig {
             reconnect_delay_initial_ms: default_reconnect_delay_initial_ms(),
             reconnect_delay_max_ms: default_reconnect_delay_max_ms(),
             radio: None,
+            short_name: None,
+            long_name: None,
         }
     }
 }
@@ -458,6 +476,18 @@ enum PendingMeshtasticAdmin {
         request_id: u32,
         reply: tokio::sync::oneshot::Sender<Result<(), String>>,
     },
+    GetOwner {
+        request_id: u32,
+        reply: tokio::sync::oneshot::Sender<Result<bbs_plugin_api::MeshtasticOwnerInfo, String>>,
+    },
+    SetOwner {
+        request_id: u32,
+        reply: tokio::sync::oneshot::Sender<Result<(), String>>,
+    },
+    GetSecurity {
+        request_id: u32,
+        reply: tokio::sync::oneshot::Sender<Result<bbs_plugin_api::MeshtasticSecurityInfo, String>>,
+    },
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -477,6 +507,9 @@ async fn event_loop(
     mut admin_rx: mpsc::Receiver<MeshtasticAdminRequest>,
 ) {
     let mut pending_admin: Option<PendingMeshtasticAdmin> = None;
+    // Session passkey received from the last GET response; echo it back in SET
+    // commands as a replay-attack guard (Meshtastic 2.5+, field 101).
+    let mut last_session_passkey: Vec<u8> = Vec::new();
 
     loop {
         tokio::select! {
@@ -491,6 +524,9 @@ async fn event_loop(
                         match op {
                             PendingMeshtasticAdmin::GetLora { reply, .. } => { let _ = reply.send(Err(err)); }
                             PendingMeshtasticAdmin::SetLora { reply, .. } => { let _ = reply.send(Err(err)); }
+                            PendingMeshtasticAdmin::GetOwner { reply, .. } => { let _ = reply.send(Err(err)); }
+                            PendingMeshtasticAdmin::SetOwner { reply, .. } => { let _ = reply.send(Err(err)); }
+                            PendingMeshtasticAdmin::GetSecurity { reply, .. } => { let _ = reply.send(Err(err)); }
                         }
                     }
                     if will_retry {
@@ -502,7 +538,11 @@ async fn event_loop(
                 }
                 Some(ClientEvent::FromRadio(msg)) => {
                     // Check if this is an admin response packet before general dispatch.
-                    let consumed = try_handle_admin_response(&msg, &mut pending_admin);
+                    let consumed = try_handle_admin_response(
+                        &msg,
+                        &mut pending_admin,
+                        &mut last_session_passkey,
+                    );
                     if !consumed {
                         handle_from_radio(
                             msg,
@@ -516,7 +556,8 @@ async fn event_loop(
                             hop_limit,
                             want_ack,
                             &packet_counter,
-                        ).await;
+                        )
+                        .await;
                     }
                 }
                 None => break,
@@ -524,38 +565,46 @@ async fn event_loop(
             Some(req) = admin_rx.recv() => {
                 let my_node_num = state.lock().expect("state mutex poisoned").my_node_num;
                 let Some(my_node_num) = my_node_num else {
-                    match req {
-                        MeshtasticAdminRequest::GetLoRaConfig { reply } => {
-                            let _ = reply.send(Err("node num not yet received from radio".into()));
-                        }
-                        MeshtasticAdminRequest::SetLoRaConfig { reply, .. } => {
-                            let _ = reply.send(Err("node num not yet received from radio".into()));
+                    // Node number not yet received — reject all admin requests.
+                    fn reject_no_num(req: MeshtasticAdminRequest) {
+                        let e = "node num not yet received from radio".to_owned();
+                        match req {
+                            MeshtasticAdminRequest::GetLoRaConfig { reply } => { let _ = reply.send(Err(e)); }
+                            MeshtasticAdminRequest::SetLoRaConfig { reply, .. } => { let _ = reply.send(Err(e)); }
+                            MeshtasticAdminRequest::GetOwner { reply } => { let _ = reply.send(Err(e)); }
+                            MeshtasticAdminRequest::SetOwner { reply, .. } => { let _ = reply.send(Err(e)); }
+                            MeshtasticAdminRequest::GetSecurity { reply } => { let _ = reply.send(Err(e)); }
                         }
                     }
+                    reject_no_num(req);
                     continue;
                 };
                 if pending_admin.is_some() {
-                    match req {
-                        MeshtasticAdminRequest::GetLoRaConfig { reply } => {
-                            let _ = reply.send(Err("another admin operation is already in progress".into()));
-                        }
-                        MeshtasticAdminRequest::SetLoRaConfig { reply, .. } => {
-                            let _ = reply.send(Err("another admin operation is already in progress".into()));
+                    // Another admin operation is in flight — reject immediately.
+                    fn reject_busy(req: MeshtasticAdminRequest) {
+                        let e = "another admin operation is already in progress".to_owned();
+                        match req {
+                            MeshtasticAdminRequest::GetLoRaConfig { reply } => { let _ = reply.send(Err(e)); }
+                            MeshtasticAdminRequest::SetLoRaConfig { reply, .. } => { let _ = reply.send(Err(e)); }
+                            MeshtasticAdminRequest::GetOwner { reply } => { let _ = reply.send(Err(e)); }
+                            MeshtasticAdminRequest::SetOwner { reply, .. } => { let _ = reply.send(Err(e)); }
+                            MeshtasticAdminRequest::GetSecurity { reply } => { let _ = reply.send(Err(e)); }
                         }
                     }
+                    reject_busy(req);
                     continue;
                 }
                 match req {
                     MeshtasticAdminRequest::GetLoRaConfig { reply } => {
-                        let request_id = packet_counter.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-                        if cmd_tx.send(admin_get_lora_config(my_node_num, request_id)).await.is_err() {
+                        let rid = packet_counter.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                        if cmd_tx.send(admin_get_lora_config(my_node_num, rid)).await.is_err() {
                             let _ = reply.send(Err("meshtastic client disconnected".into()));
                         } else {
-                            pending_admin = Some(PendingMeshtasticAdmin::GetLora { request_id, reply });
+                            pending_admin = Some(PendingMeshtasticAdmin::GetLora { request_id: rid, reply });
                         }
                     }
                     MeshtasticAdminRequest::SetLoRaConfig { config, reply } => {
-                        let request_id = packet_counter.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                        let rid = packet_counter.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
                         let lora = LoRaConfig {
                             use_preset: config.use_preset,
                             modem_preset: config.modem_preset,
@@ -570,10 +619,46 @@ async fn event_loop(
                             channel_num: config.channel_num,
                             override_frequency: config.override_frequency,
                         };
-                        if cmd_tx.send(admin_set_lora_config(my_node_num, request_id, lora)).await.is_err() {
+                        let passkey = last_session_passkey.clone();
+                        if cmd_tx.send(admin_set_lora_config(my_node_num, rid, lora, passkey)).await.is_err() {
                             let _ = reply.send(Err("meshtastic client disconnected".into()));
                         } else {
-                            pending_admin = Some(PendingMeshtasticAdmin::SetLora { request_id, reply });
+                            pending_admin = Some(PendingMeshtasticAdmin::SetLora { request_id: rid, reply });
+                        }
+                    }
+                    MeshtasticAdminRequest::GetOwner { reply } => {
+                        let rid = packet_counter.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                        if cmd_tx.send(admin_get_owner(my_node_num, rid)).await.is_err() {
+                            let _ = reply.send(Err("meshtastic client disconnected".into()));
+                        } else {
+                            pending_admin = Some(PendingMeshtasticAdmin::GetOwner { request_id: rid, reply });
+                        }
+                    }
+                    MeshtasticAdminRequest::SetOwner { long_name, short_name, reply } => {
+                        // For SetOwner we need the current values to merge — do a
+                        // GetOwner first and then set. For simplicity, send SetOwner
+                        // with only the provided fields; the device keeps others.
+                        // We synthesize a User with empty fields for what we don't change.
+                        let rid = packet_counter.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                        let user = User {
+                            id: String::new(),
+                            long_name: long_name.unwrap_or_default(),
+                            short_name: short_name.unwrap_or_default(),
+                            public_key: Vec::new(),
+                        };
+                        let passkey = last_session_passkey.clone();
+                        if cmd_tx.send(admin_set_owner(my_node_num, rid, user, passkey)).await.is_err() {
+                            let _ = reply.send(Err("meshtastic client disconnected".into()));
+                        } else {
+                            pending_admin = Some(PendingMeshtasticAdmin::SetOwner { request_id: rid, reply });
+                        }
+                    }
+                    MeshtasticAdminRequest::GetSecurity { reply } => {
+                        let rid = packet_counter.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                        if cmd_tx.send(admin_get_security_config(my_node_num, rid)).await.is_err() {
+                            let _ = reply.send(Err("meshtastic client disconnected".into()));
+                        } else {
+                            pending_admin = Some(PendingMeshtasticAdmin::GetSecurity { request_id: rid, reply });
                         }
                     }
                 }
@@ -587,10 +672,13 @@ async fn event_loop(
 }
 
 /// Try to handle an admin-channel response packet.
+///
 /// Returns `true` if the message was consumed (caller should skip general dispatch).
+/// Updates `session_passkey` with any passkey found in the decoded `AdminMessage`.
 fn try_handle_admin_response(
     msg: &proto::FromRadio,
     pending_admin: &mut Option<PendingMeshtasticAdmin>,
+    session_passkey: &mut Vec<u8>,
 ) -> bool {
     use prost::Message as _;
 
@@ -607,36 +695,41 @@ fn try_handle_admin_response(
     match pending_admin.take() {
         Some(PendingMeshtasticAdmin::GetLora { request_id, reply }) => {
             if data.reply_id != request_id && data.request_id != request_id {
-                // Not our response — put it back and don't consume.
                 *pending_admin = Some(PendingMeshtasticAdmin::GetLora { request_id, reply });
                 return false;
             }
-            // Decode AdminMessage to extract GetConfigResponse.
             match AdminMessage::decode(data.payload.as_slice()) {
-                Ok(AdminMessage {
-                    payload_variant:
+                Ok(msg) => {
+                    // Capture session passkey for subsequent SET commands.
+                    if !msg.session_passkey.is_empty() {
+                        *session_passkey = msg.session_passkey.clone();
+                    }
+                    match msg.payload_variant {
                         Some(admin_message::PayloadVariant::GetConfigResponse(MtConfig {
                             payload_variant: Some(mt_config::PayloadVariant::Lora(lora)),
-                        })),
-                }) => {
-                    let config = bbs_plugin_api::MeshtasticLoRaConfig {
-                        use_preset: lora.use_preset,
-                        modem_preset: lora.modem_preset,
-                        bandwidth: lora.bandwidth,
-                        spread_factor: lora.spread_factor,
-                        coding_rate: lora.coding_rate,
-                        frequency_offset: lora.frequency_offset,
-                        region: lora.region,
-                        hop_limit: lora.hop_limit,
-                        tx_enabled: lora.tx_enabled,
-                        tx_power: lora.tx_power,
-                        channel_num: lora.channel_num,
-                        override_frequency: lora.override_frequency,
-                    };
-                    let _ = reply.send(Ok(config));
-                }
-                Ok(_) => {
-                    let _ = reply.send(Err("unexpected admin response payload".into()));
+                        })) => {
+                            let config = bbs_plugin_api::MeshtasticLoRaConfig {
+                                use_preset: lora.use_preset,
+                                modem_preset: lora.modem_preset,
+                                bandwidth: lora.bandwidth,
+                                spread_factor: lora.spread_factor,
+                                coding_rate: lora.coding_rate,
+                                frequency_offset: lora.frequency_offset,
+                                region: lora.region,
+                                hop_limit: lora.hop_limit,
+                                tx_enabled: lora.tx_enabled,
+                                tx_power: lora.tx_power,
+                                channel_num: lora.channel_num,
+                                override_frequency: lora.override_frequency,
+                            };
+                            let _ = reply.send(Ok(config));
+                        }
+                        _ => {
+                            let _ = reply.send(Err(
+                                "unexpected admin response (expected LoRa config)".into(),
+                            ));
+                        }
+                    }
                 }
                 Err(e) => {
                     let _ = reply.send(Err(format!("failed to decode admin response: {e}")));
@@ -649,12 +742,97 @@ fn try_handle_admin_response(
                 *pending_admin = Some(PendingMeshtasticAdmin::SetLora { request_id, reply });
                 return false;
             }
-            // Any admin packet with matching reply_id/request_id for SetConfig is the ACK.
+            // Any matching admin packet is the ACK for a SET command.
             let _ = reply.send(Ok(()));
+            true
+        }
+        Some(PendingMeshtasticAdmin::GetOwner { request_id, reply }) => {
+            if data.reply_id != request_id && data.request_id != request_id {
+                *pending_admin = Some(PendingMeshtasticAdmin::GetOwner { request_id, reply });
+                return false;
+            }
+            match AdminMessage::decode(data.payload.as_slice()) {
+                Ok(msg) => {
+                    if !msg.session_passkey.is_empty() {
+                        *session_passkey = msg.session_passkey.clone();
+                    }
+                    match msg.payload_variant {
+                        Some(admin_message::PayloadVariant::GetOwnerResponse(user)) => {
+                            let info = bbs_plugin_api::MeshtasticOwnerInfo {
+                                id: user.id,
+                                long_name: user.long_name,
+                                short_name: user.short_name,
+                                public_key_hex: hex_encode(&user.public_key),
+                            };
+                            let _ = reply.send(Ok(info));
+                        }
+                        _ => {
+                            let _ = reply.send(Err(
+                                "unexpected admin response (expected owner info)".into(),
+                            ));
+                        }
+                    }
+                }
+                Err(e) => {
+                    let _ = reply.send(Err(format!("failed to decode admin response: {e}")));
+                }
+            }
+            true
+        }
+        Some(PendingMeshtasticAdmin::SetOwner { request_id, reply }) => {
+            if data.reply_id != request_id && data.request_id != request_id {
+                *pending_admin = Some(PendingMeshtasticAdmin::SetOwner { request_id, reply });
+                return false;
+            }
+            let _ = reply.send(Ok(()));
+            true
+        }
+        Some(PendingMeshtasticAdmin::GetSecurity { request_id, reply }) => {
+            if data.reply_id != request_id && data.request_id != request_id {
+                *pending_admin = Some(PendingMeshtasticAdmin::GetSecurity { request_id, reply });
+                return false;
+            }
+            match AdminMessage::decode(data.payload.as_slice()) {
+                Ok(msg) => {
+                    if !msg.session_passkey.is_empty() {
+                        *session_passkey = msg.session_passkey.clone();
+                    }
+                    match msg.payload_variant {
+                        Some(admin_message::PayloadVariant::GetConfigResponse(MtConfig {
+                            payload_variant: Some(mt_config::PayloadVariant::Security(sec)),
+                        })) => {
+                            let info = bbs_plugin_api::MeshtasticSecurityInfo {
+                                public_key_hex: hex_encode(&sec.public_key),
+                                admin_channel_enabled: sec.admin_channel_enabled,
+                            };
+                            let _ = reply.send(Ok(info));
+                        }
+                        _ => {
+                            let _ = reply.send(Err(
+                                "unexpected admin response (expected security config)".into(),
+                            ));
+                        }
+                    }
+                }
+                Err(e) => {
+                    let _ = reply.send(Err(format!("failed to decode admin response: {e}")));
+                }
+            }
             true
         }
         None => false,
     }
+}
+
+/// Hex-encode a byte slice (lowercase, no prefix).
+fn hex_encode(bytes: &[u8]) -> String {
+    bytes
+        .iter()
+        .fold(String::with_capacity(bytes.len() * 2), |mut s, b| {
+            use std::fmt::Write as _;
+            write!(s, "{b:02x}").unwrap();
+            s
+        })
 }
 
 #[allow(clippy::too_many_arguments)]

--- a/crates/bbs-meshtastic/src/lib.rs
+++ b/crates/bbs-meshtastic/src/lib.rs
@@ -34,7 +34,8 @@ use crate::{
     command::{format_response, parse_command, render_notification, truncate_utf8},
     proto::{
         admin_get_lora_config, admin_get_owner, admin_get_security_config, admin_get_session_key,
-        admin_message, admin_set_lora_config, admin_set_owner, direct_text_packet, from_radio,
+        admin_message, admin_remove_fixed_position, admin_set_fixed_position,
+        admin_set_lora_config, admin_set_owner, admin_set_time, direct_text_packet, from_radio,
         mesh_packet, mt_config, node_key, nodeinfo_broadcast, synthetic_pubkey, AdminMessage, Data,
         LoRaConfig, MeshPacket, MtConfig, NodeInfo, BROADCAST_ADDR, PORT_ADMIN_APP,
         PORT_NODEINFO_APP, PORT_TEXT_MESSAGE_APP,
@@ -68,7 +69,7 @@ pub enum MeshtasticConnectionType {
 /// completes after the transport connects (see `apply_config_on_connect`), so
 /// changes made in setup or the web admin UI take effect the next time the BBS
 /// connects.  The device persists the settings in its own flash.
-#[derive(Debug, Clone, Default, Deserialize, Serialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct MeshtasticRadioConfig {
     /// Meshtastic region code (e.g. `"US"`, `"EU_868"`, `"ANZ"`).
@@ -84,6 +85,35 @@ pub struct MeshtasticRadioConfig {
     /// default and works well for most outdoor deployments.
     #[serde(default)]
     pub modem_preset: Option<String>,
+
+    /// Enable SX126x RX boosted gain — improves receive sensitivity. Default on.
+    #[serde(default = "default_true")]
+    pub rx_boosted_gain: bool,
+
+    /// Maximum number of hops for packets originated by this node. Default 3.
+    #[serde(default = "default_radio_hops")]
+    pub hops: u32,
+
+    /// Ignore packets that arrived over MQTT. Default on.
+    #[serde(default = "default_true")]
+    pub ignore_mqtt: bool,
+
+    /// Whether the radio transmitter is enabled. Default on.
+    #[serde(default = "default_true")]
+    pub tx_enabled: bool,
+}
+
+impl Default for MeshtasticRadioConfig {
+    fn default() -> Self {
+        Self {
+            region: None,
+            modem_preset: None,
+            rx_boosted_gain: true,
+            hops: default_radio_hops(),
+            ignore_mqtt: true,
+            tx_enabled: true,
+        }
+    }
 }
 
 /// Configuration for the Meshtastic transport (`[plugins.meshtastic]`).
@@ -206,6 +236,12 @@ impl MeshtasticConfig {
 
 fn default_enabled() -> bool {
     false
+}
+fn default_true() -> bool {
+    true
+}
+fn default_radio_hops() -> u32 {
+    3
 }
 fn default_baud_rate() -> u32 {
     115_200
@@ -534,17 +570,6 @@ struct AutoApplyConfig {
     long_name: Option<String>,
 }
 
-impl AutoApplyConfig {
-    /// True when there is at least one setting to push.
-    fn has_anything(&self) -> bool {
-        self.radio
-            .as_ref()
-            .is_some_and(|r| r.region.is_some() || r.modem_preset.is_some())
-            || self.short_name.is_some()
-            || self.long_name.is_some()
-    }
-}
-
 /// Pending admin request in the Meshtastic event loop.
 ///
 /// Only GET operations are tracked here — they wait for the device's response.
@@ -594,6 +619,12 @@ enum DeferredWrite {
         user: proto::User,
         reply: Option<tokio::sync::oneshot::Sender<Result<(), String>>>,
     },
+    /// Sync the device clock to the host's current time. No reply, no reboot.
+    Time,
+    /// Set a fixed GPS position (decimal degrees). No reply, no reboot.
+    SetFixedPosition { lat: f64, lon: f64 },
+    /// Clear any fixed GPS position. No reply, no reboot.
+    RemoveFixedPosition,
 }
 
 /// Extract the `session_passkey` (AdminMessage field 101) from an inbound admin
@@ -656,8 +687,51 @@ async fn flush_deferred_writes(
                     info!("meshtastic: applied node owner info to device");
                 }
             }
+            DeferredWrite::Time => {
+                let secs = unix_now_secs();
+                if cmd_tx
+                    .send(admin_set_time(node, rid, secs, passkey.to_vec()))
+                    .await
+                    .is_ok()
+                {
+                    info!(unix_secs = secs, "meshtastic: synced device time");
+                }
+            }
+            DeferredWrite::SetFixedPosition { lat, lon } => {
+                if cmd_tx
+                    .send(admin_set_fixed_position(
+                        node,
+                        rid,
+                        lat,
+                        lon,
+                        passkey.to_vec(),
+                    ))
+                    .await
+                    .is_ok()
+                {
+                    info!(lat, lon, "meshtastic: set fixed position on device");
+                }
+            }
+            DeferredWrite::RemoveFixedPosition => {
+                if cmd_tx
+                    .send(admin_remove_fixed_position(node, rid, passkey.to_vec()))
+                    .await
+                    .is_ok()
+                {
+                    info!("meshtastic: cleared fixed position on device");
+                }
+            }
         }
     }
+}
+
+/// Current Unix time in seconds (truncated to u32, the wire field width).
+fn unix_now_secs() -> u32 {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs() as u32)
+        .unwrap_or(0)
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -723,6 +797,9 @@ async fn event_loop(
                         let r = match w {
                             DeferredWrite::Lora { reply, .. } => reply,
                             DeferredWrite::Owner { reply, .. } => reply,
+                            DeferredWrite::Time
+                            | DeferredWrite::SetFixedPosition { .. }
+                            | DeferredWrite::RemoveFixedPosition => None,
                         };
                         if let Some(r) = r {
                             let _ = r.send(Err("device disconnected".into()));
@@ -748,13 +825,24 @@ async fn event_loop(
                             msg.payload_variant,
                             Some(from_radio::PayloadVariant::ConfigCompleteId(_))
                         )
-                        && auto_apply.has_anything()
                     {
                         let (node, device_lora, device_owner) = {
                             let s = state.lock().expect("state poisoned");
                             (s.my_node_num, s.device_lora.clone(), s.device_owner.clone())
                         };
                         if let Some(node) = node {
+                            // Always sync the device clock to system time on connect.
+                            deferred_writes.push(DeferredWrite::Time);
+                            // Manage fixed position from the host's configured GPS:
+                            // set it when a location is configured, clear it otherwise.
+                            match host.node_location() {
+                                Some((lat, lon)) => deferred_writes
+                                    .push(DeferredWrite::SetFixedPosition { lat, lon }),
+                                None => {
+                                    deferred_writes.push(DeferredWrite::RemoveFixedPosition)
+                                }
+                            }
+                            // Push configured radio params + node name (skip-if-unchanged).
                             enqueue_auto_apply(
                                 &auto_apply,
                                 device_lora.as_ref(),
@@ -876,6 +964,8 @@ async fn event_loop(
                             tx_power: config.tx_power,
                             channel_num: config.channel_num,
                             override_frequency: config.override_frequency,
+                            sx126x_rx_boosted_gain: config.sx126x_rx_boosted_gain,
+                            ignore_mqtt: config.ignore_mqtt,
                         };
                         // Queue the write and request a session key. The write is
                         // sent (and `reply` completed) once the passkey arrives.
@@ -913,18 +1003,6 @@ async fn event_loop(
     }
 }
 
-/// Whether the operator's desired LoRa settings differ from the device's
-/// current config in a way that warrants a write. We only compare the fields
-/// apply-on-connect actually sets (`use_preset`, `modem_preset`, `region`); the
-/// remaining fields are preset-derived on the device and not something the
-/// operator configures here, so comparing them would force a needless write
-/// (and reboot) every connect.
-fn lora_differs(desired: &proto::LoRaConfig, current: &proto::LoRaConfig) -> bool {
-    desired.use_preset != current.use_preset
-        || desired.modem_preset != current.modem_preset
-        || desired.region != current.region
-}
-
 /// Queue the operator's configured radio and node-name settings as deferred
 /// writes, to be sent once a session passkey is obtained. Called once per
 /// connection after config sync completes — this is what makes settings from
@@ -936,34 +1014,51 @@ fn enqueue_auto_apply(
     deferred: &mut Vec<DeferredWrite>,
 ) {
     if let Some(radio) = &cfg.radio {
-        if radio.region.is_some() || radio.modem_preset.is_some() {
-            let lora = proto::LoRaConfig {
-                use_preset: true,
-                modem_preset: preset_str_to_int(
-                    radio.modem_preset.as_deref().unwrap_or("LONG_FAST"),
-                ),
-                region: region_str_to_int(radio.region.as_deref().unwrap_or("UNSET")),
-                ..Default::default()
-            };
-            // Writing LoRa config reboots the radio — even when nothing changed.
-            // Only queue the write when the device's current region/preset
-            // actually differs from what the operator configured. Skipping the
-            // no-op write keeps the radio online (and hearing adverts) instead
-            // of cycling through a reboot on every reconnect.
-            if device_lora.is_some_and(|cur| !lora_differs(&lora, cur)) {
+        // Build the desired config by *overlaying* our settings onto the
+        // device's current LoRa config — never from a zeroed default. A bare
+        // `LoRaConfig { .. ..Default::default() }` would set tx_enabled=false and
+        // hop_limit=0, clobbering the radio every write. Region/preset are only
+        // touched when explicitly configured (so we never blank a set region).
+        //
+        // Writing LoRa config reboots the radio even when unchanged, so we skip
+        // the write entirely when the merged result equals what's on the device.
+        if let Some(current) = device_lora {
+            let mut desired = current.clone();
+            desired.use_preset = true;
+            if let Some(p) = radio.modem_preset.as_deref() {
+                desired.modem_preset = preset_str_to_int(p);
+            }
+            if let Some(r) = radio.region.as_deref() {
+                desired.region = region_str_to_int(r);
+            }
+            desired.hop_limit = radio.hops;
+            desired.tx_enabled = radio.tx_enabled;
+            desired.sx126x_rx_boosted_gain = radio.rx_boosted_gain;
+            desired.ignore_mqtt = radio.ignore_mqtt;
+            if desired == *current {
                 info!(
-                    region = radio.region.as_deref().unwrap_or("UNSET"),
-                    modem_preset = radio.modem_preset.as_deref().unwrap_or("LONG_FAST"),
                     "meshtastic: radio config already matches device, skipping write (no reboot)"
                 );
             } else {
                 info!(
-                    region = radio.region.as_deref().unwrap_or("UNSET"),
-                    modem_preset = radio.modem_preset.as_deref().unwrap_or("LONG_FAST"),
+                    region = radio.region.as_deref().unwrap_or("(unchanged)"),
+                    modem_preset = radio.modem_preset.as_deref().unwrap_or("(unchanged)"),
+                    hops = radio.hops,
+                    tx_enabled = radio.tx_enabled,
+                    rx_boosted_gain = radio.rx_boosted_gain,
+                    ignore_mqtt = radio.ignore_mqtt,
                     "meshtastic: queuing radio config from config.toml for apply-on-connect"
                 );
-                deferred.push(DeferredWrite::Lora { lora, reply: None });
+                deferred.push(DeferredWrite::Lora {
+                    lora: desired,
+                    reply: None,
+                });
             }
+        } else {
+            warn!(
+                "meshtastic: device LoRa config not captured during sync; \
+                 skipping radio apply to avoid clobbering device settings"
+            );
         }
     }
     if cfg.short_name.is_some() || cfg.long_name.is_some() {
@@ -1061,6 +1156,8 @@ fn try_handle_admin_response(
                                 tx_power: lora.tx_power,
                                 channel_num: lora.channel_num,
                                 override_frequency: lora.override_frequency,
+                                sx126x_rx_boosted_gain: lora.sx126x_rx_boosted_gain,
+                                ignore_mqtt: lora.ignore_mqtt,
                             };
                             let _ = reply.send(Ok(config));
                         }

--- a/crates/bbs-meshtastic/src/lib.rs
+++ b/crates/bbs-meshtastic/src/lib.rs
@@ -61,6 +61,30 @@ pub enum MeshtasticConnectionType {
 
 // ── Config ────────────────────────────────────────────────────────────────────
 
+/// Radio parameter configuration stored in `[plugins.meshtastic.radio]`.
+///
+/// These values are **not** pushed to the device automatically on connect.
+/// Apply them on demand via the web admin UI (Settings → Meshtastic radio)
+/// or `supply-drop-bbs node set-meshtastic-radio` once that command is added.
+/// Once applied the device persists the settings in its own flash.
+#[derive(Debug, Clone, Default, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct MeshtasticRadioConfig {
+    /// Meshtastic region code (e.g. `"US"`, `"EU_868"`, `"ANZ"`).
+    ///
+    /// Sets the legal frequency range for the device.  See the Meshtastic
+    /// documentation for the full list of region codes.
+    #[serde(default)]
+    pub region: Option<String>,
+
+    /// Meshtastic modem preset (e.g. `"LONG_FAST"`, `"MEDIUM_SLOW"`).
+    ///
+    /// Predefined LoRa parameter profiles.  `"LONG_FAST"` is the Meshtastic
+    /// default and works well for most outdoor deployments.
+    #[serde(default)]
+    pub modem_preset: Option<String>,
+}
+
 /// Configuration for the Meshtastic transport (`[plugins.meshtastic]`).
 #[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
@@ -116,6 +140,21 @@ pub struct MeshtasticConfig {
     /// Maximum reconnect delay after repeated failures.
     #[serde(default = "default_reconnect_delay_max_ms")]
     pub reconnect_delay_max_ms: u64,
+
+    /// Radio parameter configuration.
+    ///
+    /// Stored here for reference and applied on demand via the web admin UI
+    /// (Settings → Meshtastic radio).  **Not** pushed automatically on every
+    /// connect — the device persists radio settings in its own flash.
+    ///
+    /// Example:
+    /// ```toml
+    /// [plugins.meshtastic.radio]
+    /// region       = "US"
+    /// modem_preset = "LONG_FAST"
+    /// ```
+    #[serde(default)]
+    pub radio: Option<MeshtasticRadioConfig>,
 }
 
 impl Default for MeshtasticConfig {
@@ -134,6 +173,7 @@ impl Default for MeshtasticConfig {
             want_ack: default_want_ack(),
             reconnect_delay_initial_ms: default_reconnect_delay_initial_ms(),
             reconnect_delay_max_ms: default_reconnect_delay_max_ms(),
+            radio: None,
         }
     }
 }

--- a/crates/bbs-meshtastic/src/lib.rs
+++ b/crates/bbs-meshtastic/src/lib.rs
@@ -64,10 +64,10 @@ pub enum MeshtasticConnectionType {
 
 /// Radio parameter configuration stored in `[plugins.meshtastic.radio]`.
 ///
-/// These values are **not** pushed to the device automatically on connect.
-/// Apply them on demand via the web admin UI (Settings → Meshtastic radio)
-/// or `supply-drop-bbs node set-meshtastic-radio` once that command is added.
-/// Once applied the device persists the settings in its own flash.
+/// These values are pushed to the device automatically once config sync
+/// completes after the transport connects (see `apply_config_on_connect`), so
+/// changes made in setup or the web admin UI take effect the next time the BBS
+/// connects.  The device persists the settings in its own flash.
 #[derive(Debug, Clone, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct MeshtasticRadioConfig {
@@ -144,9 +144,7 @@ pub struct MeshtasticConfig {
 
     /// Radio parameter configuration.
     ///
-    /// Stored here for reference and applied on demand via the web admin UI
-    /// (Settings → Meshtastic radio).  **Not** pushed automatically on every
-    /// connect — the device persists radio settings in its own flash.
+    /// Applied to the device automatically when the BBS connects.
     ///
     /// Example:
     /// ```toml
@@ -159,16 +157,13 @@ pub struct MeshtasticConfig {
 
     /// Short node name shown on OLED maps and mesh UIs (≤ 4 chars).
     ///
-    /// Stored here for reference.  Push to the device via the web admin UI
-    /// (Settings → Meshtastic device → Node name → Save to device) or by
-    /// running `supply-drop-bbs node set-meshtastic-owner` once that CLI
-    /// command is available.
+    /// Applied to the device automatically when the BBS connects.
     #[serde(default)]
     pub short_name: Option<String>,
 
     /// Full node display name shown in Meshtastic apps.
     ///
-    /// Stored alongside `short_name`; applied on demand via the web admin UI.
+    /// Applied to the device automatically when the BBS connects.
     #[serde(default)]
     pub long_name: Option<String>,
 }
@@ -262,6 +257,13 @@ pub struct MeshtasticTransport {
     admin_tx: mpsc::Sender<MeshtasticAdminRequest>,
     /// Admin channel receiver — taken by `start()` into the event loop.
     admin_rx: Mutex<Option<mpsc::Receiver<MeshtasticAdminRequest>>>,
+    /// Radio config from `[plugins.meshtastic.radio]`, applied to the device
+    /// automatically once config sync completes after connecting.
+    radio_config: Option<MeshtasticRadioConfig>,
+    /// Short node name from `[plugins.meshtastic]`, applied on connect.
+    short_name: Option<String>,
+    /// Long node name from `[plugins.meshtastic]`, applied on connect.
+    long_name: Option<String>,
 }
 
 #[async_trait]
@@ -326,6 +328,9 @@ impl Plugin for MeshtasticTransport {
             packet_counter: Arc::new(AtomicU32::new(1)),
             admin_tx,
             admin_rx: Mutex::new(Some(admin_rx)),
+            radio_config: config.radio,
+            short_name: config.short_name,
+            long_name: config.long_name,
         })
     }
 
@@ -363,6 +368,11 @@ impl Plugin for MeshtasticTransport {
         let hop_limit = self.hop_limit;
         let want_ack = self.want_ack;
         let packet_counter = Arc::clone(&self.packet_counter);
+        let auto_apply = AutoApplyConfig {
+            radio: self.radio_config.clone(),
+            short_name: self.short_name.clone(),
+            long_name: self.long_name.clone(),
+        };
 
         tokio::spawn(event_loop(
             client,
@@ -378,6 +388,7 @@ impl Plugin for MeshtasticTransport {
             want_ack,
             packet_counter,
             admin_rx,
+            auto_apply,
         ));
 
         // Subscribe to advisory domain events, mirroring the MeshCore transport.
@@ -466,6 +477,28 @@ impl TransportEngine for MeshtasticTransport {
 
 // ── Event loop ────────────────────────────────────────────────────────────────
 
+/// Settings from config.toml that are pushed to the device automatically once
+/// config sync completes after each (re)connection.  This is what makes
+/// "configure in setup or web UI → it just works" true: the operator never has
+/// to run a CLI command to apply settings.
+#[derive(Clone, Default)]
+struct AutoApplyConfig {
+    radio: Option<MeshtasticRadioConfig>,
+    short_name: Option<String>,
+    long_name: Option<String>,
+}
+
+impl AutoApplyConfig {
+    /// True when there is at least one setting to push.
+    fn has_anything(&self) -> bool {
+        self.radio
+            .as_ref()
+            .is_some_and(|r| r.region.is_some() || r.modem_preset.is_some())
+            || self.short_name.is_some()
+            || self.long_name.is_some()
+    }
+}
+
 /// Pending admin request in the Meshtastic event loop.
 enum PendingMeshtasticAdmin {
     GetLora {
@@ -505,17 +538,22 @@ async fn event_loop(
     want_ack: bool,
     packet_counter: Arc<AtomicU32>,
     mut admin_rx: mpsc::Receiver<MeshtasticAdminRequest>,
+    auto_apply: AutoApplyConfig,
 ) {
     let mut pending_admin: Option<PendingMeshtasticAdmin> = None;
     // Session passkey received from the last GET response; echo it back in SET
     // commands as a replay-attack guard (Meshtastic 2.5+, field 101).
     let mut last_session_passkey: Vec<u8> = Vec::new();
+    // Whether we've pushed the config.toml settings to the device on this
+    // connection. Reset on disconnect so settings re-apply after a reconnect.
+    let mut auto_applied = false;
 
     loop {
         tokio::select! {
             event = client.recv() => match event {
                 Some(ClientEvent::Connected) => {
                     info!("meshtastic: connected to radio");
+                    auto_applied = false;
                 }
                 Some(ClientEvent::Disconnected { will_retry }) => {
                     // Fail any in-flight admin request.
@@ -529,6 +567,7 @@ async fn event_loop(
                             PendingMeshtasticAdmin::GetSecurity { reply, .. } => { let _ = reply.send(Err(err)); }
                         }
                     }
+                    auto_applied = false;
                     if will_retry {
                         info!("meshtastic: radio disconnected, will retry");
                     } else {
@@ -537,6 +576,24 @@ async fn event_loop(
                     }
                 }
                 Some(ClientEvent::FromRadio(msg)) => {
+                    // Auto-apply config.toml settings once config sync completes.
+                    // ConfigCompleteId marks the end of the initial sync, by which
+                    // point MyInfo (node number) has already been received.
+                    if !auto_applied
+                        && matches!(
+                            msg.payload_variant,
+                            Some(from_radio::PayloadVariant::ConfigCompleteId(_))
+                        )
+                        && auto_apply.has_anything()
+                    {
+                        let node_num = state.lock().expect("state mutex poisoned").my_node_num;
+                        if let Some(node_num) = node_num {
+                            apply_config_on_connect(&cmd_tx, node_num, &auto_apply, &packet_counter)
+                                .await;
+                            auto_applied = true;
+                        }
+                    }
+
                     // Check if this is an admin response packet before general dispatch.
                     let consumed = try_handle_admin_response(
                         &msg,
@@ -667,6 +724,76 @@ async fn event_loop(
                 info!("meshtastic: shutdown signal received");
                 break;
             }
+        }
+    }
+}
+
+/// Push the operator's configured radio and node-name settings to the device.
+///
+/// Called once per connection after config sync completes.  Fire-and-forget:
+/// the device applies SetConfig / SetOwner and persists them in flash, so we
+/// don't block on ACKs here.  This is what makes settings configured in setup
+/// or the web UI take effect automatically — no CLI step required.
+///
+/// `SetOwner` is sent with an empty `public_key`; Meshtastic firmware only
+/// copies `long_name`/`short_name` from the message and never overwrites the
+/// node's PKC key from a SetOwner (the key is managed via SecurityConfig), so
+/// the node's identity key is preserved.
+async fn apply_config_on_connect(
+    cmd_tx: &mpsc::Sender<proto::ToRadio>,
+    node_num: u32,
+    cfg: &AutoApplyConfig,
+    packet_counter: &AtomicU32,
+) {
+    use proto::{admin_set_lora_config, admin_set_owner, LoRaConfig, User};
+
+    // Radio config (region + modem preset).
+    if let Some(radio) = &cfg.radio {
+        if radio.region.is_some() || radio.modem_preset.is_some() {
+            let region = region_str_to_int(radio.region.as_deref().unwrap_or("UNSET"));
+            let preset = preset_str_to_int(radio.modem_preset.as_deref().unwrap_or("LONG_FAST"));
+            let lora = LoRaConfig {
+                use_preset: true,
+                modem_preset: preset,
+                region,
+                ..Default::default()
+            };
+            let rid = packet_counter.fetch_add(1, Ordering::Relaxed);
+            info!(
+                region = radio.region.as_deref().unwrap_or("UNSET"),
+                modem_preset = radio.modem_preset.as_deref().unwrap_or("LONG_FAST"),
+                "meshtastic: auto-applying radio config from config.toml"
+            );
+            if cmd_tx
+                .send(admin_set_lora_config(node_num, rid, lora, Vec::new()))
+                .await
+                .is_err()
+            {
+                warn!("meshtastic: failed to send auto-apply radio config");
+            }
+        }
+    }
+
+    // Node name (long + short).
+    if cfg.short_name.is_some() || cfg.long_name.is_some() {
+        let user = User {
+            id: String::new(),
+            long_name: cfg.long_name.clone().unwrap_or_default(),
+            short_name: cfg.short_name.clone().unwrap_or_default(),
+            public_key: Vec::new(),
+        };
+        let rid = packet_counter.fetch_add(1, Ordering::Relaxed);
+        info!(
+            long_name = cfg.long_name.as_deref().unwrap_or(""),
+            short_name = cfg.short_name.as_deref().unwrap_or(""),
+            "meshtastic: auto-applying node name from config.toml"
+        );
+        if cmd_tx
+            .send(admin_set_owner(node_num, rid, user, Vec::new()))
+            .await
+            .is_err()
+        {
+            warn!("meshtastic: failed to send auto-apply node name");
         }
     }
 }

--- a/crates/bbs-meshtastic/src/lib.rs
+++ b/crates/bbs-meshtastic/src/lib.rs
@@ -1541,6 +1541,9 @@ fn owner_user(long_name: Option<&str>, short_name: Option<&str>) -> proto::User 
         id: String::new(),
         long_name: long_name.map(|s| clamp(s, 39)).unwrap_or_default(),
         short_name: short_name.map(|s| clamp(s, 4)).unwrap_or_default(),
+        // Left 0 (CLIENT): prost omits default-value int32 from the wire, so
+        // SetOwner never sends a role and can't clobber the device's real role.
+        role: 0,
         public_key: Vec::new(),
     }
 }
@@ -1718,8 +1721,18 @@ fn record_node_advert(host: &Arc<dyn Host>, node: NodeInfo) {
         })
         .unwrap_or((0, 0));
 
-    host.advert_bus()
-        .upsert(pubkey, name, 0, lat_1e6, lon_1e6, TRANSPORT_NAME);
+    // Record the device role (Config.DeviceConfig.Role) as the advert "type".
+    // The web interprets this per-transport (a Meshtastic role, not a MeshCore
+    // advert type).
+    let role = node.user.as_ref().map(|u| u.role).unwrap_or(0);
+    host.advert_bus().upsert(
+        pubkey,
+        name,
+        role.clamp(0, u8::MAX as i32) as u8,
+        lat_1e6,
+        lon_1e6,
+        TRANSPORT_NAME,
+    );
 }
 
 #[allow(clippy::too_many_arguments)]

--- a/crates/bbs-meshtastic/src/lib.rs
+++ b/crates/bbs-meshtastic/src/lib.rs
@@ -35,9 +35,9 @@ use crate::{
     proto::{
         admin_get_lora_config, admin_get_owner, admin_get_security_config, admin_get_session_key,
         admin_message, admin_set_lora_config, admin_set_owner, direct_text_packet, from_radio,
-        mesh_packet, mt_config, node_key, synthetic_pubkey, AdminMessage, Data, LoRaConfig,
-        MeshPacket, MtConfig, NodeInfo, BROADCAST_ADDR, PORT_ADMIN_APP, PORT_NODEINFO_APP,
-        PORT_TEXT_MESSAGE_APP,
+        mesh_packet, mt_config, node_key, nodeinfo_broadcast, synthetic_pubkey, AdminMessage, Data,
+        LoRaConfig, MeshPacket, MtConfig, NodeInfo, BROADCAST_ADDR, PORT_ADMIN_APP,
+        PORT_NODEINFO_APP, PORT_TEXT_MESSAGE_APP,
     },
     session::SessionState,
     stream::{ClientEvent, MeshtasticClient, SerialConfig, TcpConfig},
@@ -423,6 +423,52 @@ impl Plugin for MeshtasticTransport {
                         Err(tokio::sync::broadcast::error::RecvError::Closed) => break,
                     },
                     _ = notif_shutdown_rx.changed() => break,
+                }
+            }
+        });
+
+        // Self-advert: when the sysop hits "send advert" in the web UI, broadcast
+        // our node info so neighbouring Meshtastic nodes add us to their node
+        // list. The firmware otherwise only announces on boot and on a slow
+        // periodic timer, so this is the only way to appear promptly.
+        let advert_cmd_tx = self.cmd_tx.clone();
+        let advert_state = Arc::clone(&self.state);
+        let advert_counter = Arc::clone(&self.packet_counter);
+        let advert_long = self.long_name.clone();
+        let advert_short = self.short_name.clone();
+        let advert_hop = self.hop_limit;
+        let advert_want_ack = self.want_ack;
+        let mut advert_send_rx = self.host.advert_bus().subscribe_send();
+        let mut advert_shutdown_rx = self.shutdown_tx.subscribe();
+        tokio::spawn(async move {
+            loop {
+                tokio::select! {
+                    result = advert_send_rx.recv() => match result {
+                        Ok(flood) => {
+                            let node = advert_state.lock().expect("state mutex poisoned").my_node_num;
+                            let Some(node) = node else {
+                                warn!("meshtastic: send-advert requested before node number known");
+                                continue;
+                            };
+                            let mut user = owner_user(advert_long.as_deref(), advert_short.as_deref());
+                            user.id = format_node_id(node);
+                            // Flood → multi-hop (configured hop limit); direct → neighbours only.
+                            let hop = if flood { advert_hop } else { 0 };
+                            let id = advert_counter.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                            if advert_cmd_tx
+                                .send(nodeinfo_broadcast(id, user, hop, advert_want_ack))
+                                .await
+                                .is_ok()
+                            {
+                                info!(flood, "meshtastic: broadcast self node info (send advert)");
+                            }
+                        }
+                        Err(tokio::sync::broadcast::error::RecvError::Lagged(n)) => {
+                            warn!("meshtastic: advert-send stream lagged by {n}");
+                        }
+                        Err(tokio::sync::broadcast::error::RecvError::Closed) => break,
+                    },
+                    _ = advert_shutdown_rx.changed() => break,
                 }
             }
         });

--- a/crates/bbs-meshtastic/src/lib.rs
+++ b/crates/bbs-meshtastic/src/lib.rs
@@ -28,11 +28,15 @@ use serde::{Deserialize, Serialize};
 use tokio::sync::{mpsc, watch};
 use tracing::{debug, info, warn};
 
+use bbs_plugin_api::MeshtasticAdminRequest;
+
 use crate::{
     command::{format_response, parse_command, render_notification, truncate_utf8},
     proto::{
-        direct_text_packet, from_radio, mesh_packet, node_key, synthetic_pubkey, Data, MeshPacket,
-        NodeInfo, BROADCAST_ADDR, PORT_NODEINFO_APP, PORT_TEXT_MESSAGE_APP,
+        admin_get_lora_config, admin_message, admin_set_lora_config, direct_text_packet,
+        from_radio, mesh_packet, mt_config, node_key, synthetic_pubkey, AdminMessage, Data,
+        LoRaConfig, MeshPacket, MtConfig, NodeInfo, BROADCAST_ADDR, PORT_ADMIN_APP,
+        PORT_NODEINFO_APP, PORT_TEXT_MESSAGE_APP,
     },
     session::SessionState,
     stream::{ClientEvent, MeshtasticClient, SerialConfig, TcpConfig},
@@ -196,6 +200,10 @@ pub struct MeshtasticTransport {
     hop_limit: u32,
     want_ack: bool,
     packet_counter: Arc<AtomicU32>,
+    /// Admin channel sender — stored so `start()` can register it with the host.
+    admin_tx: mpsc::Sender<MeshtasticAdminRequest>,
+    /// Admin channel receiver — taken by `start()` into the event loop.
+    admin_rx: Mutex<Option<mpsc::Receiver<MeshtasticAdminRequest>>>,
 }
 
 #[async_trait]
@@ -243,6 +251,7 @@ impl Plugin for MeshtasticTransport {
 
         let cmd_tx = client.sender();
         let (shutdown_tx, _) = watch::channel(false);
+        let (admin_tx, admin_rx) = mpsc::channel::<MeshtasticAdminRequest>(4);
 
         Ok(Self {
             host,
@@ -257,6 +266,8 @@ impl Plugin for MeshtasticTransport {
             hop_limit: config.hop_limit,
             want_ack: config.want_ack,
             packet_counter: Arc::new(AtomicU32::new(1)),
+            admin_tx,
+            admin_rx: Mutex::new(Some(admin_rx)),
         })
     }
 
@@ -269,6 +280,19 @@ impl Plugin for MeshtasticTransport {
             .ok_or_else(|| {
                 PluginError::StartFailed("meshtastic transport already started".into())
             })?;
+
+        let admin_rx = self
+            .admin_rx
+            .lock()
+            .expect("admin_rx mutex poisoned")
+            .take()
+            .ok_or_else(|| {
+                PluginError::StartFailed("meshtastic admin channel already taken".into())
+            })?;
+
+        // Register admin channel with the host before spawning the event loop.
+        self.host
+            .register_meshtastic_admin_ops(self.admin_tx.clone());
 
         let host = Arc::clone(&self.host);
         let cmd_tx = self.cmd_tx.clone();
@@ -295,6 +319,7 @@ impl Plugin for MeshtasticTransport {
             hop_limit,
             want_ack,
             packet_counter,
+            admin_rx,
         ));
 
         // Subscribe to advisory domain events, mirroring the MeshCore transport.
@@ -383,6 +408,18 @@ impl TransportEngine for MeshtasticTransport {
 
 // ── Event loop ────────────────────────────────────────────────────────────────
 
+/// Pending admin request in the Meshtastic event loop.
+enum PendingMeshtasticAdmin {
+    GetLora {
+        request_id: u32,
+        reply: tokio::sync::oneshot::Sender<Result<bbs_plugin_api::MeshtasticLoRaConfig, String>>,
+    },
+    SetLora {
+        request_id: u32,
+        reply: tokio::sync::oneshot::Sender<Result<(), String>>,
+    },
+}
+
 #[allow(clippy::too_many_arguments)]
 async fn event_loop(
     mut client: MeshtasticClient,
@@ -397,7 +434,10 @@ async fn event_loop(
     hop_limit: u32,
     want_ack: bool,
     packet_counter: Arc<AtomicU32>,
+    mut admin_rx: mpsc::Receiver<MeshtasticAdminRequest>,
 ) {
+    let mut pending_admin: Option<PendingMeshtasticAdmin> = None;
+
     loop {
         tokio::select! {
             event = client.recv() => match event {
@@ -405,6 +445,14 @@ async fn event_loop(
                     info!("meshtastic: connected to radio");
                 }
                 Some(ClientEvent::Disconnected { will_retry }) => {
+                    // Fail any in-flight admin request.
+                    if let Some(op) = pending_admin.take() {
+                        let err = "device disconnected".to_owned();
+                        match op {
+                            PendingMeshtasticAdmin::GetLora { reply, .. } => { let _ = reply.send(Err(err)); }
+                            PendingMeshtasticAdmin::SetLora { reply, .. } => { let _ = reply.send(Err(err)); }
+                        }
+                    }
                     if will_retry {
                         info!("meshtastic: radio disconnected, will retry");
                     } else {
@@ -413,27 +461,159 @@ async fn event_loop(
                     }
                 }
                 Some(ClientEvent::FromRadio(msg)) => {
-                    handle_from_radio(
-                        msg,
-                        &host,
-                        &cmd_tx,
-                        &state,
-                        command_prefix,
-                        &welcome_message,
-                        node_credential_ttl_days,
-                        max_payload_bytes,
-                        hop_limit,
-                        want_ack,
-                        &packet_counter,
-                    ).await;
+                    // Check if this is an admin response packet before general dispatch.
+                    let consumed = try_handle_admin_response(&msg, &mut pending_admin);
+                    if !consumed {
+                        handle_from_radio(
+                            msg,
+                            &host,
+                            &cmd_tx,
+                            &state,
+                            command_prefix,
+                            &welcome_message,
+                            node_credential_ttl_days,
+                            max_payload_bytes,
+                            hop_limit,
+                            want_ack,
+                            &packet_counter,
+                        ).await;
+                    }
                 }
                 None => break,
+            },
+            Some(req) = admin_rx.recv() => {
+                let my_node_num = state.lock().expect("state mutex poisoned").my_node_num;
+                let Some(my_node_num) = my_node_num else {
+                    match req {
+                        MeshtasticAdminRequest::GetLoRaConfig { reply } => {
+                            let _ = reply.send(Err("node num not yet received from radio".into()));
+                        }
+                        MeshtasticAdminRequest::SetLoRaConfig { reply, .. } => {
+                            let _ = reply.send(Err("node num not yet received from radio".into()));
+                        }
+                    }
+                    continue;
+                };
+                if pending_admin.is_some() {
+                    match req {
+                        MeshtasticAdminRequest::GetLoRaConfig { reply } => {
+                            let _ = reply.send(Err("another admin operation is already in progress".into()));
+                        }
+                        MeshtasticAdminRequest::SetLoRaConfig { reply, .. } => {
+                            let _ = reply.send(Err("another admin operation is already in progress".into()));
+                        }
+                    }
+                    continue;
+                }
+                match req {
+                    MeshtasticAdminRequest::GetLoRaConfig { reply } => {
+                        let request_id = packet_counter.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                        if cmd_tx.send(admin_get_lora_config(my_node_num, request_id)).await.is_err() {
+                            let _ = reply.send(Err("meshtastic client disconnected".into()));
+                        } else {
+                            pending_admin = Some(PendingMeshtasticAdmin::GetLora { request_id, reply });
+                        }
+                    }
+                    MeshtasticAdminRequest::SetLoRaConfig { config, reply } => {
+                        let request_id = packet_counter.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                        let lora = LoRaConfig {
+                            use_preset: config.use_preset,
+                            modem_preset: config.modem_preset,
+                            bandwidth: config.bandwidth,
+                            spread_factor: config.spread_factor,
+                            coding_rate: config.coding_rate,
+                            frequency_offset: config.frequency_offset,
+                            region: config.region,
+                            hop_limit: config.hop_limit,
+                            tx_enabled: config.tx_enabled,
+                            tx_power: config.tx_power,
+                            channel_num: config.channel_num,
+                            override_frequency: config.override_frequency,
+                        };
+                        if cmd_tx.send(admin_set_lora_config(my_node_num, request_id, lora)).await.is_err() {
+                            let _ = reply.send(Err("meshtastic client disconnected".into()));
+                        } else {
+                            pending_admin = Some(PendingMeshtasticAdmin::SetLora { request_id, reply });
+                        }
+                    }
+                }
             },
             _ = shutdown_rx.changed() => {
                 info!("meshtastic: shutdown signal received");
                 break;
             }
         }
+    }
+}
+
+/// Try to handle an admin-channel response packet.
+/// Returns `true` if the message was consumed (caller should skip general dispatch).
+fn try_handle_admin_response(
+    msg: &proto::FromRadio,
+    pending_admin: &mut Option<PendingMeshtasticAdmin>,
+) -> bool {
+    use prost::Message as _;
+
+    let Some(from_radio::PayloadVariant::Packet(packet)) = &msg.payload_variant else {
+        return false;
+    };
+    let Some(mesh_packet::PayloadVariant::Decoded(data)) = &packet.payload_variant else {
+        return false;
+    };
+    if data.portnum != PORT_ADMIN_APP {
+        return false;
+    }
+
+    match pending_admin.take() {
+        Some(PendingMeshtasticAdmin::GetLora { request_id, reply }) => {
+            if data.reply_id != request_id && data.request_id != request_id {
+                // Not our response — put it back and don't consume.
+                *pending_admin = Some(PendingMeshtasticAdmin::GetLora { request_id, reply });
+                return false;
+            }
+            // Decode AdminMessage to extract GetConfigResponse.
+            match AdminMessage::decode(data.payload.as_slice()) {
+                Ok(AdminMessage {
+                    payload_variant:
+                        Some(admin_message::PayloadVariant::GetConfigResponse(MtConfig {
+                            payload_variant: Some(mt_config::PayloadVariant::Lora(lora)),
+                        })),
+                }) => {
+                    let config = bbs_plugin_api::MeshtasticLoRaConfig {
+                        use_preset: lora.use_preset,
+                        modem_preset: lora.modem_preset,
+                        bandwidth: lora.bandwidth,
+                        spread_factor: lora.spread_factor,
+                        coding_rate: lora.coding_rate,
+                        frequency_offset: lora.frequency_offset,
+                        region: lora.region,
+                        hop_limit: lora.hop_limit,
+                        tx_enabled: lora.tx_enabled,
+                        tx_power: lora.tx_power,
+                        channel_num: lora.channel_num,
+                        override_frequency: lora.override_frequency,
+                    };
+                    let _ = reply.send(Ok(config));
+                }
+                Ok(_) => {
+                    let _ = reply.send(Err("unexpected admin response payload".into()));
+                }
+                Err(e) => {
+                    let _ = reply.send(Err(format!("failed to decode admin response: {e}")));
+                }
+            }
+            true
+        }
+        Some(PendingMeshtasticAdmin::SetLora { request_id, reply }) => {
+            if data.reply_id != request_id && data.request_id != request_id {
+                *pending_admin = Some(PendingMeshtasticAdmin::SetLora { request_id, reply });
+                return false;
+            }
+            // Any admin packet with matching reply_id/request_id for SetConfig is the ACK.
+            let _ = reply.send(Ok(()));
+            true
+        }
+        None => false,
     }
 }
 
@@ -542,6 +722,10 @@ async fn handle_packet(
                 from = format_node_id(packet.from),
                 "meshtastic: nodeinfo packet observed"
             );
+            return;
+        }
+        if data.portnum == PORT_ADMIN_APP {
+            // Admin packets are handled by try_handle_admin_response in the event loop.
             return;
         }
     }

--- a/crates/bbs-meshtastic/src/lib.rs
+++ b/crates/bbs-meshtastic/src/lib.rs
@@ -34,7 +34,7 @@ use crate::{
     command::{format_response, parse_command, render_notification, truncate_utf8},
     proto::{
         admin_get_lora_config, admin_get_owner, admin_get_security_config, admin_get_session_key,
-        admin_message, admin_remove_fixed_position, admin_set_device_config,
+        admin_message, admin_reboot, admin_remove_fixed_position, admin_set_device_config,
         admin_set_fixed_position, admin_set_lora_config, admin_set_owner, admin_set_time,
         direct_text_packet, from_radio, mesh_packet, mt_config, node_key, synthetic_pubkey,
         AdminMessage, Data, LoRaConfig, MeshPacket, MtConfig, NodeInfo, BROADCAST_ADDR,
@@ -583,6 +583,11 @@ enum DeferredWrite {
     },
     /// Write the merged DeviceConfig (e.g. node_info_broadcast_secs). Reboots.
     Device { device: proto::DeviceConfig },
+    /// Reboot the radio after `secs` (forces a boot-time NodeInfo broadcast).
+    Reboot {
+        secs: i32,
+        reply: Option<tokio::sync::oneshot::Sender<Result<(), String>>>,
+    },
     /// Sync the device clock to the host's current time. No reply, no reboot.
     Time,
     /// Set a fixed GPS position (decimal degrees). No reply, no reboot.
@@ -658,6 +663,22 @@ async fn flush_deferred_writes(
                     .is_ok()
                 {
                     info!("meshtastic: applied device config (node_info_broadcast_secs) to device");
+                }
+            }
+            DeferredWrite::Reboot { secs, reply } => {
+                let ok = cmd_tx
+                    .send(admin_reboot(node, rid, secs, passkey.to_vec()))
+                    .await
+                    .is_ok();
+                if let Some(r) = reply {
+                    let _ = r.send(if ok {
+                        Ok(())
+                    } else {
+                        Err("meshtastic client disconnected".into())
+                    });
+                }
+                if ok {
+                    info!(secs, "meshtastic: requested radio reboot");
                 }
             }
             DeferredWrite::Time => {
@@ -770,6 +791,7 @@ async fn event_loop(
                         let r = match w {
                             DeferredWrite::Lora { reply, .. } => reply,
                             DeferredWrite::Owner { reply, .. } => reply,
+                            DeferredWrite::Reboot { reply, .. } => reply,
                             DeferredWrite::Device { .. }
                             | DeferredWrite::Time
                             | DeferredWrite::SetFixedPosition { .. }
@@ -899,6 +921,7 @@ async fn event_loop(
                             MeshtasticAdminRequest::GetSecurity { reply } => { let _ = reply.send(Err(e)); }
                             // Not connected yet → empty snapshot rather than an error.
                             MeshtasticAdminRequest::GetSnapshot { reply } => { let _ = reply.send(Ok(Default::default())); }
+                            MeshtasticAdminRequest::Reboot { reply, .. } => { let _ = reply.send(Err(e)); }
                         }
                     }
                     reject_no_num(req);
@@ -991,6 +1014,15 @@ async fn event_loop(
                             )
                         };
                         let _ = reply.send(Ok(snapshot));
+                    }
+                    MeshtasticAdminRequest::Reboot { seconds, reply } => {
+                        // Admin write → needs a session passkey; queue it and
+                        // request the key (sent once the passkey arrives).
+                        deferred_writes.push(DeferredWrite::Reboot {
+                            secs: seconds,
+                            reply: Some(reply),
+                        });
+                        request_session_key(&cmd_tx, my_node_num, &mut session_requested, &deferred_writes).await;
                     }
                 }
             },

--- a/crates/bbs-meshtastic/src/lib.rs
+++ b/crates/bbs-meshtastic/src/lib.rs
@@ -916,6 +916,8 @@ async fn event_loop(
                             MeshtasticAdminRequest::GetOwner { reply } => { let _ = reply.send(Err(e)); }
                             MeshtasticAdminRequest::SetOwner { reply, .. } => { let _ = reply.send(Err(e)); }
                             MeshtasticAdminRequest::GetSecurity { reply } => { let _ = reply.send(Err(e)); }
+                            // Not connected yet → empty snapshot rather than an error.
+                            MeshtasticAdminRequest::GetSnapshot { reply } => { let _ = reply.send(Ok(Default::default())); }
                         }
                     }
                     reject_no_num(req);
@@ -997,6 +999,18 @@ async fn event_loop(
                             pending_admin = Some(PendingMeshtasticAdmin::GetSecurity { request_id: rid, reply });
                         }
                     }
+                    MeshtasticAdminRequest::GetSnapshot { reply } => {
+                        // Served instantly from the sync cache — no device round-trip.
+                        let snapshot = {
+                            let st = state.lock().expect("state mutex poisoned");
+                            device_snapshot(
+                                st.device_lora.as_ref(),
+                                st.device_owner.as_ref(),
+                                st.device_security.as_ref(),
+                            )
+                        };
+                        let _ = reply.send(Ok(snapshot));
+                    }
                 }
             },
             _ = shutdown_rx.changed() => {
@@ -1014,7 +1028,7 @@ async fn event_loop(
 fn enqueue_auto_apply(
     cfg: &AutoApplyConfig,
     device_lora: Option<&proto::LoRaConfig>,
-    device_owner: Option<&(String, String)>,
+    device_owner: Option<&proto::User>,
     deferred: &mut Vec<DeferredWrite>,
 ) {
     if let Some(radio) = &cfg.radio {
@@ -1072,7 +1086,7 @@ fn enqueue_auto_apply(
         // every connect reboots the device and resets its periodic NodeInfo
         // broadcast timer, so neighbours never learn about us.
         let already_set = device_owner
-            .is_some_and(|(long, short)| *long == user.long_name && *short == user.short_name);
+            .is_some_and(|u| u.long_name == user.long_name && u.short_name == user.short_name);
         if already_set {
             info!(
                 long_name = %user.long_name,
@@ -1475,6 +1489,42 @@ where
     .map_err(|_| "timed out (20s) — is the device connected and not in use?".to_owned())?
 }
 
+/// Build a combined device snapshot DTO from the cached sync config.
+fn device_snapshot(
+    lora: Option<&proto::LoRaConfig>,
+    owner: Option<&proto::User>,
+    security: Option<&proto::SecurityConfig>,
+) -> bbs_plugin_api::MeshtasticDeviceSnapshot {
+    bbs_plugin_api::MeshtasticDeviceSnapshot {
+        lora: lora.map(|l| bbs_plugin_api::MeshtasticLoRaConfig {
+            use_preset: l.use_preset,
+            modem_preset: l.modem_preset,
+            bandwidth: l.bandwidth,
+            spread_factor: l.spread_factor,
+            coding_rate: l.coding_rate,
+            frequency_offset: l.frequency_offset,
+            region: l.region,
+            hop_limit: l.hop_limit,
+            tx_enabled: l.tx_enabled,
+            tx_power: l.tx_power,
+            channel_num: l.channel_num,
+            override_frequency: l.override_frequency,
+            sx126x_rx_boosted_gain: l.sx126x_rx_boosted_gain,
+            ignore_mqtt: l.ignore_mqtt,
+        }),
+        owner: owner.map(|u| bbs_plugin_api::MeshtasticOwnerInfo {
+            id: u.id.clone(),
+            long_name: u.long_name.clone(),
+            short_name: u.short_name.clone(),
+            public_key_hex: hex_encode(&u.public_key),
+        }),
+        security: security.map(|s| bbs_plugin_api::MeshtasticSecurityInfo {
+            public_key_hex: hex_encode(&s.public_key),
+            admin_channel_enabled: s.admin_channel_enabled,
+        }),
+    }
+}
+
 /// Build a Meshtastic owner `User` with firmware-safe field lengths.
 ///
 /// The firmware decodes these into fixed buffers — `short_name` is `char[5]`
@@ -1584,23 +1634,31 @@ async fn handle_from_radio(
                 let mut st = state.lock().expect("state mutex poisoned");
                 if Some(node.num) == st.my_node_num {
                     if let Some(u) = &node.user {
-                        st.device_owner = Some((u.long_name.clone(), u.short_name.clone()));
+                        st.device_owner = Some(u.clone());
                     }
                 }
             }
             record_node_advert(host, node);
         }
         Some(from_radio::PayloadVariant::Config(cfg)) => {
-            // Capture the device's current LoRa config from the sync stream so
-            // apply-on-connect can skip a redundant (reboot-inducing) write.
-            if let Some(proto::mt_config::PayloadVariant::Lora(lora)) = cfg.payload_variant {
-                debug!(
-                    region = lora.region,
-                    modem_preset = lora.modem_preset,
-                    use_preset = lora.use_preset,
-                    "meshtastic: captured device LoRa config from sync"
-                );
-                state.lock().expect("state mutex poisoned").device_lora = Some(lora);
+            // Capture the device's current config from the sync stream so
+            // apply-on-connect can skip redundant (reboot-inducing) writes and
+            // the web can serve a snapshot without a live admin round-trip.
+            match cfg.payload_variant {
+                Some(proto::mt_config::PayloadVariant::Lora(lora)) => {
+                    debug!(
+                        region = lora.region,
+                        modem_preset = lora.modem_preset,
+                        use_preset = lora.use_preset,
+                        "meshtastic: captured device LoRa config from sync"
+                    );
+                    state.lock().expect("state mutex poisoned").device_lora = Some(lora);
+                }
+                Some(proto::mt_config::PayloadVariant::Security(sec)) => {
+                    debug!("meshtastic: captured device security config from sync");
+                    state.lock().expect("state mutex poisoned").device_security = Some(sec);
+                }
+                None => {}
             }
         }
         Some(from_radio::PayloadVariant::Packet(packet)) => {

--- a/crates/bbs-meshtastic/src/lib.rs
+++ b/crates/bbs-meshtastic/src/lib.rs
@@ -750,14 +750,15 @@ async fn event_loop(
                         )
                         && auto_apply.has_anything()
                     {
-                        let (node, device_lora) = {
+                        let (node, device_lora, device_owner) = {
                             let s = state.lock().expect("state poisoned");
-                            (s.my_node_num, s.device_lora.clone())
+                            (s.my_node_num, s.device_lora.clone(), s.device_owner.clone())
                         };
                         if let Some(node) = node {
                             enqueue_auto_apply(
                                 &auto_apply,
                                 device_lora.as_ref(),
+                                device_owner.as_ref(),
                                 &mut deferred_writes,
                             );
                             request_session_key(
@@ -931,6 +932,7 @@ fn lora_differs(desired: &proto::LoRaConfig, current: &proto::LoRaConfig) -> boo
 fn enqueue_auto_apply(
     cfg: &AutoApplyConfig,
     device_lora: Option<&proto::LoRaConfig>,
+    device_owner: Option<&(String, String)>,
     deferred: &mut Vec<DeferredWrite>,
 ) {
     if let Some(radio) = &cfg.radio {
@@ -965,15 +967,27 @@ fn enqueue_auto_apply(
         }
     }
     if cfg.short_name.is_some() || cfg.long_name.is_some() {
-        info!(
-            long_name = cfg.long_name.as_deref().unwrap_or(""),
-            short_name = cfg.short_name.as_deref().unwrap_or(""),
-            "meshtastic: queuing node name from config.toml for apply-on-connect"
-        );
-        deferred.push(DeferredWrite::Owner {
-            user: owner_user(cfg.long_name.as_deref(), cfg.short_name.as_deref()),
-            reply: None,
-        });
+        let user = owner_user(cfg.long_name.as_deref(), cfg.short_name.as_deref());
+        // SetOwner also reboots the radio on current firmware. Skip the write
+        // when the device already carries this exact (clamped) name — otherwise
+        // every connect reboots the device and resets its periodic NodeInfo
+        // broadcast timer, so neighbours never learn about us.
+        let already_set = device_owner
+            .is_some_and(|(long, short)| *long == user.long_name && *short == user.short_name);
+        if already_set {
+            info!(
+                long_name = %user.long_name,
+                short_name = %user.short_name,
+                "meshtastic: node name already matches device, skipping write (no reboot)"
+            );
+        } else {
+            info!(
+                long_name = %user.long_name,
+                short_name = %user.short_name,
+                "meshtastic: queuing node name from config.toml for apply-on-connect"
+            );
+            deferred.push(DeferredWrite::Owner { user, reply: None });
+        }
     }
 }
 
@@ -1463,6 +1477,16 @@ async fn handle_from_radio(
             );
         }
         Some(from_radio::PayloadVariant::NodeInfo(node)) => {
+            // If this is our own node, capture the current owner name so
+            // apply-on-connect can skip a redundant (reboot-inducing) SetOwner.
+            {
+                let mut st = state.lock().expect("state mutex poisoned");
+                if Some(node.num) == st.my_node_num {
+                    if let Some(u) = &node.user {
+                        st.device_owner = Some((u.long_name.clone(), u.short_name.clone()));
+                    }
+                }
+            }
             record_node_advert(host, node);
         }
         Some(from_radio::PayloadVariant::Config(cfg)) => {

--- a/crates/bbs-meshtastic/src/lib.rs
+++ b/crates/bbs-meshtastic/src/lib.rs
@@ -857,6 +857,41 @@ async fn event_loop(
                             )
                             .await;
                             auto_applied = true;
+
+                            // Re-announce ourselves shortly after connecting so
+                            // neighbours (and the sysop's companion) re-acquire the
+                            // BBS node after a service restart. The firmware only
+                            // broadcasts NodeInfo on its own boot and a slow periodic
+                            // timer (~3h) — a software restart triggers neither, so
+                            // without this the node looks stale until a manual advert.
+                            // Use the device's real owner (with its public key) when
+                            // captured, else the configured name.
+                            let mut advert_user = device_owner.clone().unwrap_or_else(|| {
+                                owner_user(
+                                    auto_apply.long_name.as_deref(),
+                                    auto_apply.short_name.as_deref(),
+                                )
+                            });
+                            if advert_user.id.is_empty() {
+                                advert_user.id = format_node_id(node);
+                            }
+                            let advert_tx = cmd_tx.clone();
+                            tokio::spawn(async move {
+                                // Let config sync + any deferred writes settle first.
+                                tokio::time::sleep(Duration::from_secs(5)).await;
+                                if advert_tx
+                                    .send(nodeinfo_broadcast(
+                                        random_packet_id(),
+                                        advert_user,
+                                        hop_limit,
+                                        false,
+                                    ))
+                                    .await
+                                    .is_ok()
+                                {
+                                    info!("meshtastic: broadcast self node info on connect");
+                                }
+                            });
                         }
                     }
 

--- a/crates/bbs-meshtastic/src/lib.rs
+++ b/crates/bbs-meshtastic/src/lib.rs
@@ -500,22 +500,22 @@ impl AutoApplyConfig {
 }
 
 /// Pending admin request in the Meshtastic event loop.
+///
+/// Only GET operations are tracked here — they wait for the device's response.
+/// SET operations (LoRa config, owner) are fire-and-forget: Meshtastic does not
+/// send a reliable admin response for config writes — it applies them silently
+/// (and reboots only when a LoRa parameter actually changes). Waiting for an ACK
+/// would always time out, so SET requests reply success as soon as the command
+/// is sent to the device.
+#[allow(clippy::enum_variant_names)] // all are Get* by design; Set* are fire-and-forget
 enum PendingMeshtasticAdmin {
     GetLora {
         request_id: u32,
         reply: tokio::sync::oneshot::Sender<Result<bbs_plugin_api::MeshtasticLoRaConfig, String>>,
     },
-    SetLora {
-        request_id: u32,
-        reply: tokio::sync::oneshot::Sender<Result<(), String>>,
-    },
     GetOwner {
         request_id: u32,
         reply: tokio::sync::oneshot::Sender<Result<bbs_plugin_api::MeshtasticOwnerInfo, String>>,
-    },
-    SetOwner {
-        request_id: u32,
-        reply: tokio::sync::oneshot::Sender<Result<(), String>>,
     },
     GetSecurity {
         request_id: u32,
@@ -561,9 +561,7 @@ async fn event_loop(
                         let err = "device disconnected".to_owned();
                         match op {
                             PendingMeshtasticAdmin::GetLora { reply, .. } => { let _ = reply.send(Err(err)); }
-                            PendingMeshtasticAdmin::SetLora { reply, .. } => { let _ = reply.send(Err(err)); }
                             PendingMeshtasticAdmin::GetOwner { reply, .. } => { let _ = reply.send(Err(err)); }
-                            PendingMeshtasticAdmin::SetOwner { reply, .. } => { let _ = reply.send(Err(err)); }
                             PendingMeshtasticAdmin::GetSecurity { reply, .. } => { let _ = reply.send(Err(err)); }
                         }
                     }
@@ -677,10 +675,15 @@ async fn event_loop(
                             override_frequency: config.override_frequency,
                         };
                         let passkey = last_session_passkey.clone();
+                        // Fire-and-forget: Meshtastic does not send a reliable admin
+                        // response for a config write — it applies it silently (and
+                        // reboots only if a LoRa parameter actually changed). Waiting
+                        // for an ACK would always time out, so report success once
+                        // the command has been handed to the device.
                         if cmd_tx.send(admin_set_lora_config(my_node_num, rid, lora, passkey)).await.is_err() {
                             let _ = reply.send(Err("meshtastic client disconnected".into()));
                         } else {
-                            pending_admin = Some(PendingMeshtasticAdmin::SetLora { request_id: rid, reply });
+                            let _ = reply.send(Ok(()));
                         }
                     }
                     MeshtasticAdminRequest::GetOwner { reply } => {
@@ -692,10 +695,10 @@ async fn event_loop(
                         }
                     }
                     MeshtasticAdminRequest::SetOwner { long_name, short_name, reply } => {
-                        // For SetOwner we need the current values to merge — do a
-                        // GetOwner first and then set. For simplicity, send SetOwner
-                        // with only the provided fields; the device keeps others.
-                        // We synthesize a User with empty fields for what we don't change.
+                        // Firmware only copies non-empty long_name/short_name from
+                        // the User and never overwrites the PKC public key on a
+                        // SetOwner, so sending empty id/public_key is safe and
+                        // leaves the node identity key intact.
                         let rid = packet_counter.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
                         let user = User {
                             id: String::new(),
@@ -704,10 +707,13 @@ async fn event_loop(
                             public_key: Vec::new(),
                         };
                         let passkey = last_session_passkey.clone();
+                        // Fire-and-forget, consistent with SetLoRaConfig: Meshtastic
+                        // applies the owner change without a reliable admin response.
+                        // Report success once the command has been sent.
                         if cmd_tx.send(admin_set_owner(my_node_num, rid, user, passkey)).await.is_err() {
                             let _ = reply.send(Err("meshtastic client disconnected".into()));
                         } else {
-                            pending_admin = Some(PendingMeshtasticAdmin::SetOwner { request_id: rid, reply });
+                            let _ = reply.send(Ok(()));
                         }
                     }
                     MeshtasticAdminRequest::GetSecurity { reply } => {
@@ -864,15 +870,6 @@ fn try_handle_admin_response(
             }
             true
         }
-        Some(PendingMeshtasticAdmin::SetLora { request_id, reply }) => {
-            if data.reply_id != request_id && data.request_id != request_id {
-                *pending_admin = Some(PendingMeshtasticAdmin::SetLora { request_id, reply });
-                return false;
-            }
-            // Any matching admin packet is the ACK for a SET command.
-            let _ = reply.send(Ok(()));
-            true
-        }
         Some(PendingMeshtasticAdmin::GetOwner { request_id, reply }) => {
             if data.reply_id != request_id && data.request_id != request_id {
                 *pending_admin = Some(PendingMeshtasticAdmin::GetOwner { request_id, reply });
@@ -904,14 +901,6 @@ fn try_handle_admin_response(
                     let _ = reply.send(Err(format!("failed to decode admin response: {e}")));
                 }
             }
-            true
-        }
-        Some(PendingMeshtasticAdmin::SetOwner { request_id, reply }) => {
-            if data.reply_id != request_id && data.request_id != request_id {
-                *pending_admin = Some(PendingMeshtasticAdmin::SetOwner { request_id, reply });
-                return false;
-            }
-            let _ = reply.send(Ok(()));
             true
         }
         Some(PendingMeshtasticAdmin::GetSecurity { request_id, reply }) => {

--- a/crates/bbs-meshtastic/src/lib.rs
+++ b/crates/bbs-meshtastic/src/lib.rs
@@ -33,10 +33,10 @@ use bbs_plugin_api::MeshtasticAdminRequest;
 use crate::{
     command::{format_response, parse_command, render_notification, truncate_utf8},
     proto::{
-        admin_get_lora_config, admin_get_owner, admin_get_security_config, admin_message,
-        admin_set_lora_config, admin_set_owner, direct_text_packet, from_radio, mesh_packet,
-        mt_config, node_key, synthetic_pubkey, AdminMessage, Data, LoRaConfig, MeshPacket,
-        MtConfig, NodeInfo, User, BROADCAST_ADDR, PORT_ADMIN_APP, PORT_NODEINFO_APP,
+        admin_get_lora_config, admin_get_owner, admin_get_security_config, admin_get_session_key,
+        admin_message, admin_set_lora_config, admin_set_owner, direct_text_packet, from_radio,
+        mesh_packet, mt_config, node_key, synthetic_pubkey, AdminMessage, Data, LoRaConfig,
+        MeshPacket, MtConfig, NodeInfo, BROADCAST_ADDR, PORT_ADMIN_APP, PORT_NODEINFO_APP,
         PORT_TEXT_MESSAGE_APP,
     },
     session::SessionState,
@@ -533,6 +533,87 @@ fn pending_reply_abandoned(op: &PendingMeshtasticAdmin) -> bool {
     }
 }
 
+/// An admin WRITE waiting for a fresh session passkey before it can be sent.
+///
+/// Meshtastic gates admin writes on an 8-byte `session_passkey` that the device
+/// only hands out in a get-response. So a write is deferred: we send a
+/// session-key request, and once the passkey arrives we build and send the
+/// write with it echoed in.
+enum DeferredWrite {
+    Lora {
+        lora: proto::LoRaConfig,
+        reply: Option<tokio::sync::oneshot::Sender<Result<(), String>>>,
+    },
+    Owner {
+        user: proto::User,
+        reply: Option<tokio::sync::oneshot::Sender<Result<(), String>>>,
+    },
+}
+
+/// Extract the `session_passkey` (AdminMessage field 101) from an inbound admin
+/// packet, if present. Every Meshtastic admin get-response carries a fresh
+/// 8-byte passkey; harvesting it lets us authorize subsequent writes.
+fn harvest_session_passkey(msg: &proto::FromRadio) -> Option<Vec<u8>> {
+    use prost::Message as _;
+    let Some(from_radio::PayloadVariant::Packet(p)) = &msg.payload_variant else {
+        return None;
+    };
+    let Some(mesh_packet::PayloadVariant::Decoded(d)) = &p.payload_variant else {
+        return None;
+    };
+    if d.portnum != PORT_ADMIN_APP {
+        return None;
+    }
+    let admin = AdminMessage::decode(d.payload.as_slice()).ok()?;
+    (!admin.session_passkey.is_empty()).then_some(admin.session_passkey)
+}
+
+/// Send all deferred writes now that a session passkey is available.
+async fn flush_deferred_writes(
+    cmd_tx: &mpsc::Sender<proto::ToRadio>,
+    node: u32,
+    passkey: &[u8],
+    deferred: &mut Vec<DeferredWrite>,
+) {
+    for w in deferred.drain(..) {
+        let rid = random_packet_id();
+        match w {
+            DeferredWrite::Lora { lora, reply } => {
+                let ok = cmd_tx
+                    .send(admin_set_lora_config(node, rid, lora, passkey.to_vec()))
+                    .await
+                    .is_ok();
+                if let Some(r) = reply {
+                    let _ = r.send(if ok {
+                        Ok(())
+                    } else {
+                        Err("meshtastic client disconnected".into())
+                    });
+                }
+                if ok {
+                    info!("meshtastic: applied LoRa config to device");
+                }
+            }
+            DeferredWrite::Owner { user, reply } => {
+                let ok = cmd_tx
+                    .send(admin_set_owner(node, rid, user, passkey.to_vec()))
+                    .await
+                    .is_ok();
+                if let Some(r) = reply {
+                    let _ = r.send(if ok {
+                        Ok(())
+                    } else {
+                        Err("meshtastic client disconnected".into())
+                    });
+                }
+                if ok {
+                    info!("meshtastic: applied node owner info to device");
+                }
+            }
+        }
+    }
+}
+
 #[allow(clippy::too_many_arguments)]
 async fn event_loop(
     mut client: MeshtasticClient,
@@ -551,11 +632,15 @@ async fn event_loop(
     auto_apply: AutoApplyConfig,
 ) {
     let mut pending_admin: Option<PendingMeshtasticAdmin> = None;
-    // Session passkey received from the last GET response; echo it back in SET
-    // commands as a replay-attack guard (Meshtastic 2.5+, field 101).
+    // Session passkey received from the last admin get-response; required to
+    // authorize admin writes (Meshtastic AdminMessage field 101).
     let mut last_session_passkey: Vec<u8> = Vec::new();
-    // Whether we've pushed the config.toml settings to the device on this
-    // connection. Reset on disconnect so settings re-apply after a reconnect.
+    // Admin writes waiting for a fresh session passkey before they can be sent.
+    let mut deferred_writes: Vec<DeferredWrite> = Vec::new();
+    // True once we've sent a session-key request and are awaiting the passkey.
+    let mut session_requested = false;
+    // Whether we've queued the config.toml auto-apply on this connection.
+    // Reset on disconnect so settings re-apply after a reconnect.
     let mut auto_applied = false;
     // Periodically reap a pending GET whose caller has given up (its oneshot
     // receiver was dropped after the caller's own timeout). Without this, a GET
@@ -587,6 +672,17 @@ async fn event_loop(
                             PendingMeshtasticAdmin::GetSecurity { reply, .. } => { let _ = reply.send(Err(err)); }
                         }
                     }
+                    // Fail any deferred writes whose caller is waiting.
+                    for w in deferred_writes.drain(..) {
+                        let r = match w {
+                            DeferredWrite::Lora { reply, .. } => reply,
+                            DeferredWrite::Owner { reply, .. } => reply,
+                        };
+                        if let Some(r) = r {
+                            let _ = r.send(Err("device disconnected".into()));
+                        }
+                    }
+                    session_requested = false;
                     auto_applied = false;
                     if will_retry {
                         info!("meshtastic: radio disconnected, will retry");
@@ -598,7 +694,9 @@ async fn event_loop(
                 Some(ClientEvent::FromRadio(msg)) => {
                     // Auto-apply config.toml settings once config sync completes.
                     // ConfigCompleteId marks the end of the initial sync, by which
-                    // point MyInfo (node number) has already been received.
+                    // point MyInfo (node number) has already been received. We
+                    // enqueue the writes and request a session key; the writes are
+                    // sent once the passkey arrives (below).
                     if !auto_applied
                         && matches!(
                             msg.payload_variant,
@@ -606,11 +704,36 @@ async fn event_loop(
                         )
                         && auto_apply.has_anything()
                     {
-                        let node_num = state.lock().expect("state mutex poisoned").my_node_num;
-                        if let Some(node_num) = node_num {
-                            apply_config_on_connect(&cmd_tx, node_num, &auto_apply, &packet_counter)
-                                .await;
+                        let node = state.lock().expect("state poisoned").my_node_num;
+                        if let Some(node) = node {
+                            enqueue_auto_apply(&auto_apply, &mut deferred_writes);
+                            request_session_key(
+                                &cmd_tx,
+                                node,
+                                &mut session_requested,
+                                &deferred_writes,
+                            )
+                            .await;
                             auto_applied = true;
+                        }
+                    }
+
+                    // Harvest a session passkey from any admin response and, once
+                    // we have one, flush queued writes.
+                    if let Some(pk) = harvest_session_passkey(&msg) {
+                        last_session_passkey = pk;
+                    }
+                    if !deferred_writes.is_empty() && !last_session_passkey.is_empty() {
+                        let node = state.lock().expect("state poisoned").my_node_num;
+                        if let Some(node) = node {
+                            flush_deferred_writes(
+                                &cmd_tx,
+                                node,
+                                &last_session_passkey,
+                                &mut deferred_writes,
+                            )
+                            .await;
+                            session_requested = false;
                         }
                     }
 
@@ -656,19 +779,24 @@ async fn event_loop(
                     reject_no_num(req);
                     continue;
                 };
-                if pending_admin.is_some() {
-                    // Another admin operation is in flight — reject immediately.
-                    fn reject_busy(req: MeshtasticAdminRequest) {
-                        let e = "another admin operation is already in progress".to_owned();
-                        match req {
-                            MeshtasticAdminRequest::GetLoRaConfig { reply } => { let _ = reply.send(Err(e)); }
-                            MeshtasticAdminRequest::SetLoRaConfig { reply, .. } => { let _ = reply.send(Err(e)); }
-                            MeshtasticAdminRequest::GetOwner { reply } => { let _ = reply.send(Err(e)); }
-                            MeshtasticAdminRequest::SetOwner { reply, .. } => { let _ = reply.send(Err(e)); }
-                            MeshtasticAdminRequest::GetSecurity { reply } => { let _ = reply.send(Err(e)); }
-                        }
+                // Only GET operations use `pending_admin` (one in flight at a
+                // time). SET operations are queued as deferred writes, so they
+                // are not blocked by a pending GET.
+                if pending_admin.is_some()
+                    && matches!(
+                        req,
+                        MeshtasticAdminRequest::GetLoRaConfig { .. }
+                            | MeshtasticAdminRequest::GetOwner { .. }
+                            | MeshtasticAdminRequest::GetSecurity { .. }
+                    )
+                {
+                    let e = "another admin operation is already in progress".to_owned();
+                    match req {
+                        MeshtasticAdminRequest::GetLoRaConfig { reply } => { let _ = reply.send(Err(e)); }
+                        MeshtasticAdminRequest::GetOwner { reply } => { let _ = reply.send(Err(e)); }
+                        MeshtasticAdminRequest::GetSecurity { reply } => { let _ = reply.send(Err(e)); }
+                        _ => unreachable!(),
                     }
-                    reject_busy(req);
                     continue;
                 }
                 match req {
@@ -681,7 +809,6 @@ async fn event_loop(
                         }
                     }
                     MeshtasticAdminRequest::SetLoRaConfig { config, reply } => {
-                        let rid = packet_counter.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
                         let lora = LoRaConfig {
                             use_preset: config.use_preset,
                             modem_preset: config.modem_preset,
@@ -696,17 +823,10 @@ async fn event_loop(
                             channel_num: config.channel_num,
                             override_frequency: config.override_frequency,
                         };
-                        let passkey = last_session_passkey.clone();
-                        // Fire-and-forget: Meshtastic does not send a reliable admin
-                        // response for a config write — it applies it silently (and
-                        // reboots only if a LoRa parameter actually changed). Waiting
-                        // for an ACK would always time out, so report success once
-                        // the command has been handed to the device.
-                        if cmd_tx.send(admin_set_lora_config(my_node_num, rid, lora, passkey)).await.is_err() {
-                            let _ = reply.send(Err("meshtastic client disconnected".into()));
-                        } else {
-                            let _ = reply.send(Ok(()));
-                        }
+                        // Queue the write and request a session key. The write is
+                        // sent (and `reply` completed) once the passkey arrives.
+                        deferred_writes.push(DeferredWrite::Lora { lora, reply: Some(reply) });
+                        request_session_key(&cmd_tx, my_node_num, &mut session_requested, &deferred_writes).await;
                     }
                     MeshtasticAdminRequest::GetOwner { reply } => {
                         let rid = packet_counter.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
@@ -717,26 +837,9 @@ async fn event_loop(
                         }
                     }
                     MeshtasticAdminRequest::SetOwner { long_name, short_name, reply } => {
-                        // Firmware only copies non-empty long_name/short_name from
-                        // the User and never overwrites the PKC public key on a
-                        // SetOwner, so sending empty id/public_key is safe and
-                        // leaves the node identity key intact.
-                        let rid = packet_counter.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-                        let user = User {
-                            id: String::new(),
-                            long_name: long_name.unwrap_or_default(),
-                            short_name: short_name.unwrap_or_default(),
-                            public_key: Vec::new(),
-                        };
-                        let passkey = last_session_passkey.clone();
-                        // Fire-and-forget, consistent with SetLoRaConfig: Meshtastic
-                        // applies the owner change without a reliable admin response.
-                        // Report success once the command has been sent.
-                        if cmd_tx.send(admin_set_owner(my_node_num, rid, user, passkey)).await.is_err() {
-                            let _ = reply.send(Err("meshtastic client disconnected".into()));
-                        } else {
-                            let _ = reply.send(Ok(()));
-                        }
+                        let user = owner_user(long_name.as_deref(), short_name.as_deref());
+                        deferred_writes.push(DeferredWrite::Owner { user, reply: Some(reply) });
+                        request_session_key(&cmd_tx, my_node_num, &mut session_requested, &deferred_writes).await;
                     }
                     MeshtasticAdminRequest::GetSecurity { reply } => {
                         let rid = packet_counter.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
@@ -756,73 +859,59 @@ async fn event_loop(
     }
 }
 
-/// Push the operator's configured radio and node-name settings to the device.
-///
-/// Called once per connection after config sync completes.  Fire-and-forget:
-/// the device applies SetConfig / SetOwner and persists them in flash, so we
-/// don't block on ACKs here.  This is what makes settings configured in setup
-/// or the web UI take effect automatically — no CLI step required.
-///
-/// `SetOwner` is sent with an empty `public_key`; Meshtastic firmware only
-/// copies `long_name`/`short_name` from the message and never overwrites the
-/// node's PKC key from a SetOwner (the key is managed via SecurityConfig), so
-/// the node's identity key is preserved.
-async fn apply_config_on_connect(
-    cmd_tx: &mpsc::Sender<proto::ToRadio>,
-    node_num: u32,
-    cfg: &AutoApplyConfig,
-    packet_counter: &AtomicU32,
-) {
-    use proto::{admin_set_lora_config, admin_set_owner, LoRaConfig, User};
-
-    // Radio config (region + modem preset).
+/// Queue the operator's configured radio and node-name settings as deferred
+/// writes, to be sent once a session passkey is obtained. Called once per
+/// connection after config sync completes — this is what makes settings from
+/// setup or the web UI take effect automatically on connect.
+fn enqueue_auto_apply(cfg: &AutoApplyConfig, deferred: &mut Vec<DeferredWrite>) {
     if let Some(radio) = &cfg.radio {
         if radio.region.is_some() || radio.modem_preset.is_some() {
-            let region = region_str_to_int(radio.region.as_deref().unwrap_or("UNSET"));
-            let preset = preset_str_to_int(radio.modem_preset.as_deref().unwrap_or("LONG_FAST"));
-            let lora = LoRaConfig {
+            let lora = proto::LoRaConfig {
                 use_preset: true,
-                modem_preset: preset,
-                region,
+                modem_preset: preset_str_to_int(
+                    radio.modem_preset.as_deref().unwrap_or("LONG_FAST"),
+                ),
+                region: region_str_to_int(radio.region.as_deref().unwrap_or("UNSET")),
                 ..Default::default()
             };
-            let rid = packet_counter.fetch_add(1, Ordering::Relaxed);
             info!(
                 region = radio.region.as_deref().unwrap_or("UNSET"),
                 modem_preset = radio.modem_preset.as_deref().unwrap_or("LONG_FAST"),
-                "meshtastic: auto-applying radio config from config.toml"
+                "meshtastic: queuing radio config from config.toml for apply-on-connect"
             );
-            if cmd_tx
-                .send(admin_set_lora_config(node_num, rid, lora, Vec::new()))
-                .await
-                .is_err()
-            {
-                warn!("meshtastic: failed to send auto-apply radio config");
-            }
+            deferred.push(DeferredWrite::Lora { lora, reply: None });
         }
     }
-
-    // Node name (long + short).
     if cfg.short_name.is_some() || cfg.long_name.is_some() {
-        let user = User {
-            id: String::new(),
-            long_name: cfg.long_name.clone().unwrap_or_default(),
-            short_name: cfg.short_name.clone().unwrap_or_default(),
-            public_key: Vec::new(),
-        };
-        let rid = packet_counter.fetch_add(1, Ordering::Relaxed);
         info!(
             long_name = cfg.long_name.as_deref().unwrap_or(""),
             short_name = cfg.short_name.as_deref().unwrap_or(""),
-            "meshtastic: auto-applying node name from config.toml"
+            "meshtastic: queuing node name from config.toml for apply-on-connect"
         );
-        if cmd_tx
-            .send(admin_set_owner(node_num, rid, user, Vec::new()))
-            .await
-            .is_err()
-        {
-            warn!("meshtastic: failed to send auto-apply node name");
-        }
+        deferred.push(DeferredWrite::Owner {
+            user: owner_user(cfg.long_name.as_deref(), cfg.short_name.as_deref()),
+            reply: None,
+        });
+    }
+}
+
+/// Request a session key from the device (to authorize queued writes), unless a
+/// request is already outstanding or there is nothing to write.
+async fn request_session_key(
+    cmd_tx: &mpsc::Sender<proto::ToRadio>,
+    node: u32,
+    session_requested: &mut bool,
+    deferred: &[DeferredWrite],
+) {
+    if *session_requested || deferred.is_empty() {
+        return;
+    }
+    if cmd_tx
+        .send(admin_get_session_key(node, random_packet_id()))
+        .await
+        .is_ok()
+    {
+        *session_requested = true;
     }
 }
 
@@ -1030,12 +1119,7 @@ pub async fn apply_radio_from_config(
     baud_override: Option<u32>,
     addr_override: Option<String>,
 ) -> Result<(), String> {
-    use proto::{
-        admin_set_lora_config, from_radio, mesh_packet, want_config, LoRaConfig, PORT_ADMIN_APP,
-    };
-    use std::time::Duration;
-    use stream::ClientEvent;
-    use tokio::time::timeout;
+    use proto::{admin_set_lora_config, LoRaConfig};
 
     let radio_cfg = config.radio.as_ref().ok_or_else(|| {
         "no [plugins.meshtastic.radio] in config.toml — \
@@ -1053,63 +1137,16 @@ pub async fn apply_radio_from_config(
     );
 
     let mut client = make_client(config, port_override, baud_override, addr_override)?;
-
-    timeout(Duration::from_secs(15), async {
-        let cmd_tx = client.sender();
-        let mut my_node_num: Option<u32> = None;
-        let mut sent = false;
-
-        cmd_tx
-            .send(want_config(42))
-            .await
-            .map_err(|_| "send failed".to_owned())?;
-
-        while let Some(event) = client.recv().await {
-            match event {
-                ClientEvent::Connected => {}
-                ClientEvent::Disconnected { .. } => return Err("device disconnected".to_owned()),
-                ClientEvent::FromRadio(msg) => {
-                    if my_node_num.is_none() {
-                        if let Some(from_radio::PayloadVariant::MyInfo(info)) = &msg.payload_variant
-                        {
-                            my_node_num = Some(info.my_node_num);
-                        }
-                    }
-                    if let Some(node_num) = my_node_num {
-                        if !sent {
-                            let lora = LoRaConfig {
-                                use_preset: true,
-                                modem_preset: preset,
-                                region,
-                                ..Default::default()
-                            };
-                            cmd_tx
-                                .send(admin_set_lora_config(node_num, 0x1234_5601, lora, vec![]))
-                                .await
-                                .map_err(|_| "send failed".to_owned())?;
-                            sent = true;
-                        }
-                    }
-                    // Any admin packet after we sent = ACK.
-                    if sent {
-                        if let Some(from_radio::PayloadVariant::Packet(pkt)) = &msg.payload_variant
-                        {
-                            if let Some(mesh_packet::PayloadVariant::Decoded(d)) =
-                                &pkt.payload_variant
-                            {
-                                if d.portnum == PORT_ADMIN_APP {
-                                    return Ok(());
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        }
-        Err("connection closed unexpectedly".to_owned())
+    run_admin_write(&mut client, move |node, passkey| {
+        let lora = LoRaConfig {
+            use_preset: true,
+            modem_preset: preset,
+            region,
+            ..Default::default()
+        };
+        admin_set_lora_config(node, random_packet_id(), lora, passkey)
     })
     .await
-    .map_err(|_| "timed out (15s) — is the device connected and not in use?".to_owned())?
 }
 
 /// Connect to the Meshtastic device and push the node name stored in `config`.
@@ -1122,14 +1159,7 @@ pub async fn apply_owner_from_config(
     baud_override: Option<u32>,
     addr_override: Option<String>,
 ) -> Result<(), String> {
-    use prost::Message as _;
-    use proto::{
-        admin_get_owner, admin_message, admin_set_owner, from_radio, mesh_packet, want_config,
-        AdminMessage, User, PORT_ADMIN_APP,
-    };
-    use std::time::Duration;
-    use stream::ClientEvent;
-    use tokio::time::timeout;
+    use proto::admin_set_owner;
 
     if config.long_name.is_none() && config.short_name.is_none() {
         return Err(
@@ -1140,12 +1170,47 @@ pub async fn apply_owner_from_config(
     }
 
     let mut client = make_client(config, port_override, baud_override, addr_override)?;
+    let user = owner_user(config.long_name.as_deref(), config.short_name.as_deref());
+    eprintln!(
+        "Pushing owner: long_name={:?}, short_name={:?}",
+        user.long_name, user.short_name
+    );
+    run_admin_write(&mut client, move |node, passkey| {
+        admin_set_owner(node, random_packet_id(), user.clone(), passkey)
+    })
+    .await
+}
 
-    timeout(Duration::from_secs(15), async {
+/// Drive a Meshtastic admin WRITE against a freshly-connected device, handling
+/// the full handshake the firmware requires:
+///
+/// 1. `want_config` and wait for `ConfigCompleteId` (the device ignores admin
+///    packets received mid-sync).
+/// 2. Send `get_config_request: SESSIONKEY_CONFIG` and harvest the 8-byte
+///    `session_passkey` the device returns (AdminMessage field 101).
+/// 3. Build the write with that passkey echoed in and send it.
+///
+/// The passkey is what authorizes the write; without it the firmware drops the
+/// admin message. The passkey is valid for ~300 s and must come from a recent
+/// get-response.
+async fn run_admin_write<F>(client: &mut stream::MeshtasticClient, build: F) -> Result<(), String>
+where
+    F: FnOnce(u32, Vec<u8>) -> proto::ToRadio,
+{
+    use prost::Message as _;
+    use proto::{
+        admin_get_session_key, admin_message, from_radio, mesh_packet, want_config, AdminMessage,
+        PORT_ADMIN_APP,
+    };
+    use std::time::Duration;
+    use stream::ClientEvent;
+    use tokio::time::timeout;
+
+    timeout(Duration::from_secs(20), async move {
         let cmd_tx = client.sender();
         let mut my_node_num: Option<u32> = None;
-        let mut existing_owner: Option<User> = None;
-        let mut phase = 0u8; // 0=wait-node-num 1=wait-get-owner-ack 2=wait-set-ack
+        let mut requested_key = false;
+        let sess_req_id = random_packet_id();
 
         cmd_tx
             .send(want_config(42))
@@ -1154,67 +1219,55 @@ pub async fn apply_owner_from_config(
 
         while let Some(event) = client.recv().await {
             match event {
-                ClientEvent::Connected => {}
                 ClientEvent::Disconnected { .. } => return Err("device disconnected".to_owned()),
+                ClientEvent::Connected => {}
                 ClientEvent::FromRadio(msg) => {
-                    if my_node_num.is_none() {
-                        if let Some(from_radio::PayloadVariant::MyInfo(info)) = &msg.payload_variant
-                        {
+                    match &msg.payload_variant {
+                        Some(from_radio::PayloadVariant::MyInfo(info)) => {
                             my_node_num = Some(info.my_node_num);
-                            // Fetch existing owner to preserve public key.
+                        }
+                        Some(from_radio::PayloadVariant::ConfigCompleteId(_)) if !requested_key => {
+                            let Some(node) = my_node_num else {
+                                return Err("config sync completed without a node number".into());
+                            };
+                            // Step 2: request a session key to authorize the write.
                             cmd_tx
-                                .send(admin_get_owner(info.my_node_num, 0x1234_5601))
+                                .send(admin_get_session_key(node, sess_req_id))
                                 .await
                                 .map_err(|_| "send failed".to_owned())?;
-                            phase = 1;
+                            requested_key = true;
                         }
-                    }
-                    if let Some(from_radio::PayloadVariant::Packet(pkt)) = &msg.payload_variant {
-                        if let Some(mesh_packet::PayloadVariant::Decoded(d)) = &pkt.payload_variant
-                        {
-                            if d.portnum == PORT_ADMIN_APP {
-                                if phase == 1 {
+                        Some(from_radio::PayloadVariant::Packet(packet)) if requested_key => {
+                            // Look for the admin response carrying the session passkey.
+                            if let Some(mesh_packet::PayloadVariant::Decoded(d)) =
+                                &packet.payload_variant
+                            {
+                                if d.portnum == PORT_ADMIN_APP {
                                     if let Ok(adm) = AdminMessage::decode(d.payload.as_slice()) {
-                                        if let Some(
-                                            admin_message::PayloadVariant::GetOwnerResponse(u),
-                                        ) = adm.payload_variant
-                                        {
-                                            existing_owner = Some(u);
+                                        // Only act on a get-response (it carries the
+                                        // passkey); ignore our own echoed requests.
+                                        let is_resp = matches!(
+                                            adm.payload_variant,
+                                            Some(admin_message::PayloadVariant::GetConfigResponse(
+                                                _
+                                            ))
+                                        );
+                                        if is_resp || !adm.session_passkey.is_empty() {
+                                            let node = my_node_num.unwrap();
+                                            let pkt = build(node, adm.session_passkey);
+                                            cmd_tx
+                                                .send(pkt)
+                                                .await
+                                                .map_err(|_| "send failed".to_owned())?;
+                                            // Flush before dropping the connection.
+                                            tokio::time::sleep(Duration::from_millis(2000)).await;
+                                            return Ok(());
                                         }
                                     }
-                                    if let Some(owner) = existing_owner.take() {
-                                        let new_user = User {
-                                            id: owner.id,
-                                            long_name: config
-                                                .long_name
-                                                .clone()
-                                                .unwrap_or(owner.long_name),
-                                            short_name: config
-                                                .short_name
-                                                .clone()
-                                                .unwrap_or(owner.short_name),
-                                            public_key: owner.public_key,
-                                        };
-                                        eprintln!(
-                                            "Pushing owner: long_name={:?}, short_name={:?}",
-                                            new_user.long_name, new_user.short_name
-                                        );
-                                        cmd_tx
-                                            .send(admin_set_owner(
-                                                my_node_num.unwrap(),
-                                                0x1234_5602,
-                                                new_user,
-                                                vec![],
-                                            ))
-                                            .await
-                                            .map_err(|_| "send failed".to_owned())?;
-                                        phase = 2;
-                                    }
-                                } else if phase == 2 {
-                                    return Ok(());
                                 }
                             }
                         }
+                        _ => {}
                     }
                 }
             }
@@ -1222,7 +1275,44 @@ pub async fn apply_owner_from_config(
         Err("connection closed unexpectedly".to_owned())
     })
     .await
-    .map_err(|_| "timed out (15s) — is the device connected and not in use?".to_owned())?
+    .map_err(|_| "timed out (20s) — is the device connected and not in use?".to_owned())?
+}
+
+/// Build a Meshtastic owner `User` with firmware-safe field lengths.
+///
+/// The firmware decodes these into fixed buffers — `short_name` is `char[5]`
+/// (max **4** chars + null) and `long_name` is `char[40]` (max **39**). A value
+/// that overflows makes the device reject the *entire* admin message with
+/// `Can't decode protobuf reason='string overflow'`, so we clamp here. `id` and
+/// `public_key` are left empty: firmware ignores them on SetOwner and never
+/// overwrites the node's PKC key from one.
+fn owner_user(long_name: Option<&str>, short_name: Option<&str>) -> proto::User {
+    fn clamp(s: &str, max_chars: usize) -> String {
+        s.chars().take(max_chars).collect()
+    }
+    proto::User {
+        id: String::new(),
+        long_name: long_name.map(|s| clamp(s, 39)).unwrap_or_default(),
+        short_name: short_name.map(|s| clamp(s, 4)).unwrap_or_default(),
+        public_key: Vec::new(),
+    }
+}
+
+/// Generate an unpredictable, non-zero 32-bit packet id.
+///
+/// Meshtastic deduplicates received packets by `(from, id)`. Reusing fixed or
+/// process-restart-repeating ids causes the device to silently discard our
+/// admin packets as duplicates, so each packet needs a fresh, varied id —
+/// exactly what the Meshtastic app does (it uses random ids).
+fn random_packet_id() -> u32 {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.subsec_nanos() ^ (d.as_secs() as u32))
+        .unwrap_or(0);
+    // Mix and ensure non-zero.
+    let id = nanos.wrapping_mul(2_654_435_761).rotate_left(13) ^ 0x9E37_79B9;
+    id | 1
 }
 
 /// Build a [`MeshtasticClient`] from config + optional CLI overrides.
@@ -1784,6 +1874,7 @@ serial_port = "/dev/ttyAMA0"
             via_mqtt: false,
             hop_start: 0,
             public_key: Vec::new(),
+            pki_encrypted: false,
         };
         assert_eq!(text_payload(&packet), Some("hello".to_owned()));
     }

--- a/crates/bbs-meshtastic/src/lib.rs
+++ b/crates/bbs-meshtastic/src/lib.rs
@@ -523,6 +523,16 @@ enum PendingMeshtasticAdmin {
     },
 }
 
+/// True when the caller waiting on a pending GET has dropped its receiver
+/// (i.e. timed out and given up), so the pending op can be safely discarded.
+fn pending_reply_abandoned(op: &PendingMeshtasticAdmin) -> bool {
+    match op {
+        PendingMeshtasticAdmin::GetLora { reply, .. } => reply.is_closed(),
+        PendingMeshtasticAdmin::GetOwner { reply, .. } => reply.is_closed(),
+        PendingMeshtasticAdmin::GetSecurity { reply, .. } => reply.is_closed(),
+    }
+}
+
 #[allow(clippy::too_many_arguments)]
 async fn event_loop(
     mut client: MeshtasticClient,
@@ -547,9 +557,21 @@ async fn event_loop(
     // Whether we've pushed the config.toml settings to the device on this
     // connection. Reset on disconnect so settings re-apply after a reconnect.
     let mut auto_applied = false;
+    // Periodically reap a pending GET whose caller has given up (its oneshot
+    // receiver was dropped after the caller's own timeout). Without this, a GET
+    // that never gets a device response would leave `pending_admin` set forever
+    // and block every later admin operation with "another operation in progress".
+    let mut reap = tokio::time::interval(Duration::from_secs(2));
+    reap.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
 
     loop {
         tokio::select! {
+            _ = reap.tick() => {
+                if pending_admin.as_ref().is_some_and(pending_reply_abandoned) {
+                    warn!("meshtastic: clearing abandoned pending admin GET (no device response)");
+                    pending_admin = None;
+                }
+            }
             event = client.recv() => match event {
                 Some(ClientEvent::Connected) => {
                     info!("meshtastic: connected to radio");

--- a/crates/bbs-meshtastic/src/lib.rs
+++ b/crates/bbs-meshtastic/src/lib.rs
@@ -704,9 +704,16 @@ async fn event_loop(
                         )
                         && auto_apply.has_anything()
                     {
-                        let node = state.lock().expect("state poisoned").my_node_num;
+                        let (node, device_lora) = {
+                            let s = state.lock().expect("state poisoned");
+                            (s.my_node_num, s.device_lora.clone())
+                        };
                         if let Some(node) = node {
-                            enqueue_auto_apply(&auto_apply, &mut deferred_writes);
+                            enqueue_auto_apply(
+                                &auto_apply,
+                                device_lora.as_ref(),
+                                &mut deferred_writes,
+                            );
                             request_session_key(
                                 &cmd_tx,
                                 node,
@@ -859,11 +866,27 @@ async fn event_loop(
     }
 }
 
+/// Whether the operator's desired LoRa settings differ from the device's
+/// current config in a way that warrants a write. We only compare the fields
+/// apply-on-connect actually sets (`use_preset`, `modem_preset`, `region`); the
+/// remaining fields are preset-derived on the device and not something the
+/// operator configures here, so comparing them would force a needless write
+/// (and reboot) every connect.
+fn lora_differs(desired: &proto::LoRaConfig, current: &proto::LoRaConfig) -> bool {
+    desired.use_preset != current.use_preset
+        || desired.modem_preset != current.modem_preset
+        || desired.region != current.region
+}
+
 /// Queue the operator's configured radio and node-name settings as deferred
 /// writes, to be sent once a session passkey is obtained. Called once per
 /// connection after config sync completes — this is what makes settings from
 /// setup or the web UI take effect automatically on connect.
-fn enqueue_auto_apply(cfg: &AutoApplyConfig, deferred: &mut Vec<DeferredWrite>) {
+fn enqueue_auto_apply(
+    cfg: &AutoApplyConfig,
+    device_lora: Option<&proto::LoRaConfig>,
+    deferred: &mut Vec<DeferredWrite>,
+) {
     if let Some(radio) = &cfg.radio {
         if radio.region.is_some() || radio.modem_preset.is_some() {
             let lora = proto::LoRaConfig {
@@ -874,12 +897,25 @@ fn enqueue_auto_apply(cfg: &AutoApplyConfig, deferred: &mut Vec<DeferredWrite>) 
                 region: region_str_to_int(radio.region.as_deref().unwrap_or("UNSET")),
                 ..Default::default()
             };
-            info!(
-                region = radio.region.as_deref().unwrap_or("UNSET"),
-                modem_preset = radio.modem_preset.as_deref().unwrap_or("LONG_FAST"),
-                "meshtastic: queuing radio config from config.toml for apply-on-connect"
-            );
-            deferred.push(DeferredWrite::Lora { lora, reply: None });
+            // Writing LoRa config reboots the radio — even when nothing changed.
+            // Only queue the write when the device's current region/preset
+            // actually differs from what the operator configured. Skipping the
+            // no-op write keeps the radio online (and hearing adverts) instead
+            // of cycling through a reboot on every reconnect.
+            if device_lora.is_some_and(|cur| !lora_differs(&lora, cur)) {
+                info!(
+                    region = radio.region.as_deref().unwrap_or("UNSET"),
+                    modem_preset = radio.modem_preset.as_deref().unwrap_or("LONG_FAST"),
+                    "meshtastic: radio config already matches device, skipping write (no reboot)"
+                );
+            } else {
+                info!(
+                    region = radio.region.as_deref().unwrap_or("UNSET"),
+                    modem_preset = radio.modem_preset.as_deref().unwrap_or("LONG_FAST"),
+                    "meshtastic: queuing radio config from config.toml for apply-on-connect"
+                );
+                deferred.push(DeferredWrite::Lora { lora, reply: None });
+            }
         }
     }
     if cfg.short_name.is_some() || cfg.long_name.is_some() {
@@ -1383,6 +1419,19 @@ async fn handle_from_radio(
         Some(from_radio::PayloadVariant::NodeInfo(node)) => {
             record_node_advert(host, node);
         }
+        Some(from_radio::PayloadVariant::Config(cfg)) => {
+            // Capture the device's current LoRa config from the sync stream so
+            // apply-on-connect can skip a redundant (reboot-inducing) write.
+            if let Some(proto::mt_config::PayloadVariant::Lora(lora)) = cfg.payload_variant {
+                debug!(
+                    region = lora.region,
+                    modem_preset = lora.modem_preset,
+                    use_preset = lora.use_preset,
+                    "meshtastic: captured device LoRa config from sync"
+                );
+                state.lock().expect("state mutex poisoned").device_lora = Some(lora);
+            }
+        }
         Some(from_radio::PayloadVariant::Packet(packet)) => {
             handle_packet(
                 packet,
@@ -1440,7 +1489,8 @@ fn record_node_advert(host: &Arc<dyn Host>, node: NodeInfo) {
         })
         .unwrap_or((0, 0));
 
-    host.advert_bus().upsert(pubkey, name, 0, lat_1e6, lon_1e6);
+    host.advert_bus()
+        .upsert(pubkey, name, 0, lat_1e6, lon_1e6, TRANSPORT_NAME);
 }
 
 #[allow(clippy::too_many_arguments)]

--- a/crates/bbs-meshtastic/src/lib.rs
+++ b/crates/bbs-meshtastic/src/lib.rs
@@ -835,6 +835,301 @@ fn hex_encode(bytes: &[u8]) -> String {
         })
 }
 
+// ── CLI helpers — direct device config push ───────────────────────────────────
+
+fn region_str_to_int(name: &str) -> i32 {
+    match name {
+        "US" => 1,
+        "EU_433" => 2,
+        "EU_868" => 3,
+        "CN" => 4,
+        "JP" => 5,
+        "ANZ" => 6,
+        "KR" => 7,
+        "TW" => 8,
+        "RU" => 9,
+        "IN" => 10,
+        "NZ_865" => 11,
+        "TH" => 12,
+        "LORA_24" => 13,
+        "UA_433" => 14,
+        "UA_868" => 15,
+        "MY_433" => 16,
+        "MY_919" => 17,
+        "SG_923" => 18,
+        _ => 0, // UNSET
+    }
+}
+
+fn preset_str_to_int(name: &str) -> i32 {
+    match name {
+        "LONG_FAST" => 0,
+        "LONG_SLOW" => 1,
+        "VERY_LONG_SLOW" => 2,
+        "MEDIUM_SLOW" => 3,
+        "MEDIUM_FAST" => 4,
+        "SHORT_SLOW" => 5,
+        "SHORT_FAST" => 6,
+        "LONG_MODERATE" => 7,
+        "SHORT_TURBO" => 8,
+        "LONG_TURBO" => 9,
+        "LITE_FAST" => 10,
+        "LITE_SLOW" => 11,
+        "NARROW_FAST" => 12,
+        "NARROW_SLOW" => 13,
+        _ => 0, // LONG_FAST
+    }
+}
+
+/// Connect to the Meshtastic device and push the LoRa radio config stored in
+/// `config`.  Returns `Ok(())` on success or an error string.
+///
+/// Resolves the connection parameters in order: flag overrides → config values.
+/// The BBS must **not** be running on the same port when this is called.
+pub async fn apply_radio_from_config(
+    config: &MeshtasticConfig,
+    port_override: Option<String>,
+    baud_override: Option<u32>,
+    addr_override: Option<String>,
+) -> Result<(), String> {
+    use proto::{
+        admin_set_lora_config, from_radio, mesh_packet, want_config, LoRaConfig, PORT_ADMIN_APP,
+    };
+    use std::time::Duration;
+    use stream::ClientEvent;
+    use tokio::time::timeout;
+
+    let radio_cfg = config.radio.as_ref().ok_or_else(|| {
+        "no [plugins.meshtastic.radio] in config.toml — \
+         run 'supply-drop-bbs setup' to configure"
+            .to_owned()
+    })?;
+    let region = region_str_to_int(radio_cfg.region.as_deref().unwrap_or("UNSET"));
+    let preset = preset_str_to_int(radio_cfg.modem_preset.as_deref().unwrap_or("LONG_FAST"));
+    eprintln!(
+        "Pushing radio config: region={} ({}), modem_preset={} ({})",
+        region,
+        radio_cfg.region.as_deref().unwrap_or("UNSET"),
+        preset,
+        radio_cfg.modem_preset.as_deref().unwrap_or("LONG_FAST"),
+    );
+
+    let mut client = make_client(config, port_override, baud_override, addr_override)?;
+
+    timeout(Duration::from_secs(15), async {
+        let cmd_tx = client.sender();
+        let mut my_node_num: Option<u32> = None;
+        let mut sent = false;
+
+        cmd_tx
+            .send(want_config(42))
+            .await
+            .map_err(|_| "send failed".to_owned())?;
+
+        while let Some(event) = client.recv().await {
+            match event {
+                ClientEvent::Connected => {}
+                ClientEvent::Disconnected { .. } => return Err("device disconnected".to_owned()),
+                ClientEvent::FromRadio(msg) => {
+                    if my_node_num.is_none() {
+                        if let Some(from_radio::PayloadVariant::MyInfo(info)) = &msg.payload_variant
+                        {
+                            my_node_num = Some(info.my_node_num);
+                        }
+                    }
+                    if let Some(node_num) = my_node_num {
+                        if !sent {
+                            let lora = LoRaConfig {
+                                use_preset: true,
+                                modem_preset: preset,
+                                region,
+                                ..Default::default()
+                            };
+                            cmd_tx
+                                .send(admin_set_lora_config(node_num, 0x1234_5601, lora, vec![]))
+                                .await
+                                .map_err(|_| "send failed".to_owned())?;
+                            sent = true;
+                        }
+                    }
+                    // Any admin packet after we sent = ACK.
+                    if sent {
+                        if let Some(from_radio::PayloadVariant::Packet(pkt)) = &msg.payload_variant
+                        {
+                            if let Some(mesh_packet::PayloadVariant::Decoded(d)) =
+                                &pkt.payload_variant
+                            {
+                                if d.portnum == PORT_ADMIN_APP {
+                                    return Ok(());
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        Err("connection closed unexpectedly".to_owned())
+    })
+    .await
+    .map_err(|_| "timed out (15s) — is the device connected and not in use?".to_owned())?
+}
+
+/// Connect to the Meshtastic device and push the node name stored in `config`.
+///
+/// Fetches the existing owner first to preserve the PKC public key, then
+/// merges in `long_name` and `short_name` from config and sends `SetOwner`.
+pub async fn apply_owner_from_config(
+    config: &MeshtasticConfig,
+    port_override: Option<String>,
+    baud_override: Option<u32>,
+    addr_override: Option<String>,
+) -> Result<(), String> {
+    use prost::Message as _;
+    use proto::{
+        admin_get_owner, admin_message, admin_set_owner, from_radio, mesh_packet, want_config,
+        AdminMessage, User, PORT_ADMIN_APP,
+    };
+    use std::time::Duration;
+    use stream::ClientEvent;
+    use tokio::time::timeout;
+
+    if config.long_name.is_none() && config.short_name.is_none() {
+        return Err(
+            "neither long_name nor short_name is set in [plugins.meshtastic] — \
+             run 'supply-drop-bbs setup' or add them manually to config.toml"
+                .to_owned(),
+        );
+    }
+
+    let mut client = make_client(config, port_override, baud_override, addr_override)?;
+
+    timeout(Duration::from_secs(15), async {
+        let cmd_tx = client.sender();
+        let mut my_node_num: Option<u32> = None;
+        let mut existing_owner: Option<User> = None;
+        let mut phase = 0u8; // 0=wait-node-num 1=wait-get-owner-ack 2=wait-set-ack
+
+        cmd_tx
+            .send(want_config(42))
+            .await
+            .map_err(|_| "send failed".to_owned())?;
+
+        while let Some(event) = client.recv().await {
+            match event {
+                ClientEvent::Connected => {}
+                ClientEvent::Disconnected { .. } => return Err("device disconnected".to_owned()),
+                ClientEvent::FromRadio(msg) => {
+                    if my_node_num.is_none() {
+                        if let Some(from_radio::PayloadVariant::MyInfo(info)) = &msg.payload_variant
+                        {
+                            my_node_num = Some(info.my_node_num);
+                            // Fetch existing owner to preserve public key.
+                            cmd_tx
+                                .send(admin_get_owner(info.my_node_num, 0x1234_5601))
+                                .await
+                                .map_err(|_| "send failed".to_owned())?;
+                            phase = 1;
+                        }
+                    }
+                    if let Some(from_radio::PayloadVariant::Packet(pkt)) = &msg.payload_variant {
+                        if let Some(mesh_packet::PayloadVariant::Decoded(d)) = &pkt.payload_variant
+                        {
+                            if d.portnum == PORT_ADMIN_APP {
+                                if phase == 1 {
+                                    if let Ok(adm) = AdminMessage::decode(d.payload.as_slice()) {
+                                        if let Some(
+                                            admin_message::PayloadVariant::GetOwnerResponse(u),
+                                        ) = adm.payload_variant
+                                        {
+                                            existing_owner = Some(u);
+                                        }
+                                    }
+                                    if let Some(owner) = existing_owner.take() {
+                                        let new_user = User {
+                                            id: owner.id,
+                                            long_name: config
+                                                .long_name
+                                                .clone()
+                                                .unwrap_or(owner.long_name),
+                                            short_name: config
+                                                .short_name
+                                                .clone()
+                                                .unwrap_or(owner.short_name),
+                                            public_key: owner.public_key,
+                                        };
+                                        eprintln!(
+                                            "Pushing owner: long_name={:?}, short_name={:?}",
+                                            new_user.long_name, new_user.short_name
+                                        );
+                                        cmd_tx
+                                            .send(admin_set_owner(
+                                                my_node_num.unwrap(),
+                                                0x1234_5602,
+                                                new_user,
+                                                vec![],
+                                            ))
+                                            .await
+                                            .map_err(|_| "send failed".to_owned())?;
+                                        phase = 2;
+                                    }
+                                } else if phase == 2 {
+                                    return Ok(());
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        Err("connection closed unexpectedly".to_owned())
+    })
+    .await
+    .map_err(|_| "timed out (15s) — is the device connected and not in use?".to_owned())?
+}
+
+/// Build a [`MeshtasticClient`] from config + optional CLI overrides.
+fn make_client(
+    config: &MeshtasticConfig,
+    port_override: Option<String>,
+    baud_override: Option<u32>,
+    addr_override: Option<String>,
+) -> Result<stream::MeshtasticClient, String> {
+    use std::time::Duration;
+    use stream::{SerialConfig, TcpConfig};
+
+    match config.connection_type {
+        MeshtasticConnectionType::Serial | MeshtasticConnectionType::Hat => {
+            let port = port_override
+                .or_else(|| config.serial_port.clone())
+                .ok_or_else(|| {
+                    "no serial port — use --port or set serial_port in \
+                     [plugins.meshtastic] in config.toml"
+                        .to_owned()
+                })?;
+            let baud = baud_override.unwrap_or(config.baud_rate);
+            eprintln!("Connecting to {port} at {baud} baud…");
+            Ok(stream::MeshtasticClient::connect_serial(SerialConfig {
+                port,
+                baud_rate: baud,
+                reconnect_delay_initial: Duration::from_secs(1),
+                reconnect_delay_max: Duration::from_secs(1),
+            }))
+        }
+        MeshtasticConnectionType::Tcp => {
+            let addr_str = addr_override.unwrap_or_else(|| config.addr.to_string());
+            let addr: std::net::SocketAddr = addr_str
+                .parse()
+                .map_err(|e| format!("invalid TCP address '{addr_str}': {e}"))?;
+            eprintln!("Connecting to {addr}…");
+            Ok(stream::MeshtasticClient::connect_tcp(TcpConfig {
+                addr,
+                reconnect_delay_initial: Duration::from_secs(1),
+                reconnect_delay_max: Duration::from_secs(1),
+            }))
+        }
+    }
+}
+
 #[allow(clippy::too_many_arguments)]
 async fn handle_from_radio(
     msg: proto::FromRadio,

--- a/crates/bbs-meshtastic/src/lib.rs
+++ b/crates/bbs-meshtastic/src/lib.rs
@@ -469,7 +469,6 @@ impl Plugin for MeshtasticTransport {
         // periodic timer, so this is the only way to appear promptly.
         let advert_cmd_tx = self.cmd_tx.clone();
         let advert_state = Arc::clone(&self.state);
-        let advert_counter = Arc::clone(&self.packet_counter);
         let advert_long = self.long_name.clone();
         let advert_short = self.short_name.clone();
         let advert_hop = self.hop_limit;
@@ -490,7 +489,8 @@ impl Plugin for MeshtasticTransport {
                             user.id = format_node_id(node);
                             // Flood → multi-hop (configured hop limit); direct → neighbours only.
                             let hop = if flood { advert_hop } else { 0 };
-                            let id = advert_counter.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                            // Varied id so the mesh doesn't dedup the broadcast.
+                            let id = random_packet_id();
                             if advert_cmd_tx
                                 .send(nodeinfo_broadcast(id, user, hop, advert_want_ack))
                                 .await
@@ -943,7 +943,11 @@ async fn event_loop(
                 }
                 match req {
                     MeshtasticAdminRequest::GetLoRaConfig { reply } => {
-                        let rid = packet_counter.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                        // Use a varied packet id, not the sequential counter: the
+                        // device dedups by (from, id) and silently drops admin
+                        // requests whose id it has seen before, so a low/repeating
+                        // id yields no response (the GET then reaps as abandoned).
+                        let rid = random_packet_id();
                         if cmd_tx.send(admin_get_lora_config(my_node_num, rid)).await.is_err() {
                             let _ = reply.send(Err("meshtastic client disconnected".into()));
                         } else {
@@ -973,7 +977,7 @@ async fn event_loop(
                         request_session_key(&cmd_tx, my_node_num, &mut session_requested, &deferred_writes).await;
                     }
                     MeshtasticAdminRequest::GetOwner { reply } => {
-                        let rid = packet_counter.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                        let rid = random_packet_id();
                         if cmd_tx.send(admin_get_owner(my_node_num, rid)).await.is_err() {
                             let _ = reply.send(Err("meshtastic client disconnected".into()));
                         } else {
@@ -986,7 +990,7 @@ async fn event_loop(
                         request_session_key(&cmd_tx, my_node_num, &mut session_requested, &deferred_writes).await;
                     }
                     MeshtasticAdminRequest::GetSecurity { reply } => {
-                        let rid = packet_counter.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                        let rid = random_packet_id();
                         if cmd_tx.send(admin_get_security_config(my_node_num, rid)).await.is_err() {
                             let _ = reply.send(Err("meshtastic client disconnected".into()));
                         } else {

--- a/crates/bbs-meshtastic/src/lib.rs
+++ b/crates/bbs-meshtastic/src/lib.rs
@@ -34,11 +34,11 @@ use crate::{
     command::{format_response, parse_command, render_notification, truncate_utf8},
     proto::{
         admin_get_lora_config, admin_get_owner, admin_get_security_config, admin_get_session_key,
-        admin_message, admin_remove_fixed_position, admin_set_fixed_position,
-        admin_set_lora_config, admin_set_owner, admin_set_time, direct_text_packet, from_radio,
-        mesh_packet, mt_config, node_key, nodeinfo_broadcast, synthetic_pubkey, AdminMessage, Data,
-        LoRaConfig, MeshPacket, MtConfig, NodeInfo, BROADCAST_ADDR, PORT_ADMIN_APP,
-        PORT_NODEINFO_APP, PORT_TEXT_MESSAGE_APP,
+        admin_message, admin_remove_fixed_position, admin_set_device_config,
+        admin_set_fixed_position, admin_set_lora_config, admin_set_owner, admin_set_time,
+        direct_text_packet, from_radio, mesh_packet, mt_config, node_key, synthetic_pubkey,
+        AdminMessage, Data, LoRaConfig, MeshPacket, MtConfig, NodeInfo, BROADCAST_ADDR,
+        PORT_ADMIN_APP, PORT_NODEINFO_APP, PORT_TEXT_MESSAGE_APP,
     },
     session::SessionState,
     stream::{ClientEvent, MeshtasticClient, SerialConfig, TcpConfig},
@@ -463,51 +463,13 @@ impl Plugin for MeshtasticTransport {
             }
         });
 
-        // Self-advert: when the sysop hits "send advert" in the web UI, broadcast
-        // our node info so neighbouring Meshtastic nodes add us to their node
-        // list. The firmware otherwise only announces on boot and on a slow
-        // periodic timer, so this is the only way to appear promptly.
-        let advert_cmd_tx = self.cmd_tx.clone();
-        let advert_state = Arc::clone(&self.state);
-        let advert_long = self.long_name.clone();
-        let advert_short = self.short_name.clone();
-        let advert_hop = self.hop_limit;
-        let advert_want_ack = self.want_ack;
-        let mut advert_send_rx = self.host.advert_bus().subscribe_send();
-        let mut advert_shutdown_rx = self.shutdown_tx.subscribe();
-        tokio::spawn(async move {
-            loop {
-                tokio::select! {
-                    result = advert_send_rx.recv() => match result {
-                        Ok(flood) => {
-                            let node = advert_state.lock().expect("state mutex poisoned").my_node_num;
-                            let Some(node) = node else {
-                                warn!("meshtastic: send-advert requested before node number known");
-                                continue;
-                            };
-                            let mut user = owner_user(advert_long.as_deref(), advert_short.as_deref());
-                            user.id = format_node_id(node);
-                            // Flood → multi-hop (configured hop limit); direct → neighbours only.
-                            let hop = if flood { advert_hop } else { 0 };
-                            // Varied id so the mesh doesn't dedup the broadcast.
-                            let id = random_packet_id();
-                            if advert_cmd_tx
-                                .send(nodeinfo_broadcast(id, user, hop, advert_want_ack))
-                                .await
-                                .is_ok()
-                            {
-                                info!(flood, "meshtastic: broadcast self node info (send advert)");
-                            }
-                        }
-                        Err(tokio::sync::broadcast::error::RecvError::Lagged(n)) => {
-                            warn!("meshtastic: advert-send stream lagged by {n}");
-                        }
-                        Err(tokio::sync::broadcast::error::RecvError::Closed) => break,
-                    },
-                    _ = advert_shutdown_rx.changed() => break,
-                }
-            }
-        });
+        // NB: the meshtastic transport intentionally does NOT subscribe to the
+        // advert-send bus. Meshtastic NodeInfo is only ever *originated* by the
+        // device firmware (on boot, on a periodic timer, on hearing an unknown
+        // node, or when answering a NodeInfo request) — a client-injected
+        // NODEINFO_APP packet is not retransmitted by the firmware, so a manual
+        // "send advert" can't make us appear. Discoverability is handled by
+        // lowering `node_info_broadcast_secs` on connect (see enqueue_auto_apply).
 
         info!("meshtastic transport started");
         Ok(())
@@ -619,6 +581,8 @@ enum DeferredWrite {
         user: proto::User,
         reply: Option<tokio::sync::oneshot::Sender<Result<(), String>>>,
     },
+    /// Write the merged DeviceConfig (e.g. node_info_broadcast_secs). Reboots.
+    Device { device: proto::DeviceConfig },
     /// Sync the device clock to the host's current time. No reply, no reboot.
     Time,
     /// Set a fixed GPS position (decimal degrees). No reply, no reboot.
@@ -685,6 +649,15 @@ async fn flush_deferred_writes(
                 }
                 if ok {
                     info!("meshtastic: applied node owner info to device");
+                }
+            }
+            DeferredWrite::Device { device } => {
+                if cmd_tx
+                    .send(admin_set_device_config(node, rid, device, passkey.to_vec()))
+                    .await
+                    .is_ok()
+                {
+                    info!("meshtastic: applied device config (node_info_broadcast_secs) to device");
                 }
             }
             DeferredWrite::Time => {
@@ -797,7 +770,8 @@ async fn event_loop(
                         let r = match w {
                             DeferredWrite::Lora { reply, .. } => reply,
                             DeferredWrite::Owner { reply, .. } => reply,
-                            DeferredWrite::Time
+                            DeferredWrite::Device { .. }
+                            | DeferredWrite::Time
                             | DeferredWrite::SetFixedPosition { .. }
                             | DeferredWrite::RemoveFixedPosition => None,
                         };
@@ -826,9 +800,14 @@ async fn event_loop(
                             Some(from_radio::PayloadVariant::ConfigCompleteId(_))
                         )
                     {
-                        let (node, device_lora, device_owner) = {
+                        let (node, device_lora, device_owner, device_config) = {
                             let s = state.lock().expect("state poisoned");
-                            (s.my_node_num, s.device_lora.clone(), s.device_owner.clone())
+                            (
+                                s.my_node_num,
+                                s.device_lora.clone(),
+                                s.device_owner.clone(),
+                                s.device_config.clone(),
+                            )
                         };
                         if let Some(node) = node {
                             // Always sync the device clock to system time on connect.
@@ -842,11 +821,13 @@ async fn event_loop(
                                     deferred_writes.push(DeferredWrite::RemoveFixedPosition)
                                 }
                             }
-                            // Push configured radio params + node name (skip-if-unchanged).
+                            // Push configured radio params, node name, and the
+                            // node-info broadcast interval (all skip-if-unchanged).
                             enqueue_auto_apply(
                                 &auto_apply,
                                 device_lora.as_ref(),
                                 device_owner.as_ref(),
+                                device_config.as_ref(),
                                 &mut deferred_writes,
                             );
                             request_session_key(
@@ -857,41 +838,6 @@ async fn event_loop(
                             )
                             .await;
                             auto_applied = true;
-
-                            // Re-announce ourselves shortly after connecting so
-                            // neighbours (and the sysop's companion) re-acquire the
-                            // BBS node after a service restart. The firmware only
-                            // broadcasts NodeInfo on its own boot and a slow periodic
-                            // timer (~3h) — a software restart triggers neither, so
-                            // without this the node looks stale until a manual advert.
-                            // Use the device's real owner (with its public key) when
-                            // captured, else the configured name.
-                            let mut advert_user = device_owner.clone().unwrap_or_else(|| {
-                                owner_user(
-                                    auto_apply.long_name.as_deref(),
-                                    auto_apply.short_name.as_deref(),
-                                )
-                            });
-                            if advert_user.id.is_empty() {
-                                advert_user.id = format_node_id(node);
-                            }
-                            let advert_tx = cmd_tx.clone();
-                            tokio::spawn(async move {
-                                // Let config sync + any deferred writes settle first.
-                                tokio::time::sleep(Duration::from_secs(5)).await;
-                                if advert_tx
-                                    .send(nodeinfo_broadcast(
-                                        random_packet_id(),
-                                        advert_user,
-                                        hop_limit,
-                                        false,
-                                    ))
-                                    .await
-                                    .is_ok()
-                                {
-                                    info!("meshtastic: broadcast self node info on connect");
-                                }
-                            });
                         }
                     }
 
@@ -1056,6 +1002,12 @@ async fn event_loop(
     }
 }
 
+/// Target NodeInfo broadcast interval pushed to the device so it re-announces
+/// itself periodically (firmware minimum is 3600s / 1h — lower values are
+/// clamped by the firmware). This is the only firmware-supported way to keep a
+/// node discoverable; client-injected NodeInfo packets are not retransmitted.
+const NODE_INFO_BROADCAST_SECS: u32 = 3600;
+
 /// Queue the operator's configured radio and node-name settings as deferred
 /// writes, to be sent once a session passkey is obtained. Called once per
 /// connection after config sync completes — this is what makes settings from
@@ -1064,8 +1016,26 @@ fn enqueue_auto_apply(
     cfg: &AutoApplyConfig,
     device_lora: Option<&proto::LoRaConfig>,
     device_owner: Option<&proto::User>,
+    device_config: Option<&proto::DeviceConfig>,
     deferred: &mut Vec<DeferredWrite>,
 ) {
+    // Device config: lower node_info_broadcast_secs so the firmware re-announces
+    // the node hourly. Merge onto the captured DeviceConfig so role and every
+    // other field are preserved; skip the write (and its reboot) when unchanged.
+    if let Some(current) = device_config {
+        if current.node_info_broadcast_secs != NODE_INFO_BROADCAST_SECS {
+            let mut desired = current.clone();
+            desired.node_info_broadcast_secs = NODE_INFO_BROADCAST_SECS;
+            info!(
+                from = current.node_info_broadcast_secs,
+                to = NODE_INFO_BROADCAST_SECS,
+                "meshtastic: queuing device config — node_info_broadcast_secs change"
+            );
+            deferred.push(DeferredWrite::Device { device: desired });
+        } else {
+            info!("meshtastic: node_info_broadcast_secs already matches, skipping (no reboot)");
+        }
+    }
     if let Some(radio) = &cfg.radio {
         // Build the desired config by *overlaying* our settings onto the
         // device's current LoRa config — never from a zeroed default. A bare
@@ -1702,6 +1672,14 @@ async fn handle_from_radio(
                 Some(proto::mt_config::PayloadVariant::Security(sec)) => {
                     debug!("meshtastic: captured device security config from sync");
                     state.lock().expect("state mutex poisoned").device_security = Some(sec);
+                }
+                Some(proto::mt_config::PayloadVariant::Device(dev)) => {
+                    debug!(
+                        node_info_broadcast_secs = dev.node_info_broadcast_secs,
+                        role = dev.role,
+                        "meshtastic: captured device config from sync"
+                    );
+                    state.lock().expect("state mutex poisoned").device_config = Some(dev);
                 }
                 None => {}
             }

--- a/crates/bbs-meshtastic/src/proto.rs
+++ b/crates/bbs-meshtastic/src/proto.rs
@@ -402,16 +402,25 @@ fn admin_packet(to_node: u32, request_id: u32, admin: AdminMessage) -> ToRadio {
                 portnum: PORT_ADMIN_APP,
                 payload: admin.encode_to_vec(),
                 want_response: true,
-                dest: to_node,
-                source: to_node,
-                request_id,
+                // dest/source/request_id/reply_id must be 0 on an outbound
+                // request — they are only populated on *responses*. Setting
+                // source/dest to the node's own number makes the firmware treat
+                // the packet as self-originated and silently ignore it (no admin
+                // response, and SET commands never apply). The response is
+                // correlated via the MeshPacket `id` below, which the device
+                // echoes back in the response's `request_id`.
+                dest: 0,
+                source: 0,
+                request_id: 0,
                 reply_id: 0,
             })),
             id: request_id,
             rx_time: 0,
             rx_snr: 0.0,
             hop_limit: 0,
-            want_ack: false,
+            // Request a delivery ack as well, matching the Meshtastic app's
+            // admin-message behavior.
+            want_ack: true,
             priority: PRIORITY_RELIABLE,
             rx_rssi: 0,
             via_mqtt: false,

--- a/crates/bbs-meshtastic/src/proto.rs
+++ b/crates/bbs-meshtastic/src/proto.rs
@@ -200,6 +200,11 @@ pub struct User {
     /// Short display name shown on OLED/mesh maps. Firmware enforces ≤ 4 chars.
     #[prost(string, tag = "3")]
     pub short_name: String,
+    /// Device role (`Config.DeviceConfig.Role`): 0=CLIENT, 1=CLIENT_MUTE,
+    /// 2=ROUTER, 3=ROUTER_CLIENT, 4=REPEATER, 5=TRACKER, 6=SENSOR, 7=TAK,
+    /// 8=CLIENT_HIDDEN, 9=LOST_AND_FOUND, 10=TAK_TRACKER, 11=ROUTER_LATE.
+    #[prost(int32, tag = "7")]
+    pub role: i32,
     /// Node's Curve25519 public key (32 bytes), broadcast on the mesh for PKC DMs.
     #[prost(bytes = "vec", tag = "8")]
     pub public_key: Vec<u8>,

--- a/crates/bbs-meshtastic/src/proto.rs
+++ b/crates/bbs-meshtastic/src/proto.rs
@@ -174,14 +174,22 @@ pub struct NodeInfo {
     pub last_heard: u32,
 }
 
+/// Meshtastic node owner/user info (`mesh.proto User`).
+///
+/// Used in `NodeInfo` (received during config sync) and in admin owner
+/// get/set operations (`AdminMessage` fields 3/4/32).
 #[derive(Clone, PartialEq, Message)]
 pub struct User {
+    /// Unique node ID string, e.g. `"!aabbccdd"` (hex of the 32-bit node number).
     #[prost(string, tag = "1")]
     pub id: String,
+    /// Full display name (~39 chars max in firmware).
     #[prost(string, tag = "2")]
     pub long_name: String,
+    /// Short display name shown on OLED/mesh maps. Firmware enforces ≤ 4 chars.
     #[prost(string, tag = "3")]
     pub short_name: String,
+    /// Node's Curve25519 public key (32 bytes), broadcast on the mesh for PKC DMs.
     #[prost(bytes = "vec", tag = "8")]
     pub public_key: Vec<u8>,
 }
@@ -271,29 +279,71 @@ pub fn synthetic_pubkey(node_num: u32) -> [u8; 32] {
 }
 
 pub const PORT_ADMIN_APP: i32 = 67;
+/// `config_type` for `GetConfigRequest` — LoRa radio config (`Config.lora`, field 6).
+pub const CONFIG_TYPE_LORA: i32 = 5;
+/// `config_type` for `GetConfigRequest` — Security / PKC config (`Config.security`, field 8).
+pub const CONFIG_TYPE_SECURITY: i32 = 7;
 
+// ── Admin proto types (admin.proto + mesh.proto, subset) ──────────────────────
+// Note: `User` is already defined above (re-used for NodeInfo; same fields).
+
+/// Meshtastic security config (`config.proto Config.SecurityConfig`, subset).
+#[derive(Clone, PartialEq, Message)]
+pub struct SecurityConfig {
+    /// Node's Curve25519 public key — shared with mesh peers.
+    #[prost(bytes = "vec", tag = "1")]
+    pub public_key: Vec<u8>,
+    /// Node's Curve25519 private key (on-device; only visible if serial is enabled).
+    #[prost(bytes = "vec", tag = "2")]
+    pub private_key: Vec<u8>,
+    /// Allow admin commands over the legacy unencrypted admin channel.
+    #[prost(bool, tag = "8")]
+    pub admin_channel_enabled: bool,
+}
+
+/// Meshtastic admin message (`admin.proto AdminMessage`).
+///
+/// Field numbers match the current Meshtastic admin.proto.  The `session_passkey`
+/// (field 101) is a replay-attack guard: the device returns it in every GET
+/// response and the client must echo it back in SET commands within 300 s.
 #[derive(Clone, PartialEq, Message)]
 pub struct AdminMessage {
-    #[prost(oneof = "admin_message::PayloadVariant", tags = "6, 11, 13")]
+    #[prost(oneof = "admin_message::PayloadVariant", tags = "3, 4, 5, 6, 32, 34")]
     pub payload_variant: Option<admin_message::PayloadVariant>,
+    /// Replay-attack guard — echo back in all SET commands.
+    #[prost(bytes = "vec", tag = "101")]
+    pub session_passkey: Vec<u8>,
 }
 
 pub mod admin_message {
     use super::*;
     #[derive(Clone, PartialEq, Oneof)]
     pub enum PayloadVariant {
+        /// Request the node's owner/user info (send `true`).
+        #[prost(bool, tag = "3")]
+        GetOwnerRequest(bool),
+        /// Node's owner/user info (response to `GetOwnerRequest`).
+        #[prost(message, tag = "4")]
+        GetOwnerResponse(super::User),
+        /// Request a config type (`ConfigType` enum: 5 = LoRa, 7 = Security).
+        #[prost(int32, tag = "5")]
+        GetConfigRequest(i32),
+        /// Config payload (response to `GetConfigRequest`).
         #[prost(message, tag = "6")]
         GetConfigResponse(super::MtConfig),
-        #[prost(message, tag = "11")]
+        /// Update the node's owner/user info.
+        #[prost(message, tag = "32")]
+        SetOwner(super::User),
+        /// Update a config section.
+        #[prost(message, tag = "34")]
         SetConfig(super::MtConfig),
-        #[prost(int32, tag = "13")]
-        GetConfigRequest(i32),
     }
 }
 
+/// Subset of Meshtastic `Config` (`config.proto Config`).
 #[derive(Clone, PartialEq, Message)]
 pub struct MtConfig {
-    #[prost(oneof = "mt_config::PayloadVariant", tags = "3")]
+    #[prost(oneof = "mt_config::PayloadVariant", tags = "6, 8")]
     pub payload_variant: Option<mt_config::PayloadVariant>,
 }
 
@@ -301,8 +351,12 @@ pub mod mt_config {
     use super::*;
     #[derive(Clone, PartialEq, Oneof)]
     pub enum PayloadVariant {
-        #[prost(message, tag = "3")]
+        /// `Config.lora` — LoRa radio parameters (field 6 in Config oneof).
+        #[prost(message, tag = "6")]
         Lora(super::LoRaConfig),
+        /// `Config.security` — PKC / key settings (field 8 in Config oneof).
+        #[prost(message, tag = "8")]
+        Security(super::SecurityConfig),
     }
 }
 
@@ -334,16 +388,11 @@ pub struct LoRaConfig {
     pub override_frequency: f32,
 }
 
-/// CONFIG_TYPE_LORA = 5
-pub const CONFIG_TYPE_LORA: i32 = 5;
+// ── Admin packet helpers ──────────────────────────────────────────────────────
 
-pub fn admin_get_lora_config(to_node: u32, request_id: u32) -> ToRadio {
+/// Wrap an encoded `AdminMessage` in a `ToRadio` admin packet.
+fn admin_packet(to_node: u32, request_id: u32, admin: AdminMessage) -> ToRadio {
     use prost::Message as _;
-    let admin = AdminMessage {
-        payload_variant: Some(admin_message::PayloadVariant::GetConfigRequest(
-            CONFIG_TYPE_LORA,
-        )),
-    };
     ToRadio {
         payload_variant: Some(to_radio::PayloadVariant::Packet(MeshPacket {
             from: 0,
@@ -372,39 +421,80 @@ pub fn admin_get_lora_config(to_node: u32, request_id: u32) -> ToRadio {
     }
 }
 
-pub fn admin_set_lora_config(to_node: u32, request_id: u32, config: LoRaConfig) -> ToRadio {
-    use prost::Message as _;
-    let admin = AdminMessage {
-        payload_variant: Some(admin_message::PayloadVariant::SetConfig(MtConfig {
-            payload_variant: Some(mt_config::PayloadVariant::Lora(config)),
-        })),
-    };
-    ToRadio {
-        payload_variant: Some(to_radio::PayloadVariant::Packet(MeshPacket {
-            from: 0,
-            to: to_node,
-            channel: 0,
-            payload_variant: Some(mesh_packet::PayloadVariant::Decoded(Data {
-                portnum: PORT_ADMIN_APP,
-                payload: admin.encode_to_vec(),
-                want_response: true,
-                dest: to_node,
-                source: to_node,
-                request_id,
-                reply_id: 0,
+/// Build a `GetConfigRequest` for the LoRa config.
+pub fn admin_get_lora_config(to_node: u32, request_id: u32) -> ToRadio {
+    admin_packet(
+        to_node,
+        request_id,
+        AdminMessage {
+            payload_variant: Some(admin_message::PayloadVariant::GetConfigRequest(
+                CONFIG_TYPE_LORA,
+            )),
+            session_passkey: Vec::new(),
+        },
+    )
+}
+
+/// Build a `SetConfig` for the LoRa config, echoing back the session passkey.
+pub fn admin_set_lora_config(
+    to_node: u32,
+    request_id: u32,
+    config: LoRaConfig,
+    session_passkey: Vec<u8>,
+) -> ToRadio {
+    admin_packet(
+        to_node,
+        request_id,
+        AdminMessage {
+            payload_variant: Some(admin_message::PayloadVariant::SetConfig(MtConfig {
+                payload_variant: Some(mt_config::PayloadVariant::Lora(config)),
             })),
-            id: request_id,
-            rx_time: 0,
-            rx_snr: 0.0,
-            hop_limit: 0,
-            want_ack: false,
-            priority: PRIORITY_RELIABLE,
-            rx_rssi: 0,
-            via_mqtt: false,
-            hop_start: 0,
-            public_key: Vec::new(),
-        })),
-    }
+            session_passkey,
+        },
+    )
+}
+
+/// Build a `GetOwnerRequest`.
+pub fn admin_get_owner(to_node: u32, request_id: u32) -> ToRadio {
+    admin_packet(
+        to_node,
+        request_id,
+        AdminMessage {
+            payload_variant: Some(admin_message::PayloadVariant::GetOwnerRequest(true)),
+            session_passkey: Vec::new(),
+        },
+    )
+}
+
+/// Build a `SetOwner` command, echoing back the session passkey.
+pub fn admin_set_owner(
+    to_node: u32,
+    request_id: u32,
+    user: User,
+    session_passkey: Vec<u8>,
+) -> ToRadio {
+    admin_packet(
+        to_node,
+        request_id,
+        AdminMessage {
+            payload_variant: Some(admin_message::PayloadVariant::SetOwner(user)),
+            session_passkey,
+        },
+    )
+}
+
+/// Build a `GetConfigRequest` for the Security config.
+pub fn admin_get_security_config(to_node: u32, request_id: u32) -> ToRadio {
+    admin_packet(
+        to_node,
+        request_id,
+        AdminMessage {
+            payload_variant: Some(admin_message::PayloadVariant::GetConfigRequest(
+                CONFIG_TYPE_SECURITY,
+            )),
+            session_passkey: Vec::new(),
+        },
+    )
 }
 
 #[cfg(test)]

--- a/crates/bbs-meshtastic/src/proto.rs
+++ b/crates/bbs-meshtastic/src/proto.rs
@@ -270,6 +270,143 @@ pub fn synthetic_pubkey(node_num: u32) -> [u8; 32] {
     key
 }
 
+pub const PORT_ADMIN_APP: i32 = 67;
+
+#[derive(Clone, PartialEq, Message)]
+pub struct AdminMessage {
+    #[prost(oneof = "admin_message::PayloadVariant", tags = "6, 11, 13")]
+    pub payload_variant: Option<admin_message::PayloadVariant>,
+}
+
+pub mod admin_message {
+    use super::*;
+    #[derive(Clone, PartialEq, Oneof)]
+    pub enum PayloadVariant {
+        #[prost(message, tag = "6")]
+        GetConfigResponse(super::MtConfig),
+        #[prost(message, tag = "11")]
+        SetConfig(super::MtConfig),
+        #[prost(int32, tag = "13")]
+        GetConfigRequest(i32),
+    }
+}
+
+#[derive(Clone, PartialEq, Message)]
+pub struct MtConfig {
+    #[prost(oneof = "mt_config::PayloadVariant", tags = "3")]
+    pub payload_variant: Option<mt_config::PayloadVariant>,
+}
+
+pub mod mt_config {
+    use super::*;
+    #[derive(Clone, PartialEq, Oneof)]
+    pub enum PayloadVariant {
+        #[prost(message, tag = "3")]
+        Lora(super::LoRaConfig),
+    }
+}
+
+#[derive(Clone, PartialEq, Message)]
+pub struct LoRaConfig {
+    #[prost(bool, tag = "1")]
+    pub use_preset: bool,
+    #[prost(int32, tag = "2")]
+    pub modem_preset: i32,
+    #[prost(uint32, tag = "3")]
+    pub bandwidth: u32,
+    #[prost(uint32, tag = "4")]
+    pub spread_factor: u32,
+    #[prost(uint32, tag = "5")]
+    pub coding_rate: u32,
+    #[prost(float, tag = "6")]
+    pub frequency_offset: f32,
+    #[prost(int32, tag = "7")]
+    pub region: i32,
+    #[prost(uint32, tag = "8")]
+    pub hop_limit: u32,
+    #[prost(bool, tag = "9")]
+    pub tx_enabled: bool,
+    #[prost(int32, tag = "10")]
+    pub tx_power: i32,
+    #[prost(uint32, tag = "11")]
+    pub channel_num: u32,
+    #[prost(float, tag = "14")]
+    pub override_frequency: f32,
+}
+
+/// CONFIG_TYPE_LORA = 5
+pub const CONFIG_TYPE_LORA: i32 = 5;
+
+pub fn admin_get_lora_config(to_node: u32, request_id: u32) -> ToRadio {
+    use prost::Message as _;
+    let admin = AdminMessage {
+        payload_variant: Some(admin_message::PayloadVariant::GetConfigRequest(
+            CONFIG_TYPE_LORA,
+        )),
+    };
+    ToRadio {
+        payload_variant: Some(to_radio::PayloadVariant::Packet(MeshPacket {
+            from: 0,
+            to: to_node,
+            channel: 0,
+            payload_variant: Some(mesh_packet::PayloadVariant::Decoded(Data {
+                portnum: PORT_ADMIN_APP,
+                payload: admin.encode_to_vec(),
+                want_response: true,
+                dest: to_node,
+                source: to_node,
+                request_id,
+                reply_id: 0,
+            })),
+            id: request_id,
+            rx_time: 0,
+            rx_snr: 0.0,
+            hop_limit: 0,
+            want_ack: false,
+            priority: PRIORITY_RELIABLE,
+            rx_rssi: 0,
+            via_mqtt: false,
+            hop_start: 0,
+            public_key: Vec::new(),
+        })),
+    }
+}
+
+pub fn admin_set_lora_config(to_node: u32, request_id: u32, config: LoRaConfig) -> ToRadio {
+    use prost::Message as _;
+    let admin = AdminMessage {
+        payload_variant: Some(admin_message::PayloadVariant::SetConfig(MtConfig {
+            payload_variant: Some(mt_config::PayloadVariant::Lora(config)),
+        })),
+    };
+    ToRadio {
+        payload_variant: Some(to_radio::PayloadVariant::Packet(MeshPacket {
+            from: 0,
+            to: to_node,
+            channel: 0,
+            payload_variant: Some(mesh_packet::PayloadVariant::Decoded(Data {
+                portnum: PORT_ADMIN_APP,
+                payload: admin.encode_to_vec(),
+                want_response: true,
+                dest: to_node,
+                source: to_node,
+                request_id,
+                reply_id: 0,
+            })),
+            id: request_id,
+            rx_time: 0,
+            rx_snr: 0.0,
+            hop_limit: 0,
+            want_ack: false,
+            priority: PRIORITY_RELIABLE,
+            rx_rssi: 0,
+            via_mqtt: false,
+            hop_start: 0,
+            public_key: Vec::new(),
+        })),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/bbs-meshtastic/src/proto.rs
+++ b/crates/bbs-meshtastic/src/proto.rs
@@ -90,6 +90,12 @@ pub struct MeshPacket {
     pub hop_start: u32,
     #[prost(bytes = "vec", tag = "16")]
     pub public_key: Vec<u8>,
+    /// Marks the packet as using public-key cryptography. The Meshtastic app
+    /// sets this on admin messages to the local node; firmware with PKC enabled
+    /// and the legacy admin channel disabled requires it, otherwise the admin
+    /// request is silently dropped.
+    #[prost(bool, tag = "17")]
+    pub pki_encrypted: bool,
 }
 
 pub mod mesh_packet {
@@ -261,6 +267,7 @@ pub fn direct_text_packet(
             via_mqtt: false,
             hop_start: 0,
             public_key: Vec::new(),
+            pki_encrypted: false,
         })),
     }
 }
@@ -278,11 +285,19 @@ pub fn synthetic_pubkey(node_num: u32) -> [u8; 32] {
     key
 }
 
-pub const PORT_ADMIN_APP: i32 = 67;
+/// Meshtastic `PortNum::ADMIN_APP`. This is **6**, not 67 — 67 is
+/// `TELEMETRY_APP`. Sending admin messages on 67 makes the device's telemetry
+/// module consume them and the admin module never processes them.
+pub const PORT_ADMIN_APP: i32 = 6;
 /// `config_type` for `GetConfigRequest` — LoRa radio config (`Config.lora`, field 6).
 pub const CONFIG_TYPE_LORA: i32 = 5;
 /// `config_type` for `GetConfigRequest` — Security / PKC config (`Config.security`, field 8).
 pub const CONFIG_TYPE_SECURITY: i32 = 7;
+/// `config_type` for `GetConfigRequest` — session key. Requesting this opens the
+/// admin session for the connection; current Meshtastic firmware silently drops
+/// admin *writes* that aren't preceded by it. The Meshtastic app sends this
+/// before every admin set.
+pub const CONFIG_TYPE_SESSIONKEY: i32 = 8;
 
 // ── Admin proto types (admin.proto + mesh.proto, subset) ──────────────────────
 // Note: `User` is already defined above (re-used for NodeInfo; same fields).
@@ -417,15 +432,18 @@ fn admin_packet(to_node: u32, request_id: u32, admin: AdminMessage) -> ToRadio {
             id: request_id,
             rx_time: 0,
             rx_snr: 0.0,
-            hop_limit: 0,
-            // Request a delivery ack as well, matching the Meshtastic app's
-            // admin-message behavior.
+            hop_limit: 3,
             want_ack: true,
             priority: PRIORITY_RELIABLE,
             rx_rssi: 0,
             via_mqtt: false,
             hop_start: 0,
             public_key: Vec::new(),
+            // Plaintext local-serial admin. Must be false: with it set, the
+            // firmware tries to PKI-decrypt our plaintext payload into garbage
+            // ("Can't decode protobuf"). The local trusted path (from==0) needs
+            // no encryption.
+            pki_encrypted: false,
         })),
     }
 }
@@ -500,6 +518,22 @@ pub fn admin_get_security_config(to_node: u32, request_id: u32) -> ToRadio {
         AdminMessage {
             payload_variant: Some(admin_message::PayloadVariant::GetConfigRequest(
                 CONFIG_TYPE_SECURITY,
+            )),
+            session_passkey: Vec::new(),
+        },
+    )
+}
+
+/// Build a session-key `GetConfigRequest`. Send this immediately before an
+/// admin write to open the admin session — firmware drops writes that aren't
+/// preceded by it.
+pub fn admin_get_session_key(to_node: u32, request_id: u32) -> ToRadio {
+    admin_packet(
+        to_node,
+        request_id,
+        AdminMessage {
+            payload_variant: Some(admin_message::PayloadVariant::GetConfigRequest(
+                CONFIG_TYPE_SESSIONKEY,
             )),
             session_passkey: Vec::new(),
         },

--- a/crates/bbs-meshtastic/src/proto.rs
+++ b/crates/bbs-meshtastic/src/proto.rs
@@ -365,6 +365,10 @@ pub mod admin_message {
         /// Set the node's clock (Unix seconds). Does not reboot the device.
         #[prost(uint32, tag = "43")]
         SetTimeOnly(u32),
+        /// Reboot the node in N seconds (or <0 to cancel). On boot the firmware
+        /// broadcasts its NodeInfo, which is how neighbours (re)discover it.
+        #[prost(int32, tag = "97")]
+        RebootSeconds(i32),
         /// Update the node's owner/user info.
         #[prost(message, tag = "32")]
         SetOwner(super::User),
@@ -650,6 +654,20 @@ pub fn admin_remove_fixed_position(
         request_id,
         AdminMessage {
             payload_variant: Some(admin_message::PayloadVariant::RemoveFixedPosition(true)),
+            session_passkey,
+        },
+    )
+}
+
+/// Build a `RebootSeconds` admin command (reboot the node after `secs`),
+/// echoing back the session passkey. On reboot the firmware re-broadcasts its
+/// NodeInfo, which is how neighbours re-acquire the node.
+pub fn admin_reboot(to_node: u32, request_id: u32, secs: i32, session_passkey: Vec<u8>) -> ToRadio {
+    admin_packet(
+        to_node,
+        request_id,
+        AdminMessage {
+            payload_variant: Some(admin_message::PayloadVariant::RebootSeconds(secs)),
             session_passkey,
         },
     )

--- a/crates/bbs-meshtastic/src/proto.rs
+++ b/crates/bbs-meshtastic/src/proto.rs
@@ -38,7 +38,7 @@ pub mod to_radio {
 pub struct FromRadio {
     #[prost(uint32, tag = "1")]
     pub id: u32,
-    #[prost(oneof = "from_radio::PayloadVariant", tags = "2, 3, 4, 7, 8")]
+    #[prost(oneof = "from_radio::PayloadVariant", tags = "2, 3, 4, 5, 7, 8")]
     pub payload_variant: Option<from_radio::PayloadVariant>,
 }
 
@@ -53,6 +53,11 @@ pub mod from_radio {
         MyInfo(super::MyNodeInfo),
         #[prost(message, tag = "4")]
         NodeInfo(super::NodeInfo),
+        /// `Config` section streamed during the initial `want_config` sync
+        /// (e.g. the current LoRa config). Lets us read the device's live
+        /// settings without an explicit admin GET.
+        #[prost(message, tag = "5")]
+        Config(super::MtConfig),
         #[prost(uint32, tag = "7")]
         ConfigCompleteId(u32),
         #[prost(bool, tag = "8")]

--- a/crates/bbs-meshtastic/src/proto.rs
+++ b/crates/bbs-meshtastic/src/proto.rs
@@ -277,6 +277,48 @@ pub fn direct_text_packet(
     }
 }
 
+/// Broadcast our own node info (owner `User`) to the whole mesh.
+///
+/// This is the Meshtastic equivalent of MeshCore's self-advert: it makes the
+/// radio transmit a `NODEINFO_APP` packet so other nodes add us to their node
+/// list. The firmware otherwise only broadcasts node info on boot and on a slow
+/// periodic timer (~3 h by default), so without this a freshly-configured BBS
+/// node can take hours to appear on neighbouring devices.
+///
+/// `from` is left 0 (local origin); the firmware stamps it with our node
+/// number before transmit. `want_response` is false — this is an announcement,
+/// not a request for replies.
+pub fn nodeinfo_broadcast(packet_id: u32, user: User, hop_limit: u32, want_ack: bool) -> ToRadio {
+    use prost::Message as _;
+    ToRadio {
+        payload_variant: Some(to_radio::PayloadVariant::Packet(MeshPacket {
+            from: 0,
+            to: BROADCAST_ADDR,
+            channel: 0,
+            payload_variant: Some(mesh_packet::PayloadVariant::Decoded(Data {
+                portnum: PORT_NODEINFO_APP,
+                payload: user.encode_to_vec(),
+                want_response: false,
+                dest: 0,
+                source: 0,
+                request_id: 0,
+                reply_id: 0,
+            })),
+            id: packet_id,
+            rx_time: 0,
+            rx_snr: 0.0,
+            hop_limit,
+            want_ack,
+            priority: PRIORITY_RELIABLE,
+            rx_rssi: 0,
+            via_mqtt: false,
+            hop_start: 0,
+            public_key: Vec::new(),
+            pki_encrypted: false,
+        })),
+    }
+}
+
 pub fn node_key(node_num: u32) -> [u8; 6] {
     let n = node_num.to_be_bytes();
     [b'M', b'T', n[0], n[1], n[2], n[3]]

--- a/crates/bbs-meshtastic/src/proto.rs
+++ b/crates/bbs-meshtastic/src/proto.rs
@@ -282,48 +282,6 @@ pub fn direct_text_packet(
     }
 }
 
-/// Broadcast our own node info (owner `User`) to the whole mesh.
-///
-/// This is the Meshtastic equivalent of MeshCore's self-advert: it makes the
-/// radio transmit a `NODEINFO_APP` packet so other nodes add us to their node
-/// list. The firmware otherwise only broadcasts node info on boot and on a slow
-/// periodic timer (~3 h by default), so without this a freshly-configured BBS
-/// node can take hours to appear on neighbouring devices.
-///
-/// `from` is left 0 (local origin); the firmware stamps it with our node
-/// number before transmit. `want_response` is false — this is an announcement,
-/// not a request for replies.
-pub fn nodeinfo_broadcast(packet_id: u32, user: User, hop_limit: u32, want_ack: bool) -> ToRadio {
-    use prost::Message as _;
-    ToRadio {
-        payload_variant: Some(to_radio::PayloadVariant::Packet(MeshPacket {
-            from: 0,
-            to: BROADCAST_ADDR,
-            channel: 0,
-            payload_variant: Some(mesh_packet::PayloadVariant::Decoded(Data {
-                portnum: PORT_NODEINFO_APP,
-                payload: user.encode_to_vec(),
-                want_response: false,
-                dest: 0,
-                source: 0,
-                request_id: 0,
-                reply_id: 0,
-            })),
-            id: packet_id,
-            rx_time: 0,
-            rx_snr: 0.0,
-            hop_limit,
-            want_ack,
-            priority: PRIORITY_RELIABLE,
-            rx_rssi: 0,
-            via_mqtt: false,
-            hop_start: 0,
-            public_key: Vec::new(),
-            pki_encrypted: false,
-        })),
-    }
-}
-
 pub fn node_key(node_num: u32) -> [u8; 6] {
     let n = node_num.to_be_bytes();
     [b'M', b'T', n[0], n[1], n[2], n[3]]
@@ -419,7 +377,7 @@ pub mod admin_message {
 /// Subset of Meshtastic `Config` (`config.proto Config`).
 #[derive(Clone, PartialEq, Message)]
 pub struct MtConfig {
-    #[prost(oneof = "mt_config::PayloadVariant", tags = "6, 8")]
+    #[prost(oneof = "mt_config::PayloadVariant", tags = "1, 6, 8")]
     pub payload_variant: Option<mt_config::PayloadVariant>,
 }
 
@@ -427,6 +385,9 @@ pub mod mt_config {
     use super::*;
     #[derive(Clone, PartialEq, Oneof)]
     pub enum PayloadVariant {
+        /// `Config.device` — device role / node-info broadcast interval, etc.
+        #[prost(message, tag = "1")]
+        Device(super::DeviceConfig),
         /// `Config.lora` — LoRa radio parameters (field 6 in Config oneof).
         #[prost(message, tag = "6")]
         Lora(super::LoRaConfig),
@@ -434,6 +395,45 @@ pub mod mt_config {
         #[prost(message, tag = "8")]
         Security(super::SecurityConfig),
     }
+}
+
+/// Meshtastic `Config.DeviceConfig` (subset — all current fields, so a
+/// read-modify-write round-trip preserves everything we don't touch).
+///
+/// Field numbers verified against meshtastic/protobufs config.proto.
+#[derive(Clone, PartialEq, Message)]
+pub struct DeviceConfig {
+    /// Device role (`Config.DeviceConfig.Role`). MUST be preserved on a merge —
+    /// clobbering it (e.g. ROUTER→CLIENT) would break the node's mesh behavior.
+    #[prost(int32, tag = "1")]
+    pub role: i32,
+    /// Deprecated `serial_enabled`; preserved on round-trip.
+    #[prost(bool, tag = "2")]
+    pub serial_enabled: bool,
+    #[prost(uint32, tag = "4")]
+    pub button_gpio: u32,
+    #[prost(uint32, tag = "5")]
+    pub buzzer_gpio: u32,
+    /// Rebroadcast mode (`RebroadcastMode` enum).
+    #[prost(int32, tag = "6")]
+    pub rebroadcast_mode: i32,
+    /// Seconds between NodeInfo broadcasts (firmware minimum 3600).
+    #[prost(uint32, tag = "7")]
+    pub node_info_broadcast_secs: u32,
+    #[prost(bool, tag = "8")]
+    pub double_tap_as_button_press: bool,
+    /// Deprecated `is_managed`; preserved on round-trip.
+    #[prost(bool, tag = "9")]
+    pub is_managed: bool,
+    #[prost(bool, tag = "10")]
+    pub disable_triple_click: bool,
+    #[prost(string, tag = "11")]
+    pub tzdef: String,
+    #[prost(bool, tag = "12")]
+    pub led_heartbeat_disabled: bool,
+    /// Buzzer mode (`BuzzerMode` enum).
+    #[prost(int32, tag = "13")]
+    pub buzzer_mode: i32,
 }
 
 #[derive(Clone, PartialEq, Message)]
@@ -542,6 +542,25 @@ pub fn admin_set_lora_config(
         AdminMessage {
             payload_variant: Some(admin_message::PayloadVariant::SetConfig(MtConfig {
                 payload_variant: Some(mt_config::PayloadVariant::Lora(config)),
+            })),
+            session_passkey,
+        },
+    )
+}
+
+/// Build a `SetConfig` for the Device config, echoing back the session passkey.
+pub fn admin_set_device_config(
+    to_node: u32,
+    request_id: u32,
+    config: DeviceConfig,
+    session_passkey: Vec<u8>,
+) -> ToRadio {
+    admin_packet(
+        to_node,
+        request_id,
+        AdminMessage {
+            payload_variant: Some(admin_message::PayloadVariant::SetConfig(MtConfig {
+                payload_variant: Some(mt_config::PayloadVariant::Device(config)),
             })),
             session_passkey,
         },

--- a/crates/bbs-meshtastic/src/proto.rs
+++ b/crates/bbs-meshtastic/src/proto.rs
@@ -393,6 +393,15 @@ pub mod admin_message {
         /// Config payload (response to `GetConfigRequest`).
         #[prost(message, tag = "6")]
         GetConfigResponse(super::MtConfig),
+        /// Set a fixed GPS position on the node (enables fixed-position mode).
+        #[prost(message, tag = "41")]
+        SetFixedPosition(super::Position),
+        /// Clear any fixed position and disable fixed-position mode.
+        #[prost(bool, tag = "42")]
+        RemoveFixedPosition(bool),
+        /// Set the node's clock (Unix seconds). Does not reboot the device.
+        #[prost(uint32, tag = "43")]
+        SetTimeOnly(u32),
         /// Update the node's owner/user info.
         #[prost(message, tag = "32")]
         SetOwner(super::User),
@@ -446,8 +455,14 @@ pub struct LoRaConfig {
     pub tx_power: i32,
     #[prost(uint32, tag = "11")]
     pub channel_num: u32,
+    /// SX126x RX boosted gain — improves receive sensitivity on SX126x radios.
+    #[prost(bool, tag = "13")]
+    pub sx126x_rx_boosted_gain: bool,
     #[prost(float, tag = "14")]
     pub override_frequency: f32,
+    /// Ignore packets that arrived over MQTT.
+    #[prost(bool, tag = "104")]
+    pub ignore_mqtt: bool,
 }
 
 // ── Admin packet helpers ──────────────────────────────────────────────────────
@@ -552,6 +567,65 @@ pub fn admin_set_owner(
         request_id,
         AdminMessage {
             payload_variant: Some(admin_message::PayloadVariant::SetOwner(user)),
+            session_passkey,
+        },
+    )
+}
+
+/// Build a `SetTimeOnly` command to sync the device clock, echoing the passkey.
+pub fn admin_set_time(
+    to_node: u32,
+    request_id: u32,
+    unix_secs: u32,
+    session_passkey: Vec<u8>,
+) -> ToRadio {
+    admin_packet(
+        to_node,
+        request_id,
+        AdminMessage {
+            payload_variant: Some(admin_message::PayloadVariant::SetTimeOnly(unix_secs)),
+            session_passkey,
+        },
+    )
+}
+
+/// Build a `SetFixedPosition` command from decimal-degree coordinates.
+///
+/// Meshtastic stores latitude/longitude as integers in units of 1e-7 degrees.
+pub fn admin_set_fixed_position(
+    to_node: u32,
+    request_id: u32,
+    lat_deg: f64,
+    lon_deg: f64,
+    session_passkey: Vec<u8>,
+) -> ToRadio {
+    let position = Position {
+        latitude_i: Some((lat_deg * 1e7) as i32),
+        longitude_i: Some((lon_deg * 1e7) as i32),
+        altitude: 0,
+        time: 0,
+    };
+    admin_packet(
+        to_node,
+        request_id,
+        AdminMessage {
+            payload_variant: Some(admin_message::PayloadVariant::SetFixedPosition(position)),
+            session_passkey,
+        },
+    )
+}
+
+/// Build a `RemoveFixedPosition` command (clears fixed position).
+pub fn admin_remove_fixed_position(
+    to_node: u32,
+    request_id: u32,
+    session_passkey: Vec<u8>,
+) -> ToRadio {
+    admin_packet(
+        to_node,
+        request_id,
+        AdminMessage {
+            payload_variant: Some(admin_message::PayloadVariant::RemoveFixedPosition(true)),
             session_passkey,
         },
     )

--- a/crates/bbs-meshtastic/src/session.rs
+++ b/crates/bbs-meshtastic/src/session.rs
@@ -21,6 +21,11 @@ pub struct SessionEntry {
 #[derive(Debug, Default)]
 pub struct SessionState {
     pub my_node_num: Option<u32>,
+    /// The device's current LoRa config, captured from the `want_config` sync
+    /// stream. Used to skip redundant LoRa writes on connect — writing LoRa
+    /// config (even unchanged) reboots the radio, so we only write when the
+    /// desired region/preset actually differs from what the device reports.
+    pub device_lora: Option<crate::proto::LoRaConfig>,
     pub by_node: HashMap<u32, SessionEntry>,
     pub by_session: HashMap<SessionId, u32>,
 }

--- a/crates/bbs-meshtastic/src/session.rs
+++ b/crates/bbs-meshtastic/src/session.rs
@@ -36,6 +36,10 @@ pub struct SessionState {
     /// The device's current security/PKC config, captured during sync. Lets the
     /// web serve the public key + admin-channel state without a live admin GET.
     pub device_security: Option<crate::proto::SecurityConfig>,
+    /// The device's current DeviceConfig, captured during sync. Used to merge
+    /// `node_info_broadcast_secs` (and skip-if-unchanged) without clobbering
+    /// role/other device fields.
+    pub device_config: Option<crate::proto::DeviceConfig>,
     pub by_node: HashMap<u32, SessionEntry>,
     pub by_session: HashMap<SessionId, u32>,
 }

--- a/crates/bbs-meshtastic/src/session.rs
+++ b/crates/bbs-meshtastic/src/session.rs
@@ -26,12 +26,16 @@ pub struct SessionState {
     /// config (even unchanged) reboots the radio, so we only write when the
     /// desired region/preset actually differs from what the device reports.
     pub device_lora: Option<crate::proto::LoRaConfig>,
-    /// The device's current owner `(long_name, short_name)`, captured from the
-    /// local node's NodeInfo during sync. Writing the owner (`SetOwner`) also
-    /// reboots the radio on current firmware, so we skip the write when the
-    /// configured name already matches — keeping the radio online so its own
-    /// periodic NodeInfo broadcasts (how neighbours discover us) keep firing.
-    pub device_owner: Option<(String, String)>,
+    /// The device's current owner `User` (id, long/short name, public key),
+    /// captured from the local node's NodeInfo during sync. Writing the owner
+    /// (`SetOwner`) also reboots the radio on current firmware, so we skip the
+    /// write when the configured name already matches — keeping the radio online
+    /// so its own periodic NodeInfo broadcasts (how neighbours discover us) keep
+    /// firing. Also serves the web "device snapshot" without a live admin round-trip.
+    pub device_owner: Option<crate::proto::User>,
+    /// The device's current security/PKC config, captured during sync. Lets the
+    /// web serve the public key + admin-channel state without a live admin GET.
+    pub device_security: Option<crate::proto::SecurityConfig>,
     pub by_node: HashMap<u32, SessionEntry>,
     pub by_session: HashMap<SessionId, u32>,
 }

--- a/crates/bbs-meshtastic/src/session.rs
+++ b/crates/bbs-meshtastic/src/session.rs
@@ -26,6 +26,12 @@ pub struct SessionState {
     /// config (even unchanged) reboots the radio, so we only write when the
     /// desired region/preset actually differs from what the device reports.
     pub device_lora: Option<crate::proto::LoRaConfig>,
+    /// The device's current owner `(long_name, short_name)`, captured from the
+    /// local node's NodeInfo during sync. Writing the owner (`SetOwner`) also
+    /// reboots the radio on current firmware, so we skip the write when the
+    /// configured name already matches — keeping the radio online so its own
+    /// periodic NodeInfo broadcasts (how neighbours discover us) keep firing.
+    pub device_owner: Option<(String, String)>,
     pub by_node: HashMap<u32, SessionEntry>,
     pub by_session: HashMap<SessionId, u32>,
 }

--- a/crates/bbs-meshtastic/src/stream.rs
+++ b/crates/bbs-meshtastic/src/stream.rs
@@ -249,6 +249,7 @@ fn describe_from_radio(frame: &FromRadio) -> String {
     match &frame.payload_variant {
         Some(P::MyInfo(i)) => format!("MyInfo(node=0x{:08x})", i.my_node_num),
         Some(P::NodeInfo(_)) => "NodeInfo".to_owned(),
+        Some(P::Config(_)) => "Config".to_owned(),
         Some(P::ConfigCompleteId(id)) => format!("ConfigCompleteId({id})"),
         Some(P::Rebooted(_)) => "Rebooted".to_owned(),
         Some(P::Packet(p)) => match &p.payload_variant {

--- a/crates/bbs-meshtastic/src/stream.rs
+++ b/crates/bbs-meshtastic/src/stream.rs
@@ -187,7 +187,7 @@ where
         tokio::select! {
             frame = read_from_radio(reader) => match frame {
                 Ok(frame) => {
-                    debug!("meshtastic: rx FromRadio");
+                    debug!(frame = %describe_from_radio(&frame), "meshtastic: rx FromRadio");
                     if event_tx.send(ClientEvent::FromRadio(frame)).await.is_err() {
                         return SessionOutcome::Shutdown;
                     }
@@ -237,6 +237,34 @@ async fn write_to_radio<W: AsyncWrite + Unpin>(writer: &mut W, msg: &ToRadio) ->
         ));
     }
     writer.write_all(&wire).await
+}
+
+/// One-line human description of a `FromRadio` frame for debug logging.
+///
+/// For packets it includes the portnum and request_id/reply_id so that admin
+/// responses (portnum 67) and their correlation IDs are visible in the log —
+/// essential for diagnosing whether the device answers admin GET requests.
+fn describe_from_radio(frame: &FromRadio) -> String {
+    use crate::proto::{from_radio::PayloadVariant as P, mesh_packet::PayloadVariant as MP};
+    match &frame.payload_variant {
+        Some(P::MyInfo(i)) => format!("MyInfo(node=0x{:08x})", i.my_node_num),
+        Some(P::NodeInfo(_)) => "NodeInfo".to_owned(),
+        Some(P::ConfigCompleteId(id)) => format!("ConfigCompleteId({id})"),
+        Some(P::Rebooted(_)) => "Rebooted".to_owned(),
+        Some(P::Packet(p)) => match &p.payload_variant {
+            Some(MP::Decoded(d)) => format!(
+                "Packet(port={}, from=0x{:08x}, req_id={}, reply_id={}, {}B)",
+                d.portnum,
+                p.from,
+                d.request_id,
+                d.reply_id,
+                d.payload.len()
+            ),
+            Some(MP::Encrypted(_)) => "Packet(encrypted)".to_owned(),
+            None => "Packet(empty)".to_owned(),
+        },
+        None => "<empty>".to_owned(),
+    }
 }
 
 pub async fn read_from_radio<R: AsyncRead + Unpin>(reader: &mut R) -> io::Result<FromRadio> {

--- a/crates/bbs-plugin-api/src/admin.rs
+++ b/crates/bbs-plugin-api/src/admin.rs
@@ -254,6 +254,33 @@ pub struct MeshtasticLoRaConfig {
     pub override_frequency: f32,
 }
 
+/// Meshtastic node owner / identity info.
+///
+/// Returned by [`crate::host::Host::admin_get_meshtastic_owner`].
+/// The public key is hex-encoded (64 lower-case hex chars for 32 bytes).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MeshtasticOwnerInfo {
+    /// Unique node ID string, e.g. `"!aabbccdd"`.
+    pub id: String,
+    /// Full display name.
+    pub long_name: String,
+    /// Short display name (≤ 4 chars on hardware).
+    pub short_name: String,
+    /// Curve25519 public key, hex-encoded (64 chars = 32 bytes).
+    pub public_key_hex: String,
+}
+
+/// Meshtastic security / PKC configuration.
+///
+/// Returned by [`crate::host::Host::admin_get_meshtastic_security`].
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MeshtasticSecurityInfo {
+    /// Node's Curve25519 public key, hex-encoded (64 chars).
+    pub public_key_hex: String,
+    /// Whether the legacy insecure admin channel is enabled.
+    pub admin_channel_enabled: bool,
+}
+
 /// One entry in the durable audit log.
 ///
 /// Written whenever a privileged action is performed: ban, unban, validate,

--- a/crates/bbs-plugin-api/src/admin.rs
+++ b/crates/bbs-plugin-api/src/admin.rs
@@ -287,6 +287,19 @@ pub struct MeshtasticSecurityInfo {
     pub admin_channel_enabled: bool,
 }
 
+/// A combined snapshot of the connected Meshtastic device's settings, served
+/// from the config captured during the last connect-time sync (no live admin
+/// round-trip). Any field is `None` if the device hasn't reported it yet.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct MeshtasticDeviceSnapshot {
+    /// LoRa radio configuration.
+    pub lora: Option<MeshtasticLoRaConfig>,
+    /// Node owner / identity info.
+    pub owner: Option<MeshtasticOwnerInfo>,
+    /// Security / PKC configuration.
+    pub security: Option<MeshtasticSecurityInfo>,
+}
+
 /// One entry in the durable audit log.
 ///
 /// Written whenever a privileged action is performed: ban, unban, validate,

--- a/crates/bbs-plugin-api/src/admin.rs
+++ b/crates/bbs-plugin-api/src/admin.rs
@@ -252,6 +252,12 @@ pub struct MeshtasticLoRaConfig {
     pub channel_num: u32,
     /// Override frequency in MHz (0 = use region default).
     pub override_frequency: f32,
+    /// SX126x RX boosted gain — improves receive sensitivity.
+    #[serde(default)]
+    pub sx126x_rx_boosted_gain: bool,
+    /// Ignore packets that arrived over MQTT.
+    #[serde(default)]
+    pub ignore_mqtt: bool,
 }
 
 /// Meshtastic node owner / identity info.

--- a/crates/bbs-plugin-api/src/admin.rs
+++ b/crates/bbs-plugin-api/src/admin.rs
@@ -210,6 +210,50 @@ pub struct AdminAccessPolicy {
     pub guest_room_id: Option<i64>,
 }
 
+/// Radio parameters applied to a MeshCore companion device.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MeshRadioParams {
+    /// Centre frequency in Hz (e.g. 910_525_000 for 910.525 MHz).
+    pub frequency_hz: u32,
+    /// Channel bandwidth in Hz (e.g. 62_500 for 62.5 kHz).
+    pub bandwidth_hz: u32,
+    /// LoRa spreading factor (7–12).
+    pub spreading_factor: u8,
+    /// Coding rate denominator (5–8, meaning 4/5 through 4/8).
+    pub coding_rate: u8,
+    /// Transmit power in dBm.
+    pub tx_power_dbm: i8,
+}
+
+/// Meshtastic LoRa radio configuration.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MeshtasticLoRaConfig {
+    /// Whether to use a built-in modem preset instead of custom parameters.
+    pub use_preset: bool,
+    /// Meshtastic modem preset enum value (used when `use_preset` is true).
+    pub modem_preset: i32,
+    /// Channel bandwidth (device-specific units).
+    pub bandwidth: u32,
+    /// LoRa spreading factor (7–12).
+    pub spread_factor: u32,
+    /// Coding rate denominator (5–8).
+    pub coding_rate: u32,
+    /// Frequency offset in MHz.
+    pub frequency_offset: f32,
+    /// Meshtastic region enum value.
+    pub region: i32,
+    /// Maximum number of hops for mesh routing.
+    pub hop_limit: u32,
+    /// Whether the transmitter is enabled.
+    pub tx_enabled: bool,
+    /// Transmit power in dBm.
+    pub tx_power: i32,
+    /// LoRa channel number (0 = use frequency directly).
+    pub channel_num: u32,
+    /// Override frequency in MHz (0 = use region default).
+    pub override_frequency: f32,
+}
+
 /// One entry in the durable audit log.
 ///
 /// Written whenever a privileged action is performed: ban, unban, validate,

--- a/crates/bbs-plugin-api/src/advert.rs
+++ b/crates/bbs-plugin-api/src/advert.rs
@@ -40,6 +40,9 @@ pub struct AdvertRecord {
     pub first_seen_secs: i64,
     /// Unix timestamp (seconds) when this node was most recently observed.
     pub last_seen_secs: i64,
+    /// Name of the transport this advert was heard on (e.g. `"meshcore"`,
+    /// `"meshtastic"`). Identifies which radio network the node belongs to.
+    pub transport: String,
 }
 
 // ── AdvertBus ─────────────────────────────────────────────────────────────────
@@ -87,7 +90,15 @@ impl AdvertBus {
     /// Insert or update a full advertisement from a named contact.
     ///
     /// Updates all fields for an existing record; preserves `first_seen_secs`.
-    pub fn upsert(&self, pubkey: [u8; 32], name: String, adv_type: u8, gps_lat: i32, gps_lon: i32) {
+    pub fn upsert(
+        &self,
+        pubkey: [u8; 32],
+        name: String,
+        adv_type: u8,
+        gps_lat: i32,
+        gps_lon: i32,
+        transport: &str,
+    ) {
         let now = unix_now();
         let lat = gps_lat as f64 / 1_000_000.0;
         let lon = gps_lon as f64 / 1_000_000.0;
@@ -100,12 +111,14 @@ impl AdvertBus {
             lon: 0.0,
             first_seen_secs: now,
             last_seen_secs: now,
+            transport: transport.to_owned(),
         });
         entry.name = name;
         entry.adv_type = adv_type;
         entry.lat = lat;
         entry.lon = lon;
         entry.last_seen_secs = now;
+        entry.transport = transport.to_owned();
     }
 
     /// Insert or update a full advertisement with an explicit `last_seen` timestamp.
@@ -121,6 +134,7 @@ impl AdvertBus {
     /// as unreliable and falls back to the current wall-clock time.
     ///
     /// Updates all fields for an existing record; preserves `first_seen_secs`.
+    #[allow(clippy::too_many_arguments)]
     pub fn upsert_with_timestamp(
         &self,
         pubkey: [u8; 32],
@@ -129,6 +143,7 @@ impl AdvertBus {
         gps_lat: i32,
         gps_lon: i32,
         device_last_seen: i64,
+        transport: &str,
     ) {
         let now = unix_now();
         // Accept only plausible Unix timestamps. Devices without a synced RTC
@@ -155,11 +170,13 @@ impl AdvertBus {
             lon: 0.0,
             first_seen_secs: now,
             last_seen_secs: last_seen,
+            transport: transport.to_owned(),
         });
         entry.name = name;
         entry.adv_type = adv_type;
         entry.lat = lat;
         entry.lon = lon;
+        entry.transport = transport.to_owned();
         // Only advance last_seen — never move it backwards. A live advert
         // arriving later will always have a wall-clock time ≥ the stored value.
         if last_seen > entry.last_seen_secs {
@@ -171,12 +188,15 @@ impl AdvertBus {
     ///
     /// Updates `last_seen_secs` on an existing record without overwriting
     /// name, type, or location. Creates a minimal stub if unseen.
-    pub fn upsert_short(&self, pubkey: [u8; 32]) {
+    pub fn upsert_short(&self, pubkey: [u8; 32], transport: &str) {
         let now = unix_now();
         let mut records = self.records.lock().expect("advert bus poisoned");
         records
             .entry(pubkey)
-            .and_modify(|e| e.last_seen_secs = now)
+            .and_modify(|e| {
+                e.last_seen_secs = now;
+                e.transport = transport.to_owned();
+            })
             .or_insert_with(|| AdvertRecord {
                 pubkey_hex: hex_encode(&pubkey),
                 name: String::new(),
@@ -185,6 +205,7 @@ impl AdvertBus {
                 lon: 0.0,
                 first_seen_secs: now,
                 last_seen_secs: now,
+                transport: transport.to_owned(),
             });
     }
 
@@ -295,7 +316,7 @@ mod tests {
     #[test]
     fn zero_device_ts_falls_back_to_now() {
         let bus = AdvertBus::new();
-        bus.upsert_with_timestamp(dummy_key(1), "A".into(), 1, 0, 0, 0);
+        bus.upsert_with_timestamp(dummy_key(1), "A".into(), 1, 0, 0, 0, "meshcore");
         let records = bus.list();
         let ts = records[0].last_seen_secs;
         let now = now_secs();
@@ -311,7 +332,7 @@ mod tests {
     fn boot_relative_ts_is_rejected() {
         let bus = AdvertBus::new();
         let boot_relative: i64 = 3600; // 1 hour after epoch — clearly 1970
-        bus.upsert_with_timestamp(dummy_key(2), "B".into(), 1, 0, 0, boot_relative);
+        bus.upsert_with_timestamp(dummy_key(2), "B".into(), 1, 0, 0, boot_relative, "meshcore");
         let ts = bus.list()[0].last_seen_secs;
         let now = now_secs();
         assert!(
@@ -327,7 +348,15 @@ mod tests {
         let far_future: i64 = 2_000_000_000; // ~year 2033 — plausible false positive guard
                                              // Use a value well past now+fudge to ensure rejection.
         let very_far_future: i64 = 4_000_000_000; // ~year 2096
-        bus.upsert_with_timestamp(dummy_key(3), "C".into(), 1, 0, 0, very_far_future);
+        bus.upsert_with_timestamp(
+            dummy_key(3),
+            "C".into(),
+            1,
+            0,
+            0,
+            very_far_future,
+            "meshcore",
+        );
         let ts = bus.list()[0].last_seen_secs;
         let now = now_secs();
         assert!(
@@ -342,7 +371,7 @@ mod tests {
     fn plausible_ts_is_accepted() {
         let bus = AdvertBus::new();
         let plausible: i64 = 1_700_000_000; // Nov 2023 — clearly reasonable
-        bus.upsert_with_timestamp(dummy_key(4), "D".into(), 1, 0, 0, plausible);
+        bus.upsert_with_timestamp(dummy_key(4), "D".into(), 1, 0, 0, plausible, "meshcore");
         let ts = bus.list()[0].last_seen_secs;
         assert_eq!(ts, plausible, "plausible ts should be stored unchanged");
     }
@@ -351,7 +380,7 @@ mod tests {
     #[test]
     fn clear_empties_bus() {
         let bus = AdvertBus::new();
-        bus.upsert(dummy_key(5), "E".into(), 1, 0, 0);
+        bus.upsert(dummy_key(5), "E".into(), 1, 0, 0, "meshcore");
         assert_eq!(bus.list().len(), 1);
         bus.clear();
         assert_eq!(bus.list().len(), 0);
@@ -366,11 +395,35 @@ mod tests {
         let excluded_key = dummy_key(30);
 
         // old_key was last seen in Nov 2023.
-        bus.upsert_with_timestamp(old_key, "OldNode".into(), 1, 0, 0, 1_700_000_000);
+        bus.upsert_with_timestamp(
+            old_key,
+            "OldNode".into(),
+            1,
+            0,
+            0,
+            1_700_000_000,
+            "meshcore",
+        );
         // new_key was last seen in Jan 2025.
-        bus.upsert_with_timestamp(new_key, "NewNode".into(), 1, 0, 0, 1_735_689_600);
+        bus.upsert_with_timestamp(
+            new_key,
+            "NewNode".into(),
+            1,
+            0,
+            0,
+            1_735_689_600,
+            "meshcore",
+        );
         // excluded_key is even older but excluded.
-        bus.upsert_with_timestamp(excluded_key, "ExcludedNode".into(), 1, 0, 0, 1_500_000_000);
+        bus.upsert_with_timestamp(
+            excluded_key,
+            "ExcludedNode".into(),
+            1,
+            0,
+            0,
+            1_500_000_000,
+            "meshcore",
+        );
 
         let excluded_prefix: [u8; 6] = excluded_key[..6].try_into().unwrap();
         let result = bus.stalest_pubkey_excluding(&[excluded_prefix]);
@@ -387,7 +440,7 @@ mod tests {
     fn stalest_pubkey_excluding_all_excluded_returns_none() {
         let bus = AdvertBus::new();
         let key = dummy_key(11);
-        bus.upsert(key, "A".into(), 1, 0, 0);
+        bus.upsert(key, "A".into(), 1, 0, 0, "meshcore");
         let prefix: [u8; 6] = key[..6].try_into().unwrap();
         assert_eq!(bus.stalest_pubkey_excluding(&[prefix]), None);
     }
@@ -397,5 +450,24 @@ mod tests {
     fn stalest_pubkey_excluding_empty_bus_returns_none() {
         let bus = AdvertBus::new();
         assert_eq!(bus.stalest_pubkey_excluding(&[]), None);
+    }
+
+    /// The transport name is stored and surfaced via `list()`.
+    #[test]
+    fn transport_is_recorded() {
+        let bus = AdvertBus::new();
+        bus.upsert(dummy_key(40), "MC".into(), 1, 0, 0, "meshcore");
+        bus.upsert_short(dummy_key(41), "meshtastic");
+        let by_name: std::collections::HashMap<String, String> = bus
+            .list()
+            .into_iter()
+            .map(|r| (r.name, r.transport))
+            .collect();
+        assert_eq!(by_name.get("MC").map(String::as_str), Some("meshcore"));
+        // The short advert has no name; find it by transport instead.
+        assert!(
+            bus.list().iter().any(|r| r.transport == "meshtastic"),
+            "short advert should carry its transport"
+        );
     }
 }

--- a/crates/bbs-plugin-api/src/host.rs
+++ b/crates/bbs-plugin-api/src/host.rs
@@ -87,6 +87,14 @@ pub enum MeshtasticAdminRequest {
         /// One-shot channel to deliver the snapshot back to the caller.
         reply: tokio::sync::oneshot::Sender<Result<crate::admin::MeshtasticDeviceSnapshot, String>>,
     },
+    /// Reboot the radio after `seconds`. On boot the firmware re-broadcasts its
+    /// NodeInfo, so neighbours re-acquire the node.
+    Reboot {
+        /// Seconds until reboot.
+        seconds: i32,
+        /// One-shot channel to deliver the result back to the caller.
+        reply: tokio::sync::oneshot::Sender<Result<(), String>>,
+    },
 }
 
 use crate::admin::{
@@ -542,6 +550,13 @@ pub trait Host: Send + Sync {
         Err(HostError::NotSupported(
             "admin_get_meshtastic_snapshot".into(),
         ))
+    }
+
+    /// Reboot the connected Meshtastic radio after `seconds`. Forces a fresh
+    /// boot-time NodeInfo broadcast so neighbours re-acquire the node.
+    async fn admin_reboot_meshtastic(&self, seconds: i32) -> Result<(), HostError> {
+        let _ = seconds;
+        Err(HostError::NotSupported("admin_reboot_meshtastic".into()))
     }
 
     // ── Mesh node credentials ────────────────────────────────────────────────────

--- a/crates/bbs-plugin-api/src/host.rs
+++ b/crates/bbs-plugin-api/src/host.rs
@@ -80,6 +80,13 @@ pub enum MeshtasticAdminRequest {
         /// One-shot channel to deliver the result back to the caller.
         reply: tokio::sync::oneshot::Sender<Result<crate::admin::MeshtasticSecurityInfo, String>>,
     },
+    /// Fetch a combined snapshot (LoRa + owner + security) from the cache
+    /// captured during the last connect-time sync. Answered instantly without a
+    /// device round-trip.
+    GetSnapshot {
+        /// One-shot channel to deliver the snapshot back to the caller.
+        reply: tokio::sync::oneshot::Sender<Result<crate::admin::MeshtasticDeviceSnapshot, String>>,
+    },
 }
 
 use crate::admin::{
@@ -524,6 +531,16 @@ pub trait Host: Send + Sync {
     async fn admin_get_meshtastic_security(&self) -> Result<MeshtasticSecurityInfo, HostError> {
         Err(HostError::NotSupported(
             "admin_get_meshtastic_security".into(),
+        ))
+    }
+
+    /// Fetch a combined snapshot of the Meshtastic device settings from the
+    /// cache captured during the last connect-time sync (no device round-trip).
+    async fn admin_get_meshtastic_snapshot(
+        &self,
+    ) -> Result<crate::admin::MeshtasticDeviceSnapshot, HostError> {
+        Err(HostError::NotSupported(
+            "admin_get_meshtastic_snapshot".into(),
         ))
     }
 

--- a/crates/bbs-plugin-api/src/host.rs
+++ b/crates/bbs-plugin-api/src/host.rs
@@ -38,11 +38,35 @@ pub enum MeshKeyRequest {
         /// One-shot channel to deliver the result back to the caller.
         reply: tokio::sync::oneshot::Sender<Result<(), String>>,
     },
+    /// Apply LoRa radio parameters to the companion device.
+    ApplyRadio {
+        /// The radio parameters to apply.
+        params: crate::admin::MeshRadioParams,
+        /// One-shot channel to deliver the result back to the caller.
+        reply: tokio::sync::oneshot::Sender<Result<(), String>>,
+    },
+}
+
+/// Request sent from [`Host`] to the Meshtastic transport's admin channel.
+pub enum MeshtasticAdminRequest {
+    /// Fetch the current LoRa radio config from the device.
+    GetLoRaConfig {
+        /// One-shot channel to deliver the result back to the caller.
+        reply: tokio::sync::oneshot::Sender<Result<crate::admin::MeshtasticLoRaConfig, String>>,
+    },
+    /// Push a new LoRa radio config to the device.
+    SetLoRaConfig {
+        /// The LoRa config to write to the device.
+        config: crate::admin::MeshtasticLoRaConfig,
+        /// One-shot channel to deliver the result back to the caller.
+        reply: tokio::sync::oneshot::Sender<Result<(), String>>,
+    },
 }
 
 use crate::admin::{
     AdminAccessPolicy, AdminAuditEntry, AdminBackupRecord, AdminMessageRecord, AdminReports,
-    AdminRoomSummary, AdminSessionInfo, AdminStats, AdminUserInfo,
+    AdminRoomSummary, AdminSessionInfo, AdminStats, AdminUserInfo, MeshRadioParams,
+    MeshtasticLoRaConfig,
 };
 use crate::advert::AdvertBus;
 use crate::command::{Command, Response};
@@ -428,6 +452,34 @@ pub trait Host: Send + Sync {
     async fn admin_import_node_key(&self, hex: String) -> Result<(), HostError> {
         let _ = hex;
         Err(HostError::NotSupported("admin_import_node_key".into()))
+    }
+
+    /// Apply LoRa radio parameters to the MeshCore companion device.
+    /// Requires the mesh transport to be connected.
+    async fn admin_apply_mesh_radio(&self, params: MeshRadioParams) -> Result<(), HostError> {
+        let _ = params;
+        Err(HostError::NotSupported("admin_apply_mesh_radio".into()))
+    }
+
+    /// Register the Meshtastic transport's admin command channel.
+    fn register_meshtastic_admin_ops(
+        &self,
+        _sender: tokio::sync::mpsc::Sender<MeshtasticAdminRequest>,
+    ) {
+    }
+
+    /// Fetch the current LoRa radio config from the Meshtastic device.
+    async fn admin_get_meshtastic_lora(&self) -> Result<MeshtasticLoRaConfig, HostError> {
+        Err(HostError::NotSupported("admin_get_meshtastic_lora".into()))
+    }
+
+    /// Push a new LoRa radio config to the Meshtastic device.
+    async fn admin_set_meshtastic_lora(
+        &self,
+        config: MeshtasticLoRaConfig,
+    ) -> Result<(), HostError> {
+        let _ = config;
+        Err(HostError::NotSupported("admin_set_meshtastic_lora".into()))
     }
 
     // ── Mesh node credentials ────────────────────────────────────────────────────

--- a/crates/bbs-plugin-api/src/host.rs
+++ b/crates/bbs-plugin-api/src/host.rs
@@ -61,12 +61,31 @@ pub enum MeshtasticAdminRequest {
         /// One-shot channel to deliver the result back to the caller.
         reply: tokio::sync::oneshot::Sender<Result<(), String>>,
     },
+    /// Fetch the node's owner/user info (long name, short name, public key).
+    GetOwner {
+        /// One-shot channel to deliver the result back to the caller.
+        reply: tokio::sync::oneshot::Sender<Result<crate::admin::MeshtasticOwnerInfo, String>>,
+    },
+    /// Update the node's owner/user info.
+    SetOwner {
+        /// New long name, or `None` to leave unchanged.
+        long_name: Option<String>,
+        /// New short name (≤ 4 chars), or `None` to leave unchanged.
+        short_name: Option<String>,
+        /// One-shot channel to deliver the result back to the caller.
+        reply: tokio::sync::oneshot::Sender<Result<(), String>>,
+    },
+    /// Fetch the device's security / PKC configuration.
+    GetSecurity {
+        /// One-shot channel to deliver the result back to the caller.
+        reply: tokio::sync::oneshot::Sender<Result<crate::admin::MeshtasticSecurityInfo, String>>,
+    },
 }
 
 use crate::admin::{
     AdminAccessPolicy, AdminAuditEntry, AdminBackupRecord, AdminMessageRecord, AdminReports,
     AdminRoomSummary, AdminSessionInfo, AdminStats, AdminUserInfo, MeshRadioParams,
-    MeshtasticLoRaConfig,
+    MeshtasticLoRaConfig, MeshtasticOwnerInfo, MeshtasticSecurityInfo,
 };
 use crate::advert::AdvertBus;
 use crate::command::{Command, Response};
@@ -480,6 +499,32 @@ pub trait Host: Send + Sync {
     ) -> Result<(), HostError> {
         let _ = config;
         Err(HostError::NotSupported("admin_set_meshtastic_lora".into()))
+    }
+
+    /// Fetch the Meshtastic device's owner/user info (long name, short name,
+    /// public key).
+    async fn admin_get_meshtastic_owner(&self) -> Result<MeshtasticOwnerInfo, HostError> {
+        Err(HostError::NotSupported("admin_get_meshtastic_owner".into()))
+    }
+
+    /// Update the Meshtastic device's owner/user info.
+    ///
+    /// Pass `None` for any field that should not be changed.  The implementation
+    /// fetches the current owner first, merges the new values, then writes back.
+    async fn admin_set_meshtastic_owner(
+        &self,
+        long_name: Option<String>,
+        short_name: Option<String>,
+    ) -> Result<(), HostError> {
+        let _ = (long_name, short_name);
+        Err(HostError::NotSupported("admin_set_meshtastic_owner".into()))
+    }
+
+    /// Fetch the Meshtastic device's security / PKC configuration.
+    async fn admin_get_meshtastic_security(&self) -> Result<MeshtasticSecurityInfo, HostError> {
+        Err(HostError::NotSupported(
+            "admin_get_meshtastic_security".into(),
+        ))
     }
 
     // ── Mesh node credentials ────────────────────────────────────────────────────

--- a/crates/bbs-plugin-api/src/lib.rs
+++ b/crates/bbs-plugin-api/src/lib.rs
@@ -53,7 +53,7 @@ pub use admin::{
     AdminAccessPolicy, AdminAuditEntry, AdminBackupRecord, AdminDailyVolume, AdminHourlyActivity,
     AdminMessageRecord, AdminReports, AdminRoomSummary, AdminSessionInfo, AdminStaleRoom,
     AdminStats, AdminTopRoom, AdminTopSender, AdminUserInfo, AdminWeeklySignups, MeshRadioParams,
-    MeshtasticLoRaConfig,
+    MeshtasticLoRaConfig, MeshtasticOwnerInfo, MeshtasticSecurityInfo,
 };
 pub use advert::{AdvertBus, AdvertRecord};
 pub use command::{Command, Response};

--- a/crates/bbs-plugin-api/src/lib.rs
+++ b/crates/bbs-plugin-api/src/lib.rs
@@ -52,13 +52,14 @@ pub mod transport;
 pub use admin::{
     AdminAccessPolicy, AdminAuditEntry, AdminBackupRecord, AdminDailyVolume, AdminHourlyActivity,
     AdminMessageRecord, AdminReports, AdminRoomSummary, AdminSessionInfo, AdminStaleRoom,
-    AdminStats, AdminTopRoom, AdminTopSender, AdminUserInfo, AdminWeeklySignups,
+    AdminStats, AdminTopRoom, AdminTopSender, AdminUserInfo, AdminWeeklySignups, MeshRadioParams,
+    MeshtasticLoRaConfig,
 };
 pub use advert::{AdvertBus, AdvertRecord};
 pub use command::{Command, Response};
 pub use error::{HostError, PluginError, TransportError};
 pub use event::{DomainEvent, MessageRecipient, Notification, NotifyOutcome};
-pub use host::{Host, MeshKeyRequest};
+pub use host::{Host, MeshKeyRequest, MeshtasticAdminRequest};
 pub use identity::{SessionId, Username};
 pub use permissions::{PermissionCtx, PermissionLevel};
 pub use plugin::Plugin;

--- a/crates/bbs-plugin-api/src/lib.rs
+++ b/crates/bbs-plugin-api/src/lib.rs
@@ -53,7 +53,7 @@ pub use admin::{
     AdminAccessPolicy, AdminAuditEntry, AdminBackupRecord, AdminDailyVolume, AdminHourlyActivity,
     AdminMessageRecord, AdminReports, AdminRoomSummary, AdminSessionInfo, AdminStaleRoom,
     AdminStats, AdminTopRoom, AdminTopSender, AdminUserInfo, AdminWeeklySignups, MeshRadioParams,
-    MeshtasticLoRaConfig, MeshtasticOwnerInfo, MeshtasticSecurityInfo,
+    MeshtasticDeviceSnapshot, MeshtasticLoRaConfig, MeshtasticOwnerInfo, MeshtasticSecurityInfo,
 };
 pub use advert::{AdvertBus, AdvertRecord};
 pub use command::{Command, Response};

--- a/crates/bbs-web/src/lib.rs
+++ b/crates/bbs-web/src/lib.rs
@@ -568,6 +568,7 @@ fn build_router(state: Arc<AppState>) -> Router {
             get(api_get_meshtastic_owner).patch(api_patch_meshtastic_owner),
         )
         .route("/meshtastic-security", get(api_get_meshtastic_security))
+        .route("/meshtastic-device", get(api_get_meshtastic_device))
         .route("/node-identity", get(api_get_node_identity))
         .route("/node-identity/export-key", post(api_export_node_key))
         .route("/node-identity/import-key", post(api_import_node_key))
@@ -2740,6 +2741,31 @@ fn save_meshtastic_owner_to_config(
 }
 
 // ── Meshtastic radio config ───────────────────────────────────────────────────
+
+/// `GET /api/v1/meshtastic-device` — combined snapshot (LoRa + owner + security)
+/// served from the config captured during the last connect-time sync. One call,
+/// no device round-trip; used to populate the Settings page on load.
+async fn api_get_meshtastic_device(
+    State(state): State<Arc<AppState>>,
+    Extension(user): Extension<CurrentUser>,
+) -> Response {
+    if user.permission_level < 100 {
+        return (StatusCode::FORBIDDEN, Json(json_error("sysop required"))).into_response();
+    }
+    match state.host.admin_get_meshtastic_snapshot().await {
+        Ok(snapshot) => Json(snapshot).into_response(),
+        Err(HostError::NotSupported(_)) | Err(HostError::Internal(_)) => (
+            StatusCode::SERVICE_UNAVAILABLE,
+            Json(json_error("Meshtastic transport not connected")),
+        )
+            .into_response(),
+        Err(e) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(json_error(&format!("{e}"))),
+        )
+            .into_response(),
+    }
+}
 
 async fn api_get_meshtastic_radio_config(
     State(state): State<Arc<AppState>>,

--- a/crates/bbs-web/src/lib.rs
+++ b/crates/bbs-web/src/lib.rs
@@ -2758,12 +2758,31 @@ async fn api_patch_meshtastic_radio_config(
 
     // Then try to push to the live device via the transport.
     match state.host.admin_set_meshtastic_lora(config).await {
-        Ok(()) => Json(serde_json::json!({
-            "ok": true,
-            "saved": saved.is_ok(),
-            "applied": true,
-        }))
-        .into_response(),
+        Ok(()) => {
+            // Read back the device's actual config to confirm the write landed.
+            // A LoRa parameter *change* makes the device reboot, in which case
+            // the read-back times out — report applied-but-not-yet-confirmed.
+            tokio::time::sleep(std::time::Duration::from_millis(600)).await;
+            match state.host.admin_get_meshtastic_lora().await {
+                Ok(device) => Json(serde_json::json!({
+                    "ok": true,
+                    "saved": saved.is_ok(),
+                    "applied": true,
+                    "confirmed": true,
+                    "device_config": device,
+                }))
+                .into_response(),
+                Err(_) => Json(serde_json::json!({
+                    "ok": true,
+                    "saved": saved.is_ok(),
+                    "applied": true,
+                    "confirmed": false,
+                    "message": "Settings sent. The device may be rebooting to apply them; \
+                                use \"Load from device\" in a few seconds to confirm.",
+                }))
+                .into_response(),
+            }
+        }
         Err(HostError::NotSupported(_)) | Err(HostError::Internal(_)) => {
             // Transport not connected — that's OK if we saved to config.
             if saved.unwrap_or(false) {
@@ -2771,6 +2790,7 @@ async fn api_patch_meshtastic_radio_config(
                     "ok": true,
                     "saved": true,
                     "applied": false,
+                    "confirmed": false,
                     "message": "Saved to config.toml. The device is not connected right now; \
                                 these settings will be applied automatically the next time the \
                                 BBS connects to it.",
@@ -2850,18 +2870,36 @@ async fn api_patch_meshtastic_owner(
         .admin_set_meshtastic_owner(body.long_name, body.short_name)
         .await
     {
-        Ok(()) => Json(serde_json::json!({
-            "ok": true,
-            "saved": saved.is_ok(),
-            "applied": true,
-        }))
-        .into_response(),
+        Ok(()) => {
+            // Read back the device's actual owner info to confirm. A name change
+            // does not reboot the device, so this read-back is reliable.
+            tokio::time::sleep(std::time::Duration::from_millis(600)).await;
+            match state.host.admin_get_meshtastic_owner().await {
+                Ok(owner) => Json(serde_json::json!({
+                    "ok": true,
+                    "saved": saved.is_ok(),
+                    "applied": true,
+                    "confirmed": true,
+                    "device_owner": owner,
+                }))
+                .into_response(),
+                Err(_) => Json(serde_json::json!({
+                    "ok": true,
+                    "saved": saved.is_ok(),
+                    "applied": true,
+                    "confirmed": false,
+                    "message": "Name sent. Use \"Load from device\" in a few seconds to confirm.",
+                }))
+                .into_response(),
+            }
+        }
         Err(HostError::NotSupported(_)) => {
             if saved.unwrap_or(false) {
                 Json(serde_json::json!({
                     "ok": true,
                     "saved": true,
                     "applied": false,
+                    "confirmed": false,
                     "message": "Saved to config.toml. The device is not connected right now; \
                                 this name will be applied automatically the next time the BBS \
                                 connects to it.",

--- a/crates/bbs-web/src/lib.rs
+++ b/crates/bbs-web/src/lib.rs
@@ -569,6 +569,7 @@ fn build_router(state: Arc<AppState>) -> Router {
         )
         .route("/meshtastic-security", get(api_get_meshtastic_security))
         .route("/meshtastic-device", get(api_get_meshtastic_device))
+        .route("/meshtastic-reboot", post(api_reboot_meshtastic))
         .route("/node-identity", get(api_get_node_identity))
         .route("/node-identity/export-key", post(api_export_node_key))
         .route("/node-identity/import-key", post(api_import_node_key))
@@ -2772,6 +2773,37 @@ fn save_meshtastic_owner_to_config(
 }
 
 // ── Meshtastic radio config ───────────────────────────────────────────────────
+
+/// `POST /api/v1/meshtastic-reboot` — reboot the connected Meshtastic radio.
+/// On boot the firmware re-broadcasts its NodeInfo, so neighbours re-acquire
+/// the node — the firmware-supported way to force a re-announce on demand.
+async fn api_reboot_meshtastic(
+    State(state): State<Arc<AppState>>,
+    Extension(user): Extension<CurrentUser>,
+) -> Response {
+    if user.permission_level < 100 {
+        return (StatusCode::FORBIDDEN, Json(json_error("sysop required"))).into_response();
+    }
+    // 5s gives the HTTP response time to leave before the radio drops off.
+    match state.host.admin_reboot_meshtastic(5).await {
+        Ok(()) => Json(serde_json::json!({
+            "ok": true,
+            "message": "Radio reboot requested. It will drop off for ~30s, then re-announce \
+                        itself to the mesh on boot.",
+        }))
+        .into_response(),
+        Err(HostError::NotSupported(_)) | Err(HostError::Internal(_)) => (
+            StatusCode::SERVICE_UNAVAILABLE,
+            Json(json_error("Meshtastic transport not connected")),
+        )
+            .into_response(),
+        Err(e) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(json_error(&format!("{e}"))),
+        )
+            .into_response(),
+    }
+}
 
 /// `GET /api/v1/meshtastic-device` — combined snapshot (LoRa + owner + security)
 /// served from the config captured during the last connect-time sync. One call,

--- a/crates/bbs-web/src/lib.rs
+++ b/crates/bbs-web/src/lib.rs
@@ -943,6 +943,7 @@ struct AdvertResponse {
     type_name: String,
     lat: f64,
     lon: f64,
+    transport: String,
 }
 
 async fn api_adverts(State(state): State<Arc<AppState>>) -> impl IntoResponse {
@@ -957,6 +958,7 @@ async fn api_adverts(State(state): State<Arc<AppState>>) -> impl IntoResponse {
             type_name: adv_type_name(r.adv_type).to_owned(),
             lat: r.lat,
             lon: r.lon,
+            transport: r.transport,
         })
         .collect();
     Json(out)

--- a/crates/bbs-web/src/lib.rs
+++ b/crates/bbs-web/src/lib.rs
@@ -956,7 +956,7 @@ async fn api_adverts(State(state): State<Arc<AppState>>) -> impl IntoResponse {
             pubkey: r.pubkey_hex,
             name: r.name,
             adv_type: r.adv_type,
-            type_name: adv_type_name(r.adv_type).to_owned(),
+            type_name: adv_type_name(&r.transport, r.adv_type).to_owned(),
             lat: r.lat,
             lon: r.lon,
             transport: r.transport,
@@ -975,12 +975,38 @@ async fn api_adverts_clear(State(state): State<Arc<AppState>>) -> impl IntoRespo
     axum::http::StatusCode::NO_CONTENT
 }
 
-fn adv_type_name(t: u8) -> &'static str {
+/// Human-readable advert "type", interpreted per transport.
+///
+/// MeshCore uses its advert-type byte; Meshtastic reports the device role
+/// (`Config.DeviceConfig.Role`) which we surface as the type instead.
+fn adv_type_name(transport: &str, t: u8) -> &'static str {
+    if transport == "meshtastic" {
+        return meshtastic_role_name(t);
+    }
     match t {
         1 => "chat",
         2 => "repeater",
         3 => "room",
         4 => "sensor",
+        _ => "unknown",
+    }
+}
+
+/// Map a Meshtastic device role value to a short label.
+fn meshtastic_role_name(role: u8) -> &'static str {
+    match role {
+        0 => "client",
+        1 => "client_mute",
+        2 => "router",
+        3 => "router_client",
+        4 => "repeater",
+        5 => "tracker",
+        6 => "sensor",
+        7 => "tak",
+        8 => "client_hidden",
+        9 => "lost_and_found",
+        10 => "tak_tracker",
+        11 => "router_late",
         _ => "unknown",
     }
 }

--- a/crates/bbs-web/src/lib.rs
+++ b/crates/bbs-web/src/lib.rs
@@ -1731,12 +1731,17 @@ async fn api_restart(
         )
         .await;
 
-    // Spawn restart after a short delay so the 202 response can leave first.
+    // Exit the process and let systemd's `Restart=` policy start a fresh
+    // instance (picking up the new binary/config). We deliberately do NOT shell
+    // out to `sudo systemctl restart`: the unit runs as a non-root user with
+    // `NoNewPrivileges=true`, so `sudo` cannot escalate ("no new privileges flag
+    // is set") and the restart silently fails. Exiting works without any
+    // privileges. A non-zero code triggers `Restart=on-failure`; `Restart=always`
+    // restarts on any exit. The short delay lets the 202 response flush first.
+    tracing::warn!("web admin: service restart requested — exiting for systemd to restart");
     tokio::spawn(async {
         tokio::time::sleep(std::time::Duration::from_millis(500)).await;
-        let _ = std::process::Command::new("sudo")
-            .args(["systemctl", "restart", "supply-drop-bbs"])
-            .spawn();
+        std::process::exit(1);
     });
 
     (

--- a/crates/bbs-web/src/lib.rs
+++ b/crates/bbs-web/src/lib.rs
@@ -2616,10 +2616,15 @@ fn meshtastic_preset_name(n: i32) -> &'static str {
 /// Write region and modem_preset strings into `[plugins.meshtastic.radio]`
 /// in the operator config file.  Returns `Ok(true)` when written,
 /// `Ok(false)` when no config path is configured.
+#[allow(clippy::too_many_arguments)]
 fn save_meshtastic_radio_to_config(
     config_path: &Option<String>,
     region_int: i32,
     preset_int: i32,
+    hops: u32,
+    rx_boosted_gain: bool,
+    ignore_mqtt: bool,
+    tx_enabled: bool,
 ) -> Result<bool, String> {
     let path = match config_path {
         Some(p) if !p.is_empty() => std::path::PathBuf::from(p),
@@ -2660,6 +2665,22 @@ fn save_meshtastic_radio_to_config(
     radio.insert(
         "modem_preset",
         toml_edit::Item::Value(toml_edit::Value::from(meshtastic_preset_name(preset_int))),
+    );
+    radio.insert(
+        "hops",
+        toml_edit::Item::Value(toml_edit::Value::from(hops as i64)),
+    );
+    radio.insert(
+        "rx_boosted_gain",
+        toml_edit::Item::Value(toml_edit::Value::from(rx_boosted_gain)),
+    );
+    radio.insert(
+        "ignore_mqtt",
+        toml_edit::Item::Value(toml_edit::Value::from(ignore_mqtt)),
+    );
+    radio.insert(
+        "tx_enabled",
+        toml_edit::Item::Value(toml_edit::Value::from(tx_enabled)),
     );
 
     std::fs::write(&path, doc.to_string()).map_err(|e| format!("write error: {e}"))?;
@@ -2753,7 +2774,15 @@ async fn api_patch_meshtastic_radio_config(
 
     // Always save region + modem_preset to config.toml first.
     let config_path = &state.config.config_path;
-    let saved = save_meshtastic_radio_to_config(config_path, config.region, config.modem_preset);
+    let saved = save_meshtastic_radio_to_config(
+        config_path,
+        config.region,
+        config.modem_preset,
+        config.hop_limit,
+        config.sx126x_rx_boosted_gain,
+        config.ignore_mqtt,
+        config.tx_enabled,
+    );
     if let Err(ref e) = saved {
         tracing::warn!("meshtastic radio: could not save to config.toml: {e}");
     }

--- a/crates/bbs-web/src/lib.rs
+++ b/crates/bbs-web/src/lib.rs
@@ -558,6 +558,11 @@ fn build_router(state: Arc<AppState>) -> Router {
             "/radio-config",
             get(api_get_radio_config).patch(api_patch_radio_config),
         )
+        .route("/radio-config/apply", post(api_apply_radio_config))
+        .route(
+            "/meshtastic-radio-config",
+            get(api_get_meshtastic_radio_config).patch(api_patch_meshtastic_radio_config),
+        )
         .route("/node-identity", get(api_get_node_identity))
         .route("/node-identity/export-key", post(api_export_node_key))
         .route("/node-identity/import-key", post(api_import_node_key))
@@ -2514,6 +2519,92 @@ async fn api_patch_radio_config(
         presets: RADIO_PRESETS.to_vec(),
     })
     .into_response()
+}
+
+// ── Radio config apply (MeshCore) ────────────────────────────────────────────
+
+#[derive(Debug, Deserialize)]
+struct ApplyRadioBody {
+    frequency_hz: u32,
+    bandwidth_hz: u32,
+    spreading_factor: u8,
+    coding_rate: u8,
+    tx_power_dbm: i8,
+}
+
+async fn api_apply_radio_config(
+    State(state): State<Arc<AppState>>,
+    Extension(user): Extension<CurrentUser>,
+    Json(body): Json<ApplyRadioBody>,
+) -> Response {
+    if user.permission_level < 100 {
+        return (StatusCode::FORBIDDEN, Json(json_error("sysop required"))).into_response();
+    }
+    let params = bbs_plugin_api::MeshRadioParams {
+        frequency_hz: body.frequency_hz,
+        bandwidth_hz: body.bandwidth_hz,
+        spreading_factor: body.spreading_factor,
+        coding_rate: body.coding_rate,
+        tx_power_dbm: body.tx_power_dbm,
+    };
+    match state.host.admin_apply_mesh_radio(params).await {
+        Ok(()) => Json(serde_json::json!({ "ok": true })).into_response(),
+        Err(e) => {
+            let status = match &e {
+                HostError::Internal(_) => StatusCode::SERVICE_UNAVAILABLE,
+                HostError::NotSupported(_) => StatusCode::SERVICE_UNAVAILABLE,
+                _ => StatusCode::INTERNAL_SERVER_ERROR,
+            };
+            (status, Json(json_error(&format!("{e}")))).into_response()
+        }
+    }
+}
+
+// ── Meshtastic radio config ───────────────────────────────────────────────────
+
+async fn api_get_meshtastic_radio_config(
+    State(state): State<Arc<AppState>>,
+    Extension(user): Extension<CurrentUser>,
+) -> Response {
+    if user.permission_level < 100 {
+        return (StatusCode::FORBIDDEN, Json(json_error("sysop required"))).into_response();
+    }
+    match state.host.admin_get_meshtastic_lora().await {
+        Ok(config) => Json(config).into_response(),
+        Err(HostError::NotSupported(_)) | Err(HostError::Internal(_)) => (
+            StatusCode::SERVICE_UNAVAILABLE,
+            Json(json_error("Meshtastic transport not connected")),
+        )
+            .into_response(),
+        Err(e) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(json_error(&format!("{e}"))),
+        )
+            .into_response(),
+    }
+}
+
+async fn api_patch_meshtastic_radio_config(
+    State(state): State<Arc<AppState>>,
+    Extension(user): Extension<CurrentUser>,
+    Json(config): Json<bbs_plugin_api::MeshtasticLoRaConfig>,
+) -> Response {
+    if user.permission_level < 100 {
+        return (StatusCode::FORBIDDEN, Json(json_error("sysop required"))).into_response();
+    }
+    match state.host.admin_set_meshtastic_lora(config).await {
+        Ok(()) => Json(serde_json::json!({ "ok": true })).into_response(),
+        Err(HostError::NotSupported(_)) | Err(HostError::Internal(_)) => (
+            StatusCode::SERVICE_UNAVAILABLE,
+            Json(json_error("Meshtastic transport not connected")),
+        )
+            .into_response(),
+        Err(e) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(json_error(&format!("{e}"))),
+        )
+            .into_response(),
+    }
 }
 
 // ── Node identity ─────────────────────────────────────────────────────────────

--- a/crates/bbs-web/src/lib.rs
+++ b/crates/bbs-web/src/lib.rs
@@ -2565,6 +2565,157 @@ async fn api_apply_radio_config(
     }
 }
 
+// ── Meshtastic config.toml helpers ───────────────────────────────────────────
+
+fn meshtastic_region_name(n: i32) -> &'static str {
+    match n {
+        1 => "US",
+        2 => "EU_433",
+        3 => "EU_868",
+        4 => "CN",
+        5 => "JP",
+        6 => "ANZ",
+        7 => "KR",
+        8 => "TW",
+        9 => "RU",
+        10 => "IN",
+        11 => "NZ_865",
+        12 => "TH",
+        13 => "LORA_24",
+        14 => "UA_433",
+        15 => "UA_868",
+        16 => "MY_433",
+        17 => "MY_919",
+        18 => "SG_923",
+        _ => "UNSET",
+    }
+}
+
+fn meshtastic_preset_name(n: i32) -> &'static str {
+    match n {
+        0 => "LONG_FAST",
+        1 => "LONG_SLOW",
+        2 => "VERY_LONG_SLOW",
+        3 => "MEDIUM_SLOW",
+        4 => "MEDIUM_FAST",
+        5 => "SHORT_SLOW",
+        6 => "SHORT_FAST",
+        7 => "LONG_MODERATE",
+        8 => "SHORT_TURBO",
+        9 => "LONG_TURBO",
+        10 => "LITE_FAST",
+        11 => "LITE_SLOW",
+        12 => "NARROW_FAST",
+        13 => "NARROW_SLOW",
+        _ => "LONG_FAST",
+    }
+}
+
+/// Write region and modem_preset strings into `[plugins.meshtastic.radio]`
+/// in the operator config file.  Returns `Ok(true)` when written,
+/// `Ok(false)` when no config path is configured.
+fn save_meshtastic_radio_to_config(
+    config_path: &Option<String>,
+    region_int: i32,
+    preset_int: i32,
+) -> Result<bool, String> {
+    let path = match config_path {
+        Some(p) if !p.is_empty() => std::path::PathBuf::from(p),
+        _ => return Ok(false),
+    };
+    let raw = std::fs::read_to_string(&path).unwrap_or_default();
+    let mut doc = raw
+        .parse::<toml_edit::DocumentMut>()
+        .map_err(|e| format!("config parse error: {e}"))?;
+
+    // Ensure [plugins.meshtastic.radio] table path exists.
+    if doc.get("plugins").is_none() {
+        doc["plugins"] = toml_edit::Item::Table(toml_edit::Table::new());
+    }
+    let plugins = doc["plugins"].as_table_mut().unwrap();
+    if plugins.get("meshtastic").is_none() {
+        plugins.insert(
+            "meshtastic",
+            toml_edit::Item::Table(toml_edit::Table::new()),
+        );
+    }
+    let mt = plugins
+        .get_mut("meshtastic")
+        .unwrap()
+        .as_table_mut()
+        .unwrap();
+    if mt.get("radio").is_none() {
+        mt.insert("radio", toml_edit::Item::Table(toml_edit::Table::new()));
+    }
+    let radio = mt.get_mut("radio").unwrap().as_table_mut().unwrap();
+
+    if region_int != 0 {
+        radio.insert(
+            "region",
+            toml_edit::Item::Value(toml_edit::Value::from(meshtastic_region_name(region_int))),
+        );
+    }
+    radio.insert(
+        "modem_preset",
+        toml_edit::Item::Value(toml_edit::Value::from(meshtastic_preset_name(preset_int))),
+    );
+
+    std::fs::write(&path, doc.to_string()).map_err(|e| format!("write error: {e}"))?;
+    Ok(true)
+}
+
+/// Write short_name and/or long_name into `[plugins.meshtastic]`
+/// in the operator config file.
+fn save_meshtastic_owner_to_config(
+    config_path: &Option<String>,
+    short_name: Option<&str>,
+    long_name: Option<&str>,
+) -> Result<bool, String> {
+    let path = match config_path {
+        Some(p) if !p.is_empty() => std::path::PathBuf::from(p),
+        _ => return Ok(false),
+    };
+    if short_name.is_none() && long_name.is_none() {
+        return Ok(true);
+    }
+    let raw = std::fs::read_to_string(&path).unwrap_or_default();
+    let mut doc = raw
+        .parse::<toml_edit::DocumentMut>()
+        .map_err(|e| format!("config parse error: {e}"))?;
+
+    if doc.get("plugins").is_none() {
+        doc["plugins"] = toml_edit::Item::Table(toml_edit::Table::new());
+    }
+    let plugins = doc["plugins"].as_table_mut().unwrap();
+    if plugins.get("meshtastic").is_none() {
+        plugins.insert(
+            "meshtastic",
+            toml_edit::Item::Table(toml_edit::Table::new()),
+        );
+    }
+    let mt = plugins
+        .get_mut("meshtastic")
+        .unwrap()
+        .as_table_mut()
+        .unwrap();
+
+    if let Some(sn) = short_name {
+        mt.insert(
+            "short_name",
+            toml_edit::Item::Value(toml_edit::Value::from(sn)),
+        );
+    }
+    if let Some(ln) = long_name {
+        mt.insert(
+            "long_name",
+            toml_edit::Item::Value(toml_edit::Value::from(ln)),
+        );
+    }
+
+    std::fs::write(&path, doc.to_string()).map_err(|e| format!("write error: {e}"))?;
+    Ok(true)
+}
+
 // ── Meshtastic radio config ───────────────────────────────────────────────────
 
 async fn api_get_meshtastic_radio_config(
@@ -2597,13 +2748,44 @@ async fn api_patch_meshtastic_radio_config(
     if user.permission_level < 100 {
         return (StatusCode::FORBIDDEN, Json(json_error("sysop required"))).into_response();
     }
+
+    // Always save region + modem_preset to config.toml first.
+    let config_path = &state.config.config_path;
+    let saved = save_meshtastic_radio_to_config(config_path, config.region, config.modem_preset);
+    if let Err(ref e) = saved {
+        tracing::warn!("meshtastic radio: could not save to config.toml: {e}");
+    }
+
+    // Then try to push to the live device via the transport.
     match state.host.admin_set_meshtastic_lora(config).await {
-        Ok(()) => Json(serde_json::json!({ "ok": true })).into_response(),
-        Err(HostError::NotSupported(_)) | Err(HostError::Internal(_)) => (
-            StatusCode::SERVICE_UNAVAILABLE,
-            Json(json_error("Meshtastic transport not connected")),
-        )
-            .into_response(),
+        Ok(()) => Json(serde_json::json!({
+            "ok": true,
+            "saved": saved.is_ok(),
+            "applied": true,
+        }))
+        .into_response(),
+        Err(HostError::NotSupported(_)) | Err(HostError::Internal(_)) => {
+            // Transport not connected — that's OK if we saved to config.
+            if saved.unwrap_or(false) {
+                Json(serde_json::json!({
+                    "ok": true,
+                    "saved": true,
+                    "applied": false,
+                    "message": "Saved to config.toml. Settings will not take effect on the \
+                                device until you run: supply-drop-bbs node set-meshtastic-radio \
+                                (while the BBS is stopped).",
+                }))
+                .into_response()
+            } else {
+                (
+                    StatusCode::SERVICE_UNAVAILABLE,
+                    Json(json_error(
+                        "Meshtastic transport not connected and no config path configured",
+                    )),
+                )
+                    .into_response()
+            }
+        }
         Err(e) => (
             StatusCode::INTERNAL_SERVER_ERROR,
             Json(json_error(&format!("{e}"))),
@@ -2650,17 +2832,51 @@ async fn api_patch_meshtastic_owner(
     if user.permission_level < 100 {
         return (StatusCode::FORBIDDEN, Json(json_error("sysop required"))).into_response();
     }
+
+    // Always save short/long name to config.toml first.
+    let config_path = &state.config.config_path;
+    let saved = save_meshtastic_owner_to_config(
+        config_path,
+        body.short_name.as_deref(),
+        body.long_name.as_deref(),
+    );
+    if let Err(ref e) = saved {
+        tracing::warn!("meshtastic owner: could not save to config.toml: {e}");
+    }
+
+    // Then try to push to the live device via the transport.
     match state
         .host
         .admin_set_meshtastic_owner(body.long_name, body.short_name)
         .await
     {
-        Ok(()) => Json(serde_json::json!({ "ok": true })).into_response(),
-        Err(HostError::NotSupported(_)) => (
-            StatusCode::SERVICE_UNAVAILABLE,
-            Json(json_error("Meshtastic transport not connected")),
-        )
-            .into_response(),
+        Ok(()) => Json(serde_json::json!({
+            "ok": true,
+            "saved": saved.is_ok(),
+            "applied": true,
+        }))
+        .into_response(),
+        Err(HostError::NotSupported(_)) => {
+            if saved.unwrap_or(false) {
+                Json(serde_json::json!({
+                    "ok": true,
+                    "saved": true,
+                    "applied": false,
+                    "message": "Saved to config.toml. Settings will not take effect on the \
+                                device until you run: supply-drop-bbs node set-meshtastic-owner \
+                                (while the BBS is stopped).",
+                }))
+                .into_response()
+            } else {
+                (
+                    StatusCode::SERVICE_UNAVAILABLE,
+                    Json(json_error(
+                        "Meshtastic transport not connected and no config path configured",
+                    )),
+                )
+                    .into_response()
+            }
+        }
         Err(e) => (
             StatusCode::INTERNAL_SERVER_ERROR,
             Json(json_error(&format!("{e}"))),

--- a/crates/bbs-web/src/lib.rs
+++ b/crates/bbs-web/src/lib.rs
@@ -2771,9 +2771,9 @@ async fn api_patch_meshtastic_radio_config(
                     "ok": true,
                     "saved": true,
                     "applied": false,
-                    "message": "Saved to config.toml. Settings will not take effect on the \
-                                device until you run: supply-drop-bbs node set-meshtastic-radio \
-                                (while the BBS is stopped).",
+                    "message": "Saved to config.toml. The device is not connected right now; \
+                                these settings will be applied automatically the next time the \
+                                BBS connects to it.",
                 }))
                 .into_response()
             } else {
@@ -2862,9 +2862,9 @@ async fn api_patch_meshtastic_owner(
                     "ok": true,
                     "saved": true,
                     "applied": false,
-                    "message": "Saved to config.toml. Settings will not take effect on the \
-                                device until you run: supply-drop-bbs node set-meshtastic-owner \
-                                (while the BBS is stopped).",
+                    "message": "Saved to config.toml. The device is not connected right now; \
+                                this name will be applied automatically the next time the BBS \
+                                connects to it.",
                 }))
                 .into_response()
             } else {

--- a/crates/bbs-web/src/lib.rs
+++ b/crates/bbs-web/src/lib.rs
@@ -563,6 +563,11 @@ fn build_router(state: Arc<AppState>) -> Router {
             "/meshtastic-radio-config",
             get(api_get_meshtastic_radio_config).patch(api_patch_meshtastic_radio_config),
         )
+        .route(
+            "/meshtastic-owner",
+            get(api_get_meshtastic_owner).patch(api_patch_meshtastic_owner),
+        )
+        .route("/meshtastic-security", get(api_get_meshtastic_security))
         .route("/node-identity", get(api_get_node_identity))
         .route("/node-identity/export-key", post(api_export_node_key))
         .route("/node-identity/import-key", post(api_import_node_key))
@@ -2595,6 +2600,87 @@ async fn api_patch_meshtastic_radio_config(
     match state.host.admin_set_meshtastic_lora(config).await {
         Ok(()) => Json(serde_json::json!({ "ok": true })).into_response(),
         Err(HostError::NotSupported(_)) | Err(HostError::Internal(_)) => (
+            StatusCode::SERVICE_UNAVAILABLE,
+            Json(json_error("Meshtastic transport not connected")),
+        )
+            .into_response(),
+        Err(e) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(json_error(&format!("{e}"))),
+        )
+            .into_response(),
+    }
+}
+
+// ── Meshtastic owner / user info ──────────────────────────────────────────────
+
+#[derive(Debug, Deserialize)]
+struct PatchMeshtasticOwnerBody {
+    long_name: Option<String>,
+    short_name: Option<String>,
+}
+
+async fn api_get_meshtastic_owner(
+    State(state): State<Arc<AppState>>,
+    Extension(user): Extension<CurrentUser>,
+) -> Response {
+    if user.permission_level < 100 {
+        return (StatusCode::FORBIDDEN, Json(json_error("sysop required"))).into_response();
+    }
+    match state.host.admin_get_meshtastic_owner().await {
+        Ok(info) => Json(info).into_response(),
+        Err(HostError::NotSupported(_)) => (
+            StatusCode::SERVICE_UNAVAILABLE,
+            Json(json_error("Meshtastic transport not connected")),
+        )
+            .into_response(),
+        Err(e) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(json_error(&format!("{e}"))),
+        )
+            .into_response(),
+    }
+}
+
+async fn api_patch_meshtastic_owner(
+    State(state): State<Arc<AppState>>,
+    Extension(user): Extension<CurrentUser>,
+    Json(body): Json<PatchMeshtasticOwnerBody>,
+) -> Response {
+    if user.permission_level < 100 {
+        return (StatusCode::FORBIDDEN, Json(json_error("sysop required"))).into_response();
+    }
+    match state
+        .host
+        .admin_set_meshtastic_owner(body.long_name, body.short_name)
+        .await
+    {
+        Ok(()) => Json(serde_json::json!({ "ok": true })).into_response(),
+        Err(HostError::NotSupported(_)) => (
+            StatusCode::SERVICE_UNAVAILABLE,
+            Json(json_error("Meshtastic transport not connected")),
+        )
+            .into_response(),
+        Err(e) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(json_error(&format!("{e}"))),
+        )
+            .into_response(),
+    }
+}
+
+// ── Meshtastic security / PKC info ────────────────────────────────────────────
+
+async fn api_get_meshtastic_security(
+    State(state): State<Arc<AppState>>,
+    Extension(user): Extension<CurrentUser>,
+) -> Response {
+    if user.permission_level < 100 {
+        return (StatusCode::FORBIDDEN, Json(json_error("sysop required"))).into_response();
+    }
+    match state.host.admin_get_meshtastic_security().await {
+        Ok(info) => Json(info).into_response(),
+        Err(HostError::NotSupported(_)) => (
             StatusCode::SERVICE_UNAVAILABLE,
             Json(json_error("Meshtastic transport not connected")),
         )

--- a/crates/bbs-web/web/src/pages/AdvertsPage.vue
+++ b/crates/bbs-web/web/src/pages/AdvertsPage.vue
@@ -88,6 +88,25 @@ const groups = computed(() => {
   return m
 })
 
+// ── Transport / type filters ────────────────────────────────────────────────
+const filterTransport = ref('')
+const filterType = ref('')
+
+const transportOptions = computed(() =>
+  [...new Set(rows.value.map((r) => r.transport).filter(Boolean))].sort(),
+)
+const typeOptions = computed(() =>
+  [...new Set(rows.value.map((r) => r.type_name).filter(Boolean))].sort(),
+)
+
+const filteredRows = computed(() =>
+  rows.value.filter(
+    (r) =>
+      (!filterTransport.value || r.transport === filterTransport.value) &&
+      (!filterType.value || r.type_name === filterType.value),
+  ),
+)
+
 onMounted(() => {
   load()
   timer = window.setInterval(load, 5000)
@@ -155,11 +174,35 @@ const columns = [
       </span>
     </p>
 
+    <!-- Transport / type filters -->
+    <div class="advert-filters">
+      <label>
+        transport
+        <select v-model="filterTransport">
+          <option value="">all</option>
+          <option v-for="t in transportOptions" :key="t" :value="t">{{ t }}</option>
+        </select>
+      </label>
+      <label>
+        type
+        <select v-model="filterType">
+          <option value="">all</option>
+          <option v-for="t in typeOptions" :key="t" :value="t">{{ t }}</option>
+        </select>
+      </label>
+      <button
+        v-if="filterTransport || filterType"
+        type="button"
+        class="link-btn"
+        @click="filterTransport = ''; filterType = ''"
+      >clear filters</button>
+    </div>
+
     <p v-if="error" class="error">{{ error }}</p>
 
     <DataTable
       :columns="columns"
-      :rows="rows"
+      :rows="filteredRows"
       :row-key="(r) => `${r.ts}-${r.pubkey}`"
       :page-size="50"
       empty="No adverts heard yet (is mesh transport enabled and connected?)."
@@ -204,7 +247,29 @@ h1 { margin: 0; }
 .status-line { margin: 0; padding: 0.25rem 0.5rem; border-radius: 3px; }
 .status-line.ok    { color: #2a8a2a; border: 1px solid #2a8a2a; background: rgba(42,138,42,0.08); }
 .status-line.error { color: var(--error); border: 1px solid var(--error); background: rgba(200,60,60,0.08); }
-.btn-danger { color: var(--error); border-color: var(--error); }
+.btn-danger {
+  background: var(--error);
+  color: #fff;
+  border-color: var(--error);
+}
+.btn-danger:hover:not(:disabled) { filter: brightness(1.08); }
+.btn-danger:disabled { opacity: 0.5; }
+
+.advert-filters {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  flex-wrap: wrap;
+  font-size: 0.85em;
+  color: var(--muted);
+}
+.advert-filters label { display: flex; align-items: center; gap: 0.4rem; }
+.advert-filters select { font: inherit; padding: 0.15rem 0.3rem; }
+.link-btn {
+  background: none; border: none; padding: 0;
+  color: var(--accent, #4a90d9); cursor: pointer; font: inherit;
+  text-decoration: underline;
+}
 
 .type-summary { margin: 0; display: flex; flex-wrap: wrap; gap: 0.4rem; }
 
@@ -217,6 +282,17 @@ h1 { margin: 0; }
 .badge.type-room     { background: #f0e2c2; color: #604010; }
 .badge.type-sensor   { background: #f0d2d2; color: #602020; }
 .badge.type-unknown  { background: var(--row-alt); color: var(--muted); }
+/* Meshtastic device roles */
+.badge.type-client        { background: #d2efd2; color: #205020; }
+.badge.type-client_mute   { background: #e0e8d2; color: #404f20; }
+.badge.type-client_hidden { background: var(--row-alt); color: var(--muted); }
+.badge.type-router        { background: #d2dff0; color: #203560; }
+.badge.type-router_client { background: #d2dff0; color: #203560; }
+.badge.type-router_late   { background: #d2dff0; color: #203560; }
+.badge.type-tracker       { background: #e2d2f0; color: #402060; }
+.badge.type-tak           { background: #f0e2c2; color: #604010; }
+.badge.type-tak_tracker   { background: #f0e2c2; color: #604010; }
+.badge.type-lost_and_found { background: #f0d2d2; color: #602020; }
 .badge.transport-meshcore   { background: #d2dff0; color: #203560; }
 .badge.transport-meshtastic { background: #e2d2f0; color: #402060; }
 </style>

--- a/crates/bbs-web/web/src/pages/AdvertsPage.vue
+++ b/crates/bbs-web/web/src/pages/AdvertsPage.vue
@@ -13,6 +13,7 @@ interface Advert {
   type_name: string
   lat: number
   lon: number
+  transport: string
 }
 
 const auth = useAuthStore()
@@ -96,6 +97,7 @@ onUnmounted(() => { if (timer !== undefined) window.clearInterval(timer) })
 const columns = [
   { key: 'ts', label: 'last seen' },
   { key: 'name', label: 'name' },
+  { key: 'transport', label: 'transport' },
   { key: 'type_name', label: 'type' },
   { key: 'pubkey', label: 'pubkey' },
   { key: 'location', label: 'location' },
@@ -163,6 +165,10 @@ const columns = [
       empty="No adverts heard yet (is mesh transport enabled and connected?)."
     >
       <template #[`cell:ts`]="{ row }">{{ fmtLocal(row.ts) }}</template>
+      <template #[`cell:transport`]="{ row }">
+        <span v-if="row.transport" class="badge" :class="`transport-${row.transport}`">{{ row.transport }}</span>
+        <span v-else class="muted">—</span>
+      </template>
       <template #[`cell:type_name`]="{ row }">
         <span class="badge" :class="`type-${row.type_name}`">{{ row.type_name }}</span>
       </template>
@@ -211,4 +217,6 @@ h1 { margin: 0; }
 .badge.type-room     { background: #f0e2c2; color: #604010; }
 .badge.type-sensor   { background: #f0d2d2; color: #602020; }
 .badge.type-unknown  { background: var(--row-alt); color: var(--muted); }
+.badge.transport-meshcore   { background: #d2dff0; color: #203560; }
+.badge.transport-meshtastic { background: #e2d2f0; color: #402060; }
 </style>

--- a/crates/bbs-web/web/src/pages/SettingsPage.vue
+++ b/crates/bbs-web/web/src/pages/SettingsPage.vue
@@ -502,6 +502,34 @@ const MESHTASTIC_PRESETS = [
   { value: 13, label: 'NARROW_SLOW — EU_868 62.5 kHz, ~LONG_FAST range' },
 ]
 
+// Region frequency ranges (MHz) and preset bandwidths (kHz), used to show the
+// frequency the device will operate on. Mirrors the Meshtastic firmware's
+// region table and modem-preset bandwidths.
+const MESHTASTIC_REGION_FREQ: Record<number, { start: number; end: number }> = {
+  1:  { start: 902.0,  end: 928.0 },   // US
+  2:  { start: 433.0,  end: 434.0 },   // EU_433
+  3:  { start: 869.4,  end: 869.65 },  // EU_868
+  4:  { start: 470.0,  end: 510.0 },   // CN
+  5:  { start: 920.8,  end: 927.8 },   // JP
+  6:  { start: 915.0,  end: 928.0 },   // ANZ
+  7:  { start: 920.0,  end: 923.0 },   // KR
+  8:  { start: 920.0,  end: 925.0 },   // TW
+  9:  { start: 868.7,  end: 869.2 },   // RU
+  10: { start: 865.0,  end: 867.0 },   // IN
+  11: { start: 864.0,  end: 868.0 },   // NZ_865
+  12: { start: 920.0,  end: 925.0 },   // TH
+  13: { start: 2400.0, end: 2483.5 },  // LORA_24
+  14: { start: 433.0,  end: 434.7 },   // UA_433
+  15: { start: 868.0,  end: 868.6 },   // UA_868
+  16: { start: 433.0,  end: 435.0 },   // MY_433
+  17: { start: 919.0,  end: 924.0 },   // MY_919
+  18: { start: 917.0,  end: 925.0 },   // SG_923
+}
+const MESHTASTIC_PRESET_BW_KHZ: Record<number, number> = {
+  0: 250, 1: 125, 3: 250, 4: 250, 5: 250, 6: 250,
+  7: 125, 8: 500, 9: 500, 10: 250, 11: 250, 12: 62.5, 13: 62.5,
+}
+
 // ── Meshtastic radio ──────────────────────────────────────────────────────────
 
 const meshtasticRadioLoading = ref(false)
@@ -524,6 +552,18 @@ const meshtasticOverrideFrequency = ref(0)
 const meshtasticRxBoostedGain = ref(true)
 const meshtasticIgnoreMqtt = ref(true)
 
+// Frequency (MHz) the device will use, derived from region + preset + channel
+// slot. Channel slot is the configured channel_num (1-based; 0 = device auto-
+// selects slot 1 by default, or a slot hashed from the channel name).
+const meshtasticDerivedFreq = computed<number | null>(() => {
+  const r = MESHTASTIC_REGION_FREQ[meshtasticRegion.value]
+  if (!r) return null
+  const bw = MESHTASTIC_PRESET_BW_KHZ[meshtasticModemPreset.value] ?? 250
+  const slot = meshtasticChannelNum.value > 0 ? meshtasticChannelNum.value - 1 : 0
+  const freq = r.start + bw / 2000 + slot * (bw / 1000)
+  return Math.round(freq * 1000) / 1000
+})
+
 function applyMeshtasticRadioFields(r: any) {
   meshtasticUsePreset.value         = r.use_preset ?? false
   meshtasticModemPreset.value       = r.modem_preset ?? 0
@@ -541,16 +581,20 @@ function applyMeshtasticRadioFields(r: any) {
   meshtasticIgnoreMqtt.value        = r.ignore_mqtt ?? true
 }
 
-async function loadMeshtasticRadio() {
+async function loadMeshtasticRadio(opts: { silent?: boolean } = {}) {
   meshtasticRadioLoading.value = true
   meshtasticRadioError.value = null
   meshtasticRadioOk.value = null
   try {
     const r = await api.get<any>('/api/v1/meshtastic-radio-config')
     applyMeshtasticRadioFields(r)
-    meshtasticRadioOk.value = 'Loaded from device.'
+    if (!opts.silent) meshtasticRadioOk.value = 'Loaded from device.'
   } catch (e: any) {
-    meshtasticRadioError.value = e?.message ?? 'failed to load meshtastic radio config'
+    // On the silent mount-time load, stay quiet when the transport isn't
+    // connected — the user can hit "load from device" explicitly.
+    if (!opts.silent) {
+      meshtasticRadioError.value = e?.message ?? 'failed to load meshtastic radio config'
+    }
   } finally {
     meshtasticRadioLoading.value = false
   }
@@ -562,7 +606,8 @@ async function saveMeshtasticRadio() {
   meshtasticRadioOk.value = null
   try {
     const res = await api.patch<any>('/api/v1/meshtastic-radio-config', {
-      use_preset:         meshtasticUsePreset.value,
+      // We always operate in preset mode; bandwidth/SF/CR are preset-derived.
+      use_preset:         true,
       modem_preset:       meshtasticModemPreset.value,
       bandwidth:          meshtasticBandwidth.value,
       spread_factor:      meshtasticSpreadFactor.value,
@@ -776,12 +821,25 @@ function copyToClipboard(text: string) {
   navigator.clipboard.writeText(text).catch(() => {})
 }
 
+// Which settings tab is visible. Sections are grouped by area so the two
+// MeshCore pieces (radio + identity) and the two Meshtastic pieces (radio +
+// device) live together instead of being interleaved.
+type SettingsTab = 'general' | 'meshcore' | 'meshtastic' | 'system'
+const settingsTab = ref<SettingsTab>('general')
+const SETTINGS_TABS: { id: SettingsTab; label: string }[] = [
+  { id: 'general', label: 'General' },
+  { id: 'meshcore', label: 'MeshCore' },
+  { id: 'meshtastic', label: 'Meshtastic' },
+  { id: 'system', label: 'System' },
+]
+
 onMounted(() => {
   load()
   loadRooms()
   loadAccessPolicy()
   loadRadioConfig()
   loadNodeIdentity()
+  loadMeshtasticRadio({ silent: true })
 })
 </script>
 
@@ -814,10 +872,24 @@ chmod g+w {{ configFile }}</pre>
     <div v-if="saveOk" class="notice ok-notice">{{ saveOk }}</div>
     <div v-if="saveError" class="notice error-notice">{{ saveError }}</div>
 
+    <nav v-if="!loadError" class="settings-tabs" role="tablist">
+      <button
+        v-for="t in SETTINGS_TABS"
+        :key="t.id"
+        type="button"
+        role="tab"
+        :class="{ active: settingsTab === t.id }"
+        :aria-selected="settingsTab === t.id"
+        @click="settingsTab = t.id"
+      >
+        {{ t.label }}
+      </button>
+    </nav>
+
     <form v-if="!loadError" @submit.prevent="save" class="settings-form" novalidate>
 
       <!-- BBS Identity -->
-      <section class="card">
+      <section v-show="settingsTab === 'general'" class="card">
         <h2>BBS identity</h2>
 
         <div class="field" :class="{ 'has-error': validationErrors.bbs_name }">
@@ -868,7 +940,7 @@ chmod g+w {{ configFile }}</pre>
       </section>
 
       <!-- GPS location -->
-      <section class="card">
+      <section v-show="settingsTab === 'general'" class="card">
         <h2>GPS location</h2>
         <p class="hint">
           When set, the mesh transport sends your coordinates to the radio on connect so your
@@ -898,7 +970,7 @@ chmod g+w {{ configFile }}</pre>
       </section>
 
       <!-- Backup -->
-      <section class="card">
+      <section v-show="settingsTab === 'system'" class="card">
         <h2>Automatic backups</h2>
         <div class="field checkbox-field">
           <label>
@@ -926,7 +998,7 @@ chmod g+w {{ configFile }}</pre>
       </section>
 
       <!-- Security -->
-      <section class="card">
+      <section v-show="settingsTab === 'system'" class="card">
         <h2>Security</h2>
         <div class="field-row">
           <div class="field" :class="{ 'has-error': validationErrors.security_session_web_hours }">
@@ -956,7 +1028,7 @@ chmod g+w {{ configFile }}</pre>
       </section>
 
       <!-- Logging -->
-      <section class="card">
+      <section v-show="settingsTab === 'system'" class="card">
         <h2>Logging</h2>
         <div class="field">
           <label>Log level</label>
@@ -967,16 +1039,8 @@ chmod g+w {{ configFile }}</pre>
         </div>
       </section>
 
-      <div class="actions">
-        <button type="submit" :disabled="saving || !writable || !isDirty || !isFormValid">
-          {{ saving ? 'saving…' : 'save settings' }}
-        </button>
-        <span v-if="!writable" class="hint">config file is not writable</span>
-        <span v-else-if="!isDirty" class="hint">no unsaved changes</span>
-      </div>
-
       <!-- Access policy -->
-      <section class="card">
+      <section v-show="settingsTab === 'general'" class="card">
         <h2>Access policy</h2>
         <p class="hint">
           Controls how new registrations are handled. Changes take effect
@@ -1037,7 +1101,7 @@ chmod g+w {{ configFile }}</pre>
       </section>
 
       <!-- MeshCore Radio — shown for all MeshCore connection types -->
-      <section v-if="radioConfig" class="card">
+      <section v-if="radioConfig" v-show="settingsTab === 'meshcore'" class="card">
         <h2>MeshCore radio</h2>
         <p class="hint">
           LoRa parameters for the MeshCore companion device.
@@ -1101,7 +1165,7 @@ chmod g+w {{ configFile }}</pre>
       </section>
 
       <!-- Meshtastic radio -->
-      <section class="card">
+      <section v-show="settingsTab === 'meshtastic'" class="card">
         <h2>Meshtastic radio</h2>
         <p class="hint">
           LoRa radio configuration for the connected Meshtastic device.
@@ -1124,43 +1188,42 @@ chmod g+w {{ configFile }}</pre>
           </div>
           <div class="field">
             <label>Modem preset</label>
-            <select v-model.number="meshtasticModemPreset" :disabled="meshtasticRadioLoading || !meshtasticUsePreset">
+            <select v-model.number="meshtasticModemPreset" :disabled="meshtasticRadioLoading">
               <option v-for="p in MESHTASTIC_PRESETS" :key="p.value" :value="p.value">
                 {{ p.label }}
               </option>
             </select>
-            <p class="hint">Only used when "Use preset" is enabled.</p>
+            <p class="hint">Bandwidth, spreading factor, and coding rate are set by the preset.</p>
           </div>
         </div>
-        <!-- Custom LoRa parameters — visible when not using preset -->
         <div class="field-row">
-          <div class="field">
-            <label>Spread factor</label>
-            <input v-model.number="meshtasticSpreadFactor" type="number" min="7" max="12" :disabled="meshtasticRadioLoading || meshtasticUsePreset" />
-          </div>
-          <div class="field">
-            <label>Bandwidth (kHz units)</label>
-            <input v-model.number="meshtasticBandwidth" type="number" min="0" :disabled="meshtasticRadioLoading || meshtasticUsePreset" />
-          </div>
           <div class="field">
             <label>TX power (dBm)</label>
             <input v-model.number="meshtasticTxPower" type="number" :disabled="meshtasticRadioLoading" />
           </div>
-        </div>
-        <div class="field-row">
           <div class="field">
             <label>Hop limit</label>
             <input v-model.number="meshtasticHopLimit" type="number" min="0" max="7" :disabled="meshtasticRadioLoading" />
           </div>
           <div class="field">
-            <label>Override frequency (MHz)</label>
-            <input v-model.number="meshtasticOverrideFrequency" type="number" step="0.001" :disabled="meshtasticRadioLoading" />
+            <label>Frequency (MHz)</label>
+            <input
+              v-model.number="meshtasticOverrideFrequency"
+              type="number"
+              step="0.001"
+              :placeholder="meshtasticDerivedFreq !== null ? String(meshtasticDerivedFreq) : ''"
+              :disabled="meshtasticRadioLoading"
+            />
+            <p class="hint">
+              <template v-if="meshtasticDerivedFreq !== null">
+                Region/preset default: <strong>{{ meshtasticDerivedFreq }} MHz</strong>.
+              </template>
+              Leave 0 to use the default; enter a value to override.
+            </p>
           </div>
-          <div class="field" style="display:flex;flex-direction:column;gap:0.5rem;justify-content:flex-end;">
-            <label style="display:flex;align-items:center;gap:0.5rem;">
-              <input type="checkbox" v-model="meshtasticUsePreset" :disabled="meshtasticRadioLoading" />
-              Use preset
-            </label>
+        </div>
+        <div class="field-row">
+          <div class="field" style="display:flex;flex-direction:column;gap:0.5rem;">
             <label style="display:flex;align-items:center;gap:0.5rem;">
               <input type="checkbox" v-model="meshtasticTxEnabled" :disabled="meshtasticRadioLoading" />
               TX enabled
@@ -1177,7 +1240,7 @@ chmod g+w {{ configFile }}</pre>
         </div>
 
         <div class="actions">
-          <button type="button" :disabled="meshtasticRadioLoading" @click="loadMeshtasticRadio">
+          <button type="button" :disabled="meshtasticRadioLoading" @click="loadMeshtasticRadio()">
             {{ meshtasticRadioLoading ? 'loading…' : 'load from device' }}
           </button>
           <button type="button" :disabled="meshtasticRadioLoading || meshtasticRadioSaving" @click="saveMeshtasticRadio">
@@ -1187,7 +1250,7 @@ chmod g+w {{ configFile }}</pre>
       </section>
 
       <!-- Meshtastic device — owner info and PKC key -->
-      <section class="card">
+      <section v-show="settingsTab === 'meshtastic'" class="card">
         <h2>Meshtastic device <span class="badge">Meshtastic</span></h2>
         <p class="hint">
           Node identity and PKC (public-key cryptography) settings for the connected
@@ -1260,7 +1323,7 @@ chmod g+w {{ configFile }}</pre>
       </section>
 
       <!-- Node identity -->
-      <section class="card">
+      <section v-show="settingsTab === 'meshcore'" class="card">
         <h2>Node identity <span class="badge">MeshCore</span></h2>
         <p class="hint">
           The <strong>MeshCore</strong> companion device's identity keypair. The public key
@@ -1347,7 +1410,7 @@ chmod g+w {{ configFile }}</pre>
       </section>
 
       <!-- Service restart -->
-      <section class="card">
+      <section v-show="settingsTab === 'system'" class="card">
         <h2>Service</h2>
         <p class="hint">
           Restart the systemd service to apply config changes. The web UI will
@@ -1363,6 +1426,18 @@ chmod g+w {{ configFile }}</pre>
         </div>
       </section>
 
+      <!-- Global save for the config-file-backed settings (General + System). -->
+      <div
+        v-show="settingsTab === 'general' || settingsTab === 'system'"
+        class="actions save-actions"
+      >
+        <button type="submit" :disabled="saving || !writable || !isDirty || !isFormValid">
+          {{ saving ? 'saving…' : 'save settings' }}
+        </button>
+        <span v-if="!writable" class="hint">config file is not writable</span>
+        <span v-else-if="!isDirty" class="hint">no unsaved changes</span>
+      </div>
+
     </form>
   </div>
 </template>
@@ -1371,6 +1446,31 @@ chmod g+w {{ configFile }}</pre>
 .page { display: flex; flex-direction: column; gap: 1.2rem; }
 .page-header { display: flex; flex-direction: column; gap: 0.2rem; }
 h1 { margin: 0; }
+
+.settings-tabs {
+  display: flex;
+  gap: 0.25rem;
+  border-bottom: 1px solid var(--border);
+  flex-wrap: wrap;
+}
+.settings-tabs button {
+  appearance: none;
+  background: transparent;
+  border: none;
+  border-bottom: 2px solid transparent;
+  padding: 0.5rem 0.9rem;
+  font: inherit;
+  color: var(--muted);
+  cursor: pointer;
+  margin-bottom: -1px;
+}
+.settings-tabs button:hover { color: var(--fg); }
+.settings-tabs button.active {
+  color: var(--fg);
+  border-bottom-color: var(--accent, #4a90d9);
+  font-weight: 600;
+}
+.save-actions { position: sticky; bottom: 0; }
 h2 { margin: 0 0 1rem; font-size: 1em; text-transform: uppercase; letter-spacing: 0.06em; color: var(--muted); }
 .small { font-size: 0.85em; }
 p { margin: 0; }

--- a/crates/bbs-web/web/src/pages/SettingsPage.vue
+++ b/crates/bbs-web/web/src/pages/SettingsPage.vue
@@ -521,6 +521,8 @@ const meshtasticTxEnabled = ref(true)
 const meshtasticTxPower = ref(17)
 const meshtasticChannelNum = ref(0)
 const meshtasticOverrideFrequency = ref(0)
+const meshtasticRxBoostedGain = ref(true)
+const meshtasticIgnoreMqtt = ref(true)
 
 function applyMeshtasticRadioFields(r: any) {
   meshtasticUsePreset.value         = r.use_preset ?? false
@@ -535,6 +537,8 @@ function applyMeshtasticRadioFields(r: any) {
   meshtasticTxPower.value           = r.tx_power ?? 17
   meshtasticChannelNum.value        = r.channel_num ?? 0
   meshtasticOverrideFrequency.value = r.override_frequency ?? 0
+  meshtasticRxBoostedGain.value     = r.sx126x_rx_boosted_gain ?? true
+  meshtasticIgnoreMqtt.value        = r.ignore_mqtt ?? true
 }
 
 async function loadMeshtasticRadio() {
@@ -570,6 +574,8 @@ async function saveMeshtasticRadio() {
       tx_power:           meshtasticTxPower.value,
       channel_num:        meshtasticChannelNum.value,
       override_frequency: meshtasticOverrideFrequency.value,
+      sx126x_rx_boosted_gain: meshtasticRxBoostedGain.value,
+      ignore_mqtt:        meshtasticIgnoreMqtt.value,
     })
     if (res?.applied === false) {
       meshtasticRadioOk.value = 'Saved. The device is not connected right now — these settings will be applied automatically the next time the BBS connects to it.'
@@ -1158,6 +1164,14 @@ chmod g+w {{ configFile }}</pre>
             <label style="display:flex;align-items:center;gap:0.5rem;">
               <input type="checkbox" v-model="meshtasticTxEnabled" :disabled="meshtasticRadioLoading" />
               TX enabled
+            </label>
+            <label style="display:flex;align-items:center;gap:0.5rem;">
+              <input type="checkbox" v-model="meshtasticRxBoostedGain" :disabled="meshtasticRadioLoading" />
+              RX boosted gain
+            </label>
+            <label style="display:flex;align-items:center;gap:0.5rem;">
+              <input type="checkbox" v-model="meshtasticIgnoreMqtt" :disabled="meshtasticRadioLoading" />
+              Ignore MQTT
             </label>
           </div>
         </div>

--- a/crates/bbs-web/web/src/pages/SettingsPage.vue
+++ b/crates/bbs-web/web/src/pages/SettingsPage.vue
@@ -430,11 +430,108 @@ async function saveRadioConfig() {
     }
     const updated = await api.patch<RadioConfigData>('/api/v1/radio-config', patch)
     radioConfig.value = updated
-    radioSaveOk.value = 'Radio config saved to config.toml. Run: sudo supply-drop-bbs node set-radio — to push to the device (only needed when parameters change).'
+    radioSaveOk.value = 'Radio config saved to config.toml.'
   } catch (e: any) {
     radioSaveError.value = e?.message ?? 'failed to save radio config'
   } finally {
     radioSaving.value = false
+  }
+}
+
+const radioApplying = ref(false)
+const radioApplyOk = ref<string | null>(null)
+const radioApplyError = ref<string | null>(null)
+
+async function applyRadioConfig() {
+  radioApplying.value  = true
+  radioApplyOk.value   = null
+  radioApplyError.value = null
+  try {
+    await api.post('/api/v1/radio-config/apply', {
+      frequency_hz:     radioFrequencyHz.value     ? parseInt(radioFrequencyHz.value, 10)     : 0,
+      bandwidth_hz:     radioBandwidthHz.value     ? parseInt(radioBandwidthHz.value, 10)     : 0,
+      spreading_factor: radioSpreadingFactor.value ? parseInt(radioSpreadingFactor.value, 10) : 0,
+      coding_rate:      radioCodingRate.value      ? parseInt(radioCodingRate.value, 10)      : 0,
+      tx_power_dbm:     radioTxPowerDbm.value      ? parseInt(radioTxPowerDbm.value, 10)      : 0,
+    })
+    radioApplyOk.value = 'Radio parameters applied to device.'
+  } catch (e: any) {
+    radioApplyError.value = e?.message ?? 'failed to apply radio config'
+  } finally {
+    radioApplying.value = false
+  }
+}
+
+// ── Meshtastic radio ──────────────────────────────────────────────────────────
+
+const meshtasticRadioLoading = ref(false)
+const meshtasticRadioSaving = ref(false)
+const meshtasticRadioError = ref<string | null>(null)
+const meshtasticRadioOk = ref<string | null>(null)
+
+const meshtasticUsePreset = ref(false)
+const meshtasticModemPreset = ref(0)
+const meshtasticBandwidth = ref(0)
+const meshtasticSpreadFactor = ref(11)
+const meshtasticCodingRate = ref(8)
+const meshtasticFrequencyOffset = ref(0)
+const meshtasticRegion = ref(0)
+const meshtasticHopLimit = ref(3)
+const meshtasticTxEnabled = ref(true)
+const meshtasticTxPower = ref(17)
+const meshtasticChannelNum = ref(0)
+const meshtasticOverrideFrequency = ref(0)
+
+async function loadMeshtasticRadio() {
+  meshtasticRadioLoading.value = true
+  meshtasticRadioError.value = null
+  meshtasticRadioOk.value = null
+  try {
+    const r = await api.get<any>('/api/v1/meshtastic-radio-config')
+    meshtasticUsePreset.value         = r.use_preset ?? false
+    meshtasticModemPreset.value       = r.modem_preset ?? 0
+    meshtasticBandwidth.value         = r.bandwidth ?? 0
+    meshtasticSpreadFactor.value      = r.spread_factor ?? 11
+    meshtasticCodingRate.value        = r.coding_rate ?? 8
+    meshtasticFrequencyOffset.value   = r.frequency_offset ?? 0
+    meshtasticRegion.value            = r.region ?? 0
+    meshtasticHopLimit.value          = r.hop_limit ?? 3
+    meshtasticTxEnabled.value         = r.tx_enabled ?? true
+    meshtasticTxPower.value           = r.tx_power ?? 17
+    meshtasticChannelNum.value        = r.channel_num ?? 0
+    meshtasticOverrideFrequency.value = r.override_frequency ?? 0
+    meshtasticRadioOk.value = 'Loaded from device.'
+  } catch (e: any) {
+    meshtasticRadioError.value = e?.message ?? 'failed to load meshtastic radio config'
+  } finally {
+    meshtasticRadioLoading.value = false
+  }
+}
+
+async function saveMeshtasticRadio() {
+  meshtasticRadioSaving.value = true
+  meshtasticRadioError.value = null
+  meshtasticRadioOk.value = null
+  try {
+    await api.patch('/api/v1/meshtastic-radio-config', {
+      use_preset:         meshtasticUsePreset.value,
+      modem_preset:       meshtasticModemPreset.value,
+      bandwidth:          meshtasticBandwidth.value,
+      spread_factor:      meshtasticSpreadFactor.value,
+      coding_rate:        meshtasticCodingRate.value,
+      frequency_offset:   meshtasticFrequencyOffset.value,
+      region:             meshtasticRegion.value,
+      hop_limit:          meshtasticHopLimit.value,
+      tx_enabled:         meshtasticTxEnabled.value,
+      tx_power:           meshtasticTxPower.value,
+      channel_num:        meshtasticChannelNum.value,
+      override_frequency: meshtasticOverrideFrequency.value,
+    })
+    meshtasticRadioOk.value = 'Radio config saved to device.'
+  } catch (e: any) {
+    meshtasticRadioError.value = e?.message ?? 'failed to save meshtastic radio config'
+  } finally {
+    meshtasticRadioSaving.value = false
   }
 }
 
@@ -799,24 +896,21 @@ chmod g+w {{ configFile }}</pre>
         </div>
       </section>
 
-      <!-- MeshCore Radio — USB serial only -->
-      <!-- Pi HAT and TCP connections have their radio managed by pymc-companion;
-           node set-radio speaks directly to the USB serial device and is not
-           applicable to those connection types. -->
-      <section v-if="radioConfig?.connection_type === 'serial'" class="card">
+      <!-- MeshCore Radio — shown for all MeshCore connection types -->
+      <section v-if="radioConfig" class="card">
         <h2>MeshCore radio</h2>
         <p class="hint">
-          LoRa parameters for the USB MeshCore companion device
-          <span v-if="radioConfig.serial_port">(<code>{{ radioConfig.serial_port }}</code>)</span>.
-          Save here to record them in config.toml, then push to the device once with
-          <code>sudo supply-drop-bbs node set-radio</code>.
-          The device stores these settings in its own flash — you only need to run that
-          command when you change the parameters, not on every restart.
+          LoRa parameters for the MeshCore companion device.
+          Save here to record them in config.toml. Use <strong>Apply to device</strong>
+          to push the current values directly to the live companion device over the
+          existing connection.
         </p>
 
         <div v-if="radioError" class="notice error-notice">{{ radioError }}</div>
         <div v-if="radioSaveOk" class="notice ok-notice">{{ radioSaveOk }}</div>
         <div v-if="radioSaveError" class="notice error-notice">{{ radioSaveError }}</div>
+        <div v-if="radioApplyOk" class="notice ok-notice">{{ radioApplyOk }}</div>
+        <div v-if="radioApplyError" class="notice error-notice">{{ radioApplyError }}</div>
 
         <div class="field">
           <label>Region preset</label>
@@ -859,7 +953,80 @@ chmod g+w {{ configFile }}</pre>
           <button type="button" :disabled="radioSaving || radioLoading || !writable" @click="saveRadioConfig">
             {{ radioSaving ? 'saving…' : 'save radio config' }}
           </button>
+          <button type="button" :disabled="radioApplying || radioLoading || !radioConfig" @click="applyRadioConfig">
+            {{ radioApplying ? 'applying…' : 'apply to device' }}
+          </button>
           <span v-if="!writable" class="hint">config file is not writable</span>
+        </div>
+      </section>
+
+      <!-- Meshtastic radio -->
+      <section class="card">
+        <h2>Meshtastic radio</h2>
+        <p class="hint">
+          LoRa radio configuration for the connected Meshtastic device.
+          Use <strong>Load from device</strong> to read the current settings,
+          edit them, then <strong>Save to device</strong> to push them back.
+        </p>
+
+        <div v-if="meshtasticRadioError" class="notice error-notice">{{ meshtasticRadioError }}</div>
+        <div v-if="meshtasticRadioOk" class="notice ok-notice">{{ meshtasticRadioOk }}</div>
+
+        <div class="field-row">
+          <div class="field">
+            <label>Spread factor</label>
+            <input v-model.number="meshtasticSpreadFactor" type="number" min="7" max="12" :disabled="meshtasticRadioLoading" />
+          </div>
+          <div class="field">
+            <label>Bandwidth</label>
+            <input v-model.number="meshtasticBandwidth" type="number" min="0" :disabled="meshtasticRadioLoading" />
+          </div>
+          <div class="field">
+            <label>TX power (dBm)</label>
+            <input v-model.number="meshtasticTxPower" type="number" :disabled="meshtasticRadioLoading" />
+          </div>
+        </div>
+        <div class="field-row">
+          <div class="field">
+            <label>Region</label>
+            <input v-model.number="meshtasticRegion" type="number" min="0" :disabled="meshtasticRadioLoading" />
+            <p class="hint">Meshtastic region enum value</p>
+          </div>
+          <div class="field">
+            <label>Hop limit</label>
+            <input v-model.number="meshtasticHopLimit" type="number" min="0" max="7" :disabled="meshtasticRadioLoading" />
+          </div>
+          <div class="field">
+            <label>Modem preset</label>
+            <input v-model.number="meshtasticModemPreset" type="number" min="0" :disabled="meshtasticRadioLoading || meshtasticUsePreset" />
+          </div>
+        </div>
+        <div class="field-row">
+          <div class="field">
+            <label>Override frequency (MHz)</label>
+            <input v-model.number="meshtasticOverrideFrequency" type="number" step="0.001" :disabled="meshtasticRadioLoading" />
+          </div>
+          <div class="field">
+            <label style="display:flex;align-items:center;gap:0.5rem;">
+              <input type="checkbox" v-model="meshtasticUsePreset" :disabled="meshtasticRadioLoading" />
+              Use preset
+            </label>
+          </div>
+          <div class="field">
+            <label style="display:flex;align-items:center;gap:0.5rem;">
+              <input type="checkbox" v-model="meshtasticTxEnabled" :disabled="meshtasticRadioLoading" />
+              TX enabled
+            </label>
+          </div>
+        </div>
+
+        <div class="actions">
+          <button type="button" :disabled="meshtasticRadioLoading" @click="loadMeshtasticRadio">
+            {{ meshtasticRadioLoading ? 'loading…' : 'load from device' }}
+          </button>
+          <button type="button" :disabled="meshtasticRadioLoading || meshtasticRadioSaving" @click="saveMeshtasticRadio">
+            {{ meshtasticRadioSaving ? 'saving…' : 'save to device' }}
+          </button>
         </div>
       </section>
 

--- a/crates/bbs-web/web/src/pages/SettingsPage.vue
+++ b/crates/bbs-web/web/src/pages/SettingsPage.vue
@@ -522,24 +522,28 @@ const meshtasticTxPower = ref(17)
 const meshtasticChannelNum = ref(0)
 const meshtasticOverrideFrequency = ref(0)
 
+function applyMeshtasticRadioFields(r: any) {
+  meshtasticUsePreset.value         = r.use_preset ?? false
+  meshtasticModemPreset.value       = r.modem_preset ?? 0
+  meshtasticBandwidth.value         = r.bandwidth ?? 0
+  meshtasticSpreadFactor.value      = r.spread_factor ?? 11
+  meshtasticCodingRate.value        = r.coding_rate ?? 8
+  meshtasticFrequencyOffset.value   = r.frequency_offset ?? 0
+  meshtasticRegion.value            = r.region ?? 0
+  meshtasticHopLimit.value          = r.hop_limit ?? 3
+  meshtasticTxEnabled.value         = r.tx_enabled ?? true
+  meshtasticTxPower.value           = r.tx_power ?? 17
+  meshtasticChannelNum.value        = r.channel_num ?? 0
+  meshtasticOverrideFrequency.value = r.override_frequency ?? 0
+}
+
 async function loadMeshtasticRadio() {
   meshtasticRadioLoading.value = true
   meshtasticRadioError.value = null
   meshtasticRadioOk.value = null
   try {
     const r = await api.get<any>('/api/v1/meshtastic-radio-config')
-    meshtasticUsePreset.value         = r.use_preset ?? false
-    meshtasticModemPreset.value       = r.modem_preset ?? 0
-    meshtasticBandwidth.value         = r.bandwidth ?? 0
-    meshtasticSpreadFactor.value      = r.spread_factor ?? 11
-    meshtasticCodingRate.value        = r.coding_rate ?? 8
-    meshtasticFrequencyOffset.value   = r.frequency_offset ?? 0
-    meshtasticRegion.value            = r.region ?? 0
-    meshtasticHopLimit.value          = r.hop_limit ?? 3
-    meshtasticTxEnabled.value         = r.tx_enabled ?? true
-    meshtasticTxPower.value           = r.tx_power ?? 17
-    meshtasticChannelNum.value        = r.channel_num ?? 0
-    meshtasticOverrideFrequency.value = r.override_frequency ?? 0
+    applyMeshtasticRadioFields(r)
     meshtasticRadioOk.value = 'Loaded from device.'
   } catch (e: any) {
     meshtasticRadioError.value = e?.message ?? 'failed to load meshtastic radio config'
@@ -567,10 +571,14 @@ async function saveMeshtasticRadio() {
       channel_num:        meshtasticChannelNum.value,
       override_frequency: meshtasticOverrideFrequency.value,
     })
-    if (res?.applied === false && res?.saved) {
+    if (res?.applied === false) {
       meshtasticRadioOk.value = 'Saved. The device is not connected right now — these settings will be applied automatically the next time the BBS connects to it.'
+    } else if (res?.confirmed && res?.device_config) {
+      // Update the form to reflect the device's actual current values.
+      applyMeshtasticRadioFields(res.device_config)
+      meshtasticRadioOk.value = 'Applied — confirmed on device.'
     } else {
-      meshtasticRadioOk.value = 'Radio config saved and applied to device.'
+      meshtasticRadioOk.value = res?.message ?? 'Settings sent — use "Load from device" shortly to confirm.'
     }
   } catch (e: any) {
     meshtasticRadioError.value = e?.message ?? 'failed to save meshtastic radio config'
@@ -631,11 +639,15 @@ async function saveMeshtasticOwner() {
       long_name: meshtasticLongName.value || null,
       short_name: meshtasticShortName.value || null,
     })
-    if (res?.applied === false && res?.saved) {
+    if (res?.applied === false) {
       meshtasticOwnerOk.value = 'Saved. The device is not connected right now — this name will be applied automatically the next time the BBS connects to it.'
+    } else if (res?.confirmed && res?.device_owner) {
+      meshtasticOwner.value = res.device_owner
+      meshtasticLongName.value = res.device_owner.long_name
+      meshtasticShortName.value = res.device_owner.short_name
+      meshtasticOwnerOk.value = 'Applied — confirmed on device.'
     } else {
-      meshtasticOwnerOk.value = 'Node name saved and applied to device.'
-      await loadMeshtasticOwner()
+      meshtasticOwnerOk.value = res?.message ?? 'Name sent — use "Load from device" shortly to confirm.'
     }
   } catch (e: any) {
     meshtasticOwnerError.value = e?.message ?? 'failed to save device owner info'

--- a/crates/bbs-web/web/src/pages/SettingsPage.vue
+++ b/crates/bbs-web/web/src/pages/SettingsPage.vue
@@ -773,6 +773,24 @@ async function refreshMeshtasticDevice() {
   }
 }
 
+// Reboot the radio (forces a boot-time NodeInfo broadcast so neighbours
+// re-acquire the node). The device drops off for ~30s.
+const meshtasticRebooting = ref(false)
+const meshtasticRebootMsg = ref<string | null>(null)
+async function rebootMeshtasticRadio() {
+  if (!confirm('Reboot the Meshtastic radio? It drops off the mesh for ~30s, then re-announces itself to neighbours on boot.')) return
+  meshtasticRebooting.value = true
+  meshtasticRebootMsg.value = null
+  try {
+    const res = await api.post<any>('/api/v1/meshtastic-reboot', {})
+    meshtasticRebootMsg.value = res?.message ?? 'Reboot requested.'
+  } catch (e: any) {
+    meshtasticRebootMsg.value = e?.message ?? 'failed to reboot radio'
+  } finally {
+    meshtasticRebooting.value = false
+  }
+}
+
 // ── Node identity ─────────────────────────────────────────────────────────────
 
 interface NodeIdentityData {
@@ -1369,6 +1387,19 @@ chmod g+w {{ configFile }}</pre>
         </div>
         <div v-else class="muted" style="margin:0.5rem 0;">
           {{ meshtasticSecurityLoading ? 'Loading…' : 'Not available — device not connected, or use "Refresh from device" above.' }}
+        </div>
+
+        <h3 style="margin: 1.5rem 0 0.5rem">Re-announce</h3>
+        <p class="hint">
+          Reboot the radio to force a fresh NodeInfo broadcast so neighbouring nodes
+          re-acquire this BBS. Use this if the BBS disappears from another node's list.
+          The radio also re-announces automatically about once an hour.
+        </p>
+        <div v-if="meshtasticRebootMsg" class="notice ok-notice">{{ meshtasticRebootMsg }}</div>
+        <div class="actions" style="margin-top:0.5rem;">
+          <button type="button" class="secondary" :disabled="meshtasticRebooting" @click="rebootMeshtasticRadio">
+            {{ meshtasticRebooting ? 'rebooting…' : 'reboot radio (re-announce)' }}
+          </button>
         </div>
       </section>
 

--- a/crates/bbs-web/web/src/pages/SettingsPage.vue
+++ b/crates/bbs-web/web/src/pages/SettingsPage.vue
@@ -462,6 +462,46 @@ async function applyRadioConfig() {
   }
 }
 
+// ── Meshtastic region / modem preset constants ────────────────────────────────
+
+const MESHTASTIC_REGIONS = [
+  { value: 0,  label: 'UNSET — not configured' },
+  { value: 1,  label: 'US — United States (902–928 MHz)' },
+  { value: 2,  label: 'EU_433 — Europe 433 MHz' },
+  { value: 3,  label: 'EU_868 — Europe 868 MHz' },
+  { value: 4,  label: 'CN — China 470–510 MHz' },
+  { value: 5,  label: 'JP — Japan 920–923 MHz' },
+  { value: 6,  label: 'ANZ — Australia/New Zealand 915–928 MHz' },
+  { value: 7,  label: 'KR — South Korea 920–923 MHz' },
+  { value: 8,  label: 'TW — Taiwan 920–925 MHz' },
+  { value: 9,  label: 'RU — Russia 868 MHz' },
+  { value: 10, label: 'IN — India 865–867 MHz' },
+  { value: 11, label: 'NZ_865 — New Zealand 865 MHz' },
+  { value: 12, label: 'TH — Thailand 920–925 MHz' },
+  { value: 13, label: 'LORA_24 — 2.4 GHz (SX128x)' },
+  { value: 14, label: 'UA_433 — Ukraine 433 MHz' },
+  { value: 15, label: 'UA_868 — Ukraine 868 MHz' },
+  { value: 16, label: 'MY_433 — Malaysia 433 MHz' },
+  { value: 17, label: 'MY_919 — Malaysia 919 MHz' },
+  { value: 18, label: 'SG_923 — Singapore 923 MHz' },
+]
+
+const MESHTASTIC_PRESETS = [
+  { value: 0, label: 'LONG_FAST — long range, fast (default)' },
+  { value: 1, label: 'LONG_SLOW — long range, slow (deprecated in 2.7)' },
+  { value: 3, label: 'MEDIUM_SLOW — medium range, slow' },
+  { value: 4, label: 'MEDIUM_FAST — medium range, fast' },
+  { value: 5, label: 'SHORT_SLOW — short range, slow' },
+  { value: 6, label: 'SHORT_FAST — short range, fast' },
+  { value: 7, label: 'LONG_MODERATE — long range, moderate (125 kHz)' },
+  { value: 8, label: 'SHORT_TURBO — fastest (500 kHz, not legal everywhere)' },
+  { value: 9, label: 'LONG_TURBO — long range, 500 kHz' },
+  { value: 10, label: 'LITE_FAST — EU_866 compliant, ~MEDIUM_FAST range' },
+  { value: 11, label: 'LITE_SLOW — EU_866 compliant, ~LONG_FAST range' },
+  { value: 12, label: 'NARROW_FAST — EU_868 62.5 kHz, ~SHORT_SLOW range' },
+  { value: 13, label: 'NARROW_SLOW — EU_868 62.5 kHz, ~LONG_FAST range' },
+]
+
 // ── Meshtastic radio ──────────────────────────────────────────────────────────
 
 const meshtasticRadioLoading = ref(false)
@@ -532,6 +572,80 @@ async function saveMeshtasticRadio() {
     meshtasticRadioError.value = e?.message ?? 'failed to save meshtastic radio config'
   } finally {
     meshtasticRadioSaving.value = false
+  }
+}
+
+// ── Meshtastic device (owner + security) ─────────────────────────────────────
+
+interface MeshtasticOwnerData {
+  id: string
+  long_name: string
+  short_name: string
+  public_key_hex: string
+}
+
+interface MeshtasticSecurityData {
+  public_key_hex: string
+  admin_channel_enabled: boolean
+}
+
+const meshtasticOwnerLoading = ref(false)
+const meshtasticOwnerSaving = ref(false)
+const meshtasticOwnerError = ref<string | null>(null)
+const meshtasticOwnerOk = ref<string | null>(null)
+const meshtasticOwner = ref<MeshtasticOwnerData | null>(null)
+const meshtasticLongName = ref('')
+const meshtasticShortName = ref('')
+
+const meshtasticSecurityLoading = ref(false)
+const meshtasticSecurityError = ref<string | null>(null)
+const meshtasticSecurity = ref<MeshtasticSecurityData | null>(null)
+
+async function loadMeshtasticOwner() {
+  meshtasticOwnerLoading.value = true
+  meshtasticOwnerError.value = null
+  meshtasticOwnerOk.value = null
+  try {
+    const r = await api.get<MeshtasticOwnerData>('/api/v1/meshtastic-owner')
+    meshtasticOwner.value = r
+    meshtasticLongName.value = r.long_name
+    meshtasticShortName.value = r.short_name
+    meshtasticOwnerOk.value = 'Loaded from device.'
+  } catch (e: any) {
+    meshtasticOwnerError.value = e?.message ?? 'failed to load device owner info'
+  } finally {
+    meshtasticOwnerLoading.value = false
+  }
+}
+
+async function saveMeshtasticOwner() {
+  meshtasticOwnerSaving.value = true
+  meshtasticOwnerError.value = null
+  meshtasticOwnerOk.value = null
+  try {
+    await api.patch('/api/v1/meshtastic-owner', {
+      long_name: meshtasticLongName.value || null,
+      short_name: meshtasticShortName.value || null,
+    })
+    meshtasticOwnerOk.value = 'Device owner info updated.'
+    await loadMeshtasticOwner()
+  } catch (e: any) {
+    meshtasticOwnerError.value = e?.message ?? 'failed to save device owner info'
+  } finally {
+    meshtasticOwnerSaving.value = false
+  }
+}
+
+async function loadMeshtasticSecurity() {
+  meshtasticSecurityLoading.value = true
+  meshtasticSecurityError.value = null
+  try {
+    const r = await api.get<MeshtasticSecurityData>('/api/v1/meshtastic-security')
+    meshtasticSecurity.value = r
+  } catch (e: any) {
+    meshtasticSecurityError.value = e?.message ?? 'failed to load security config'
+  } finally {
+    meshtasticSecurityLoading.value = false
   }
 }
 
@@ -972,14 +1086,35 @@ chmod g+w {{ configFile }}</pre>
         <div v-if="meshtasticRadioError" class="notice error-notice">{{ meshtasticRadioError }}</div>
         <div v-if="meshtasticRadioOk" class="notice ok-notice">{{ meshtasticRadioOk }}</div>
 
+        <!-- Region and modem preset — dropdowns -->
+        <div class="field-row">
+          <div class="field">
+            <label>Region</label>
+            <select v-model.number="meshtasticRegion" :disabled="meshtasticRadioLoading">
+              <option v-for="r in MESHTASTIC_REGIONS" :key="r.value" :value="r.value">
+                {{ r.label }}
+              </option>
+            </select>
+          </div>
+          <div class="field">
+            <label>Modem preset</label>
+            <select v-model.number="meshtasticModemPreset" :disabled="meshtasticRadioLoading || !meshtasticUsePreset">
+              <option v-for="p in MESHTASTIC_PRESETS" :key="p.value" :value="p.value">
+                {{ p.label }}
+              </option>
+            </select>
+            <p class="hint">Only used when "Use preset" is enabled.</p>
+          </div>
+        </div>
+        <!-- Custom LoRa parameters — visible when not using preset -->
         <div class="field-row">
           <div class="field">
             <label>Spread factor</label>
-            <input v-model.number="meshtasticSpreadFactor" type="number" min="7" max="12" :disabled="meshtasticRadioLoading" />
+            <input v-model.number="meshtasticSpreadFactor" type="number" min="7" max="12" :disabled="meshtasticRadioLoading || meshtasticUsePreset" />
           </div>
           <div class="field">
-            <label>Bandwidth</label>
-            <input v-model.number="meshtasticBandwidth" type="number" min="0" :disabled="meshtasticRadioLoading" />
+            <label>Bandwidth (kHz units)</label>
+            <input v-model.number="meshtasticBandwidth" type="number" min="0" :disabled="meshtasticRadioLoading || meshtasticUsePreset" />
           </div>
           <div class="field">
             <label>TX power (dBm)</label>
@@ -988,31 +1123,18 @@ chmod g+w {{ configFile }}</pre>
         </div>
         <div class="field-row">
           <div class="field">
-            <label>Region</label>
-            <input v-model.number="meshtasticRegion" type="number" min="0" :disabled="meshtasticRadioLoading" />
-            <p class="hint">Meshtastic region enum value</p>
-          </div>
-          <div class="field">
             <label>Hop limit</label>
             <input v-model.number="meshtasticHopLimit" type="number" min="0" max="7" :disabled="meshtasticRadioLoading" />
           </div>
           <div class="field">
-            <label>Modem preset</label>
-            <input v-model.number="meshtasticModemPreset" type="number" min="0" :disabled="meshtasticRadioLoading || meshtasticUsePreset" />
-          </div>
-        </div>
-        <div class="field-row">
-          <div class="field">
             <label>Override frequency (MHz)</label>
             <input v-model.number="meshtasticOverrideFrequency" type="number" step="0.001" :disabled="meshtasticRadioLoading" />
           </div>
-          <div class="field">
+          <div class="field" style="display:flex;flex-direction:column;gap:0.5rem;justify-content:flex-end;">
             <label style="display:flex;align-items:center;gap:0.5rem;">
               <input type="checkbox" v-model="meshtasticUsePreset" :disabled="meshtasticRadioLoading" />
               Use preset
             </label>
-          </div>
-          <div class="field">
             <label style="display:flex;align-items:center;gap:0.5rem;">
               <input type="checkbox" v-model="meshtasticTxEnabled" :disabled="meshtasticRadioLoading" />
               TX enabled
@@ -1030,15 +1152,89 @@ chmod g+w {{ configFile }}</pre>
         </div>
       </section>
 
+      <!-- Meshtastic device — owner info and PKC key -->
+      <section class="card">
+        <h2>Meshtastic device <span class="badge">Meshtastic</span></h2>
+        <p class="hint">
+          Node identity and PKC (public-key cryptography) settings for the connected
+          Meshtastic radio. The public key is derived from the device's private key and is
+          broadcast on the mesh so other nodes can send you encrypted direct messages.
+        </p>
+
+        <!-- Owner / node name -->
+        <h3 style="margin: 1rem 0 0.5rem">Node name</h3>
+        <div v-if="meshtasticOwnerError" class="notice error-notice">{{ meshtasticOwnerError }}</div>
+        <div v-if="meshtasticOwnerOk" class="notice ok-notice">{{ meshtasticOwnerOk }}</div>
+
+        <div v-if="meshtasticOwner" class="field-row">
+          <div class="field">
+            <label>Node ID</label>
+            <code style="display:block;padding:0.3rem 0;">{{ meshtasticOwner.id }}</code>
+          </div>
+          <div class="field">
+            <label>Long name</label>
+            <input v-model="meshtasticLongName" type="text" maxlength="39" :disabled="meshtasticOwnerLoading" />
+          </div>
+          <div class="field">
+            <label>Short name <span class="hint" style="display:inline">(≤ 4 chars)</span></label>
+            <input v-model="meshtasticShortName" type="text" maxlength="4" :disabled="meshtasticOwnerLoading" />
+          </div>
+        </div>
+        <div v-else class="muted" style="margin:0.5rem 0;">
+          {{ meshtasticOwnerLoading ? 'Loading…' : 'Not loaded — click "Load from device" to read.' }}
+        </div>
+
+        <div class="actions" style="margin-top:0.75rem;">
+          <button type="button" :disabled="meshtasticOwnerLoading" @click="loadMeshtasticOwner">
+            {{ meshtasticOwnerLoading ? 'loading…' : 'load from device' }}
+          </button>
+          <button type="button" :disabled="meshtasticOwnerLoading || meshtasticOwnerSaving || !meshtasticOwner" @click="saveMeshtasticOwner">
+            {{ meshtasticOwnerSaving ? 'saving…' : 'save to device' }}
+          </button>
+        </div>
+
+        <!-- PKC public key -->
+        <h3 style="margin: 1.5rem 0 0.5rem">Public key (PKC)</h3>
+        <div v-if="meshtasticSecurityError" class="notice error-notice">{{ meshtasticSecurityError }}</div>
+
+        <div v-if="meshtasticSecurity" class="field">
+          <label>Public key (Curve25519, hex)</label>
+          <div class="key-display">
+            <code class="key-hex">{{ meshtasticSecurity.public_key_hex || '(not set)' }}</code>
+            <button
+              v-if="meshtasticSecurity.public_key_hex"
+              type="button"
+              class="icon-btn"
+              title="Copy public key"
+              @click="copyToClipboard(meshtasticSecurity.public_key_hex)"
+            >⎘</button>
+          </div>
+          <p class="hint" style="margin-top:0.3rem;">
+            Admin channel: <strong>{{ meshtasticSecurity.admin_channel_enabled ? 'enabled' : 'disabled' }}</strong>.
+            To manage the private key or admin keys, use the Meshtastic app or meshtasticd CLI.
+          </p>
+        </div>
+        <div v-else class="muted" style="margin:0.5rem 0;">
+          {{ meshtasticSecurityLoading ? 'Loading…' : 'Not loaded — click "Load security config" to read.' }}
+        </div>
+
+        <div class="actions" style="margin-top:0.75rem;">
+          <button type="button" :disabled="meshtasticSecurityLoading" @click="loadMeshtasticSecurity">
+            {{ meshtasticSecurityLoading ? 'loading…' : 'load security config' }}
+          </button>
+        </div>
+      </section>
+
       <!-- Node identity -->
       <section class="card">
-        <h2>Node identity</h2>
+        <h2>Node identity <span class="badge">MeshCore</span></h2>
         <p class="hint">
-          The MeshCore companion device's identity keypair. The public key identifies
-          your node on the mesh network and is shared with other stations to contact you.
-          Use <strong>Set node key</strong> to paste a known 64-character hex key (e.g. when
-          migrating to new hardware). Export the private key for backup before a firmware
-          flash. <strong>Keep the private key secret.</strong>
+          The <strong>MeshCore</strong> companion device's identity keypair. The public key
+          identifies your node on the MeshCore mesh network and is shared with other stations
+          to contact you. Use <strong>Set node key</strong> to paste a known 64-character hex
+          key (e.g. when migrating to new hardware). Export the private key for backup before a
+          firmware flash. <strong>Keep the private key secret.</strong>
+          For Meshtastic PKC keys, see the <em>Meshtastic device</em> section below.
         </p>
 
         <div v-if="nodeIdentityError" class="notice error-notice">{{ nodeIdentityError }}</div>

--- a/crates/bbs-web/web/src/pages/SettingsPage.vue
+++ b/crates/bbs-web/web/src/pages/SettingsPage.vue
@@ -568,7 +568,7 @@ async function saveMeshtasticRadio() {
       override_frequency: meshtasticOverrideFrequency.value,
     })
     if (res?.applied === false && res?.saved) {
-      meshtasticRadioOk.value = 'Saved to config.toml. Device not connected — settings will apply next time you run: supply-drop-bbs node set-meshtastic-radio'
+      meshtasticRadioOk.value = 'Saved. The device is not connected right now — these settings will be applied automatically the next time the BBS connects to it.'
     } else {
       meshtasticRadioOk.value = 'Radio config saved and applied to device.'
     }
@@ -632,7 +632,7 @@ async function saveMeshtasticOwner() {
       short_name: meshtasticShortName.value || null,
     })
     if (res?.applied === false && res?.saved) {
-      meshtasticOwnerOk.value = 'Saved to config.toml. Device not connected — settings will apply next time you run: supply-drop-bbs node set-meshtastic-owner'
+      meshtasticOwnerOk.value = 'Saved. The device is not connected right now — this name will be applied automatically the next time the BBS connects to it.'
     } else {
       meshtasticOwnerOk.value = 'Node name saved and applied to device.'
       await loadMeshtasticOwner()

--- a/crates/bbs-web/web/src/pages/SettingsPage.vue
+++ b/crates/bbs-web/web/src/pages/SettingsPage.vue
@@ -430,7 +430,7 @@ async function saveRadioConfig() {
     }
     const updated = await api.patch<RadioConfigData>('/api/v1/radio-config', patch)
     radioConfig.value = updated
-    radioSaveOk.value = 'Radio config saved. Apply to device with: sudo supply-drop-bbs node set-radio'
+    radioSaveOk.value = 'Radio config saved to config.toml. Run: sudo supply-drop-bbs node set-radio — to push to the device (only needed when parameters change).'
   } catch (e: any) {
     radioSaveError.value = e?.message ?? 'failed to save radio config'
   } finally {
@@ -799,26 +799,19 @@ chmod g+w {{ configFile }}</pre>
         </div>
       </section>
 
-      <!-- MeshCore Radio -->
-      <section class="card">
+      <!-- MeshCore Radio — USB serial only -->
+      <!-- Pi HAT and TCP connections have their radio managed by pymc-companion;
+           node set-radio speaks directly to the USB serial device and is not
+           applicable to those connection types. -->
+      <section v-if="radioConfig?.connection_type === 'serial'" class="card">
         <h2>MeshCore radio</h2>
         <p class="hint">
-          LoRa parameters for the MeshCore companion device
-          <span v-if="radioConfig?.connection_type === 'serial' && radioConfig?.serial_port">
-            (<code>{{ radioConfig.serial_port }}</code>)
-          </span>
-          <span v-else-if="radioConfig?.connection_type === 'hat'">
-            (Pi HAT via pymc-companion)
-          </span>
-          <span v-else-if="radioConfig?.connection_type === 'tcp'">
-            (TCP — pymc-companion)
-          </span>.
-          Saved to <code>[plugins.mesh.radio]</code> in config.toml.
-          Settings are <strong>not</strong> applied automatically — after saving, run:
-          <code>sudo supply-drop-bbs node set-radio</code>
-        </p>
-        <p class="hint" style="margin-top: 0.3rem">
-          Using Meshtastic? Radio parameters are configured in the Meshtastic app — they are not managed here.
+          LoRa parameters for the USB MeshCore companion device
+          <span v-if="radioConfig.serial_port">(<code>{{ radioConfig.serial_port }}</code>)</span>.
+          Save here to record them in config.toml, then push to the device once with
+          <code>sudo supply-drop-bbs node set-radio</code>.
+          The device stores these settings in its own flash — you only need to run that
+          command when you change the parameters, not on every restart.
         </p>
 
         <div v-if="radioError" class="notice error-notice">{{ radioError }}</div>

--- a/crates/bbs-web/web/src/pages/SettingsPage.vue
+++ b/crates/bbs-web/web/src/pages/SettingsPage.vue
@@ -564,6 +564,25 @@ const meshtasticDerivedFreq = computed<number | null>(() => {
   return Math.round(freq * 1000) / 1000
 })
 
+// What the Frequency field shows/edits: the override when set, otherwise the
+// region/preset-derived default. Entering the derived value (or 0/blank) clears
+// the override so the device keeps deriving it from the region.
+const meshtasticFreqInput = computed<number>({
+  get() {
+    if (meshtasticOverrideFrequency.value && meshtasticOverrideFrequency.value !== 0) {
+      return meshtasticOverrideFrequency.value
+    }
+    return meshtasticDerivedFreq.value ?? 0
+  },
+  set(v) {
+    if (!v || v === meshtasticDerivedFreq.value) {
+      meshtasticOverrideFrequency.value = 0
+    } else {
+      meshtasticOverrideFrequency.value = v
+    }
+  },
+})
+
 function applyMeshtasticRadioFields(r: any) {
   meshtasticUsePreset.value         = r.use_preset ?? false
   meshtasticModemPreset.value       = r.modem_preset ?? 0
@@ -664,7 +683,7 @@ const meshtasticSecurityLoading = ref(false)
 const meshtasticSecurityError = ref<string | null>(null)
 const meshtasticSecurity = ref<MeshtasticSecurityData | null>(null)
 
-async function loadMeshtasticOwner() {
+async function loadMeshtasticOwner(opts: { silent?: boolean } = {}) {
   meshtasticOwnerLoading.value = true
   meshtasticOwnerError.value = null
   meshtasticOwnerOk.value = null
@@ -673,9 +692,11 @@ async function loadMeshtasticOwner() {
     meshtasticOwner.value = r
     meshtasticLongName.value = r.long_name
     meshtasticShortName.value = r.short_name
-    meshtasticOwnerOk.value = 'Loaded from device.'
+    if (!opts.silent) meshtasticOwnerOk.value = 'Loaded from device.'
   } catch (e: any) {
-    meshtasticOwnerError.value = e?.message ?? 'failed to load device owner info'
+    if (!opts.silent) {
+      meshtasticOwnerError.value = e?.message ?? 'failed to load device owner info'
+    }
   } finally {
     meshtasticOwnerLoading.value = false
   }
@@ -840,6 +861,7 @@ onMounted(() => {
   loadRadioConfig()
   loadNodeIdentity()
   loadMeshtasticRadio({ silent: true })
+  loadMeshtasticOwner({ silent: true })
 })
 </script>
 
@@ -1208,17 +1230,21 @@ chmod g+w {{ configFile }}</pre>
           <div class="field">
             <label>Frequency (MHz)</label>
             <input
-              v-model.number="meshtasticOverrideFrequency"
+              v-model.number="meshtasticFreqInput"
               type="number"
               step="0.001"
-              :placeholder="meshtasticDerivedFreq !== null ? String(meshtasticDerivedFreq) : ''"
               :disabled="meshtasticRadioLoading"
             />
             <p class="hint">
-              <template v-if="meshtasticDerivedFreq !== null">
-                Region/preset default: <strong>{{ meshtasticDerivedFreq }} MHz</strong>.
+              <template v-if="meshtasticOverrideFrequency && meshtasticOverrideFrequency !== 0">
+                Overriding the region default.
               </template>
-              Leave 0 to use the default; enter a value to override.
+              <template v-else-if="meshtasticDerivedFreq !== null">
+                Derived from region + preset. Edit to override.
+              </template>
+              <template v-else>
+                Select a region to see the operating frequency.
+              </template>
             </p>
           </div>
         </div>
@@ -1263,8 +1289,8 @@ chmod g+w {{ configFile }}</pre>
         <div v-if="meshtasticOwnerError" class="notice error-notice">{{ meshtasticOwnerError }}</div>
         <div v-if="meshtasticOwnerOk" class="notice ok-notice">{{ meshtasticOwnerOk }}</div>
 
-        <div v-if="meshtasticOwner" class="field-row">
-          <div class="field">
+        <div class="field-row">
+          <div v-if="meshtasticOwner" class="field">
             <label>Node ID</label>
             <code style="display:block;padding:0.3rem 0;">{{ meshtasticOwner.id }}</code>
           </div>
@@ -1277,15 +1303,16 @@ chmod g+w {{ configFile }}</pre>
             <input v-model="meshtasticShortName" type="text" maxlength="4" :disabled="meshtasticOwnerLoading" />
           </div>
         </div>
-        <div v-else class="muted" style="margin:0.5rem 0;">
-          {{ meshtasticOwnerLoading ? 'Loading…' : 'Not loaded — click "Load from device" to read.' }}
-        </div>
+        <p class="hint">
+          Saved to config.toml and pushed to the device. Applied automatically on the next
+          connect even if the device is offline now.
+        </p>
 
         <div class="actions" style="margin-top:0.75rem;">
-          <button type="button" :disabled="meshtasticOwnerLoading" @click="loadMeshtasticOwner">
+          <button type="button" :disabled="meshtasticOwnerLoading" @click="loadMeshtasticOwner()">
             {{ meshtasticOwnerLoading ? 'loading…' : 'load from device' }}
           </button>
-          <button type="button" :disabled="meshtasticOwnerLoading || meshtasticOwnerSaving || !meshtasticOwner" @click="saveMeshtasticOwner">
+          <button type="button" :disabled="meshtasticOwnerLoading || meshtasticOwnerSaving" @click="saveMeshtasticOwner">
             {{ meshtasticOwnerSaving ? 'saving…' : 'save to device' }}
           </button>
         </div>

--- a/crates/bbs-web/web/src/pages/SettingsPage.vue
+++ b/crates/bbs-web/web/src/pages/SettingsPage.vue
@@ -553,7 +553,7 @@ async function saveMeshtasticRadio() {
   meshtasticRadioError.value = null
   meshtasticRadioOk.value = null
   try {
-    await api.patch('/api/v1/meshtastic-radio-config', {
+    const res = await api.patch<any>('/api/v1/meshtastic-radio-config', {
       use_preset:         meshtasticUsePreset.value,
       modem_preset:       meshtasticModemPreset.value,
       bandwidth:          meshtasticBandwidth.value,
@@ -567,7 +567,11 @@ async function saveMeshtasticRadio() {
       channel_num:        meshtasticChannelNum.value,
       override_frequency: meshtasticOverrideFrequency.value,
     })
-    meshtasticRadioOk.value = 'Radio config saved to device.'
+    if (res?.applied === false && res?.saved) {
+      meshtasticRadioOk.value = 'Saved to config.toml. Device not connected — settings will apply next time you run: supply-drop-bbs node set-meshtastic-radio'
+    } else {
+      meshtasticRadioOk.value = 'Radio config saved and applied to device.'
+    }
   } catch (e: any) {
     meshtasticRadioError.value = e?.message ?? 'failed to save meshtastic radio config'
   } finally {
@@ -623,12 +627,16 @@ async function saveMeshtasticOwner() {
   meshtasticOwnerError.value = null
   meshtasticOwnerOk.value = null
   try {
-    await api.patch('/api/v1/meshtastic-owner', {
+    const res = await api.patch<any>('/api/v1/meshtastic-owner', {
       long_name: meshtasticLongName.value || null,
       short_name: meshtasticShortName.value || null,
     })
-    meshtasticOwnerOk.value = 'Device owner info updated.'
-    await loadMeshtasticOwner()
+    if (res?.applied === false && res?.saved) {
+      meshtasticOwnerOk.value = 'Saved to config.toml. Device not connected — settings will apply next time you run: supply-drop-bbs node set-meshtastic-owner'
+    } else {
+      meshtasticOwnerOk.value = 'Node name saved and applied to device.'
+      await loadMeshtasticOwner()
+    }
   } catch (e: any) {
     meshtasticOwnerError.value = e?.message ?? 'failed to save device owner info'
   } finally {

--- a/crates/bbs-web/web/src/pages/SettingsPage.vue
+++ b/crates/bbs-web/web/src/pages/SettingsPage.vue
@@ -741,6 +741,38 @@ async function loadMeshtasticSecurity() {
   }
 }
 
+// Populate radio + owner + security in a single call from the cached snapshot
+// (captured during the last connect-time sync). Used on page load — no buttons,
+// no device round-trip. Silent: stays quiet if the transport isn't connected.
+async function loadMeshtasticSnapshot() {
+  try {
+    const s = await api.get<any>('/api/v1/meshtastic-device')
+    if (s?.lora) applyMeshtasticRadioFields(s.lora)
+    if (s?.owner) {
+      meshtasticOwner.value = s.owner
+      meshtasticLongName.value = s.owner.long_name
+      meshtasticShortName.value = s.owner.short_name
+    }
+    if (s?.security) meshtasticSecurity.value = s.security
+  } catch {
+    // No transport / not connected — leave sections at their defaults.
+  }
+}
+
+// Manual "refresh from device": live reads against the device, one section at a
+// time (only one admin op may be in flight). Surfaces errors, unlike the load.
+const meshtasticRefreshing = ref(false)
+async function refreshMeshtasticDevice() {
+  meshtasticRefreshing.value = true
+  try {
+    await loadMeshtasticRadio()
+    await loadMeshtasticOwner()
+    await loadMeshtasticSecurity()
+  } finally {
+    meshtasticRefreshing.value = false
+  }
+}
+
 // ── Node identity ─────────────────────────────────────────────────────────────
 
 interface NodeIdentityData {
@@ -860,8 +892,7 @@ onMounted(() => {
   loadAccessPolicy()
   loadRadioConfig()
   loadNodeIdentity()
-  loadMeshtasticRadio({ silent: true })
-  loadMeshtasticOwner({ silent: true })
+  loadMeshtasticSnapshot()
 })
 </script>
 
@@ -1266,12 +1297,13 @@ chmod g+w {{ configFile }}</pre>
         </div>
 
         <div class="actions">
-          <button type="button" :disabled="meshtasticRadioLoading" @click="loadMeshtasticRadio()">
-            {{ meshtasticRadioLoading ? 'loading…' : 'load from device' }}
-          </button>
           <button type="button" :disabled="meshtasticRadioLoading || meshtasticRadioSaving" @click="saveMeshtasticRadio">
             {{ meshtasticRadioSaving ? 'saving…' : 'save to device' }}
           </button>
+          <button type="button" class="secondary" :disabled="meshtasticRefreshing" @click="refreshMeshtasticDevice">
+            {{ meshtasticRefreshing ? 'refreshing…' : 'refresh from device' }}
+          </button>
+          <span class="hint">Values shown are from the last device sync. Refresh to re-read live.</span>
         </div>
       </section>
 
@@ -1309,9 +1341,6 @@ chmod g+w {{ configFile }}</pre>
         </p>
 
         <div class="actions" style="margin-top:0.75rem;">
-          <button type="button" :disabled="meshtasticOwnerLoading" @click="loadMeshtasticOwner()">
-            {{ meshtasticOwnerLoading ? 'loading…' : 'load from device' }}
-          </button>
           <button type="button" :disabled="meshtasticOwnerLoading || meshtasticOwnerSaving" @click="saveMeshtasticOwner">
             {{ meshtasticOwnerSaving ? 'saving…' : 'save to device' }}
           </button>
@@ -1339,13 +1368,7 @@ chmod g+w {{ configFile }}</pre>
           </p>
         </div>
         <div v-else class="muted" style="margin:0.5rem 0;">
-          {{ meshtasticSecurityLoading ? 'Loading…' : 'Not loaded — click "Load security config" to read.' }}
-        </div>
-
-        <div class="actions" style="margin-top:0.75rem;">
-          <button type="button" :disabled="meshtasticSecurityLoading" @click="loadMeshtasticSecurity">
-            {{ meshtasticSecurityLoading ? 'loading…' : 'load security config' }}
-          </button>
+          {{ meshtasticSecurityLoading ? 'Loading…' : 'Not available — device not connected, or use "Refresh from device" above.' }}
         </div>
       </section>
 

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -471,6 +471,39 @@ a TCP stream. Default port for `meshtasticd` is `4403`.
 |--------|--------|--------------------|----------|-----------------------------|
 | `addr` | string | `"127.0.0.1:4403"` | no       | Address of the meshtasticd listener |
 
+### Node name
+
+| Key          | Type   | Default | Required | Description                                              |
+|--------------|--------|---------|----------|----------------------------------------------------------|
+| `long_name`  | string | (unset) | no       | Node long name shown on mesh maps (≤ 39 chars)           |
+| `short_name` | string | (unset) | no       | Node short name shown on OLED / maps (≤ 4 chars)         |
+
+### Radio settings — `[plugins.meshtastic.radio]`
+
+These are pushed to the connected device automatically when the BBS connects,
+so changes made here (or in the web **Settings** page) take effect on the next
+connect. Writes are **skipped when the value already matches the device**, so the
+radio only reboots when something actually changed.
+
+| Key               | Type    | Default     | Required | Description                                                        |
+|-------------------|---------|-------------|----------|--------------------------------------------------------------------|
+| `region`          | string  | (unset)     | no       | Region code, e.g. `"US"`, `"EU_868"`, `"ANZ"`. Leave unset to keep the device's current region. |
+| `modem_preset`    | string  | `"LONG_FAST"` | no     | LoRa modem preset, e.g. `"LONG_FAST"`, `"MEDIUM_SLOW"`             |
+| `hops`            | integer | `3`         | no       | Max hops for packets this node originates                          |
+| `rx_boosted_gain` | bool    | `true`      | no       | SX126x RX boosted gain (improves receive sensitivity)              |
+| `ignore_mqtt`     | bool    | `true`      | no       | Ignore packets that arrived over MQTT                              |
+| `tx_enabled`      | bool    | `true`      | no       | Whether the radio transmitter is enabled                           |
+
+On connect the BBS also:
+
+- **syncs the device clock** to system time,
+- **sets a fixed GPS position** from the `[location]` config (or clears it when no
+  location is configured), and
+- sets the device's `node_info_broadcast_secs` to **3600 s (1 h, the firmware
+  minimum)** so the node re-announces itself to the mesh hourly. This is the
+  firmware-native way neighbouring nodes discover the BBS; you can also force an
+  immediate re-announce with the **"reboot radio"** button on the Settings page.
+
 ### Example
 
 ```toml
@@ -478,6 +511,16 @@ a TCP stream. Default port for `meshtasticd` is `4403`.
 enabled         = true
 connection_type = "serial"
 serial_port     = "/dev/ttyUSB0"
+long_name       = "Supply Drop BBS"
+short_name      = "SDB"
+
+[plugins.meshtastic.radio]
+region          = "US"
+modem_preset    = "LONG_FAST"
+hops            = 3
+rx_boosted_gain = true
+ignore_mqtt     = true
+tx_enabled      = true
 ```
 
 ## `[plugins.web]` - admin web (only if `admin-web` feature enabled)

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -378,7 +378,7 @@ User=supply-drop
 Group=supply-drop
 SupplementaryGroups=dialout
 ExecStart=/usr/local/bin/supply-drop-bbs run --config /etc/supply-drop-bbs/config.toml
-Restart=on-failure
+Restart=always
 RestartSec=5s
 StandardOutput=journal
 StandardError=journal
@@ -390,6 +390,12 @@ PrivateTmp=yes
 [Install]
 WantedBy=multi-user.target
 ```
+
+> **Web "Restart service" button.** The web admin's restart action works by having
+> the BBS process **exit**, which `Restart=always` then brings back up — it does
+> *not* shell out to `systemctl`, because the unit runs as a non-root user with
+> `NoNewPrivileges=yes` (so `sudo` can't escalate). No sudoers rule is needed; if
+> an older install left `/etc/sudoers.d/supply-drop-bbs`, it's removed on upgrade.
 
 ### Pi HAT - two services
 

--- a/install.sh
+++ b/install.sh
@@ -400,17 +400,12 @@ install -m 644 "$SRC_DIR/supply-drop-bbs.service" "$UNIT_FILE"
 systemctl daemon-reload
 success "Systemd unit installed"
 
-# ── Sudoers rule — web UI service restart ─────────────────────────────────────
-# Grants the service user permission to run exactly one command as root:
-# restarting its own systemd unit. Scoped as tightly as possible.
-
-SUDOERS_FILE="/etc/sudoers.d/supply-drop-bbs"
-_systemctl_path=$(command -v systemctl || echo /usr/bin/systemctl)
-info "Installing sudoers rule for web-UI service restart..."
-echo "${SERVICE_USER} ALL=(root) NOPASSWD: ${_systemctl_path} restart supply-drop-bbs" \
-    > "$SUDOERS_FILE"
-chmod 440 "$SUDOERS_FILE"
-success "Sudoers rule installed ($SUDOERS_FILE)"
+# ── Web-UI service restart ────────────────────────────────────────────────────
+# No sudoers rule is needed: the unit runs with NoNewPrivileges=yes (so `sudo`
+# can't escalate anyway), and the web-UI "restart service" simply exits the
+# process — systemd's Restart=always then starts a fresh instance. Remove any
+# stale sudoers rule from older installs.
+rm -f /etc/sudoers.d/supply-drop-bbs
 
 # ── Setup wizard ──────────────────────────────────────────────────────────────
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -360,6 +360,52 @@ enum NodeAction {
         #[arg(long)]
         list_presets: bool,
     },
+
+    /// Apply Meshtastic LoRa radio configuration from config.toml to the device.
+    ///
+    /// Reads `[plugins.meshtastic.radio]` (region and modem preset) and pushes
+    /// them to the connected Meshtastic radio.  The device stores the settings
+    /// in its own flash so they survive power cycles.
+    ///
+    /// The BBS service must **not** be running on the same port when you run this.
+    ///
+    /// Example:
+    ///   supply-drop-bbs node set-meshtastic-radio
+    #[cfg(feature = "transport-meshtastic")]
+    SetMeshtasticRadio {
+        /// Serial port (e.g. /dev/ttyUSB0, COM3). Defaults to serial_port in config.toml.
+        #[arg(long)]
+        port: Option<String>,
+        /// Baud rate. Defaults to the value in config.toml or 115200.
+        #[arg(long)]
+        baud: Option<u32>,
+        /// TCP address for meshtasticd (e.g. 127.0.0.1:4403). Defaults to addr in config.toml.
+        #[arg(long)]
+        addr: Option<String>,
+    },
+
+    /// Apply Meshtastic node name (long name + short name) from config.toml to the device.
+    ///
+    /// Reads `[plugins.meshtastic]` `long_name` and `short_name` and pushes them
+    /// to the connected Meshtastic radio.  The existing PKC public key is
+    /// preserved by fetching owner info from the device first.
+    ///
+    /// The BBS service must **not** be running on the same port when you run this.
+    ///
+    /// Example:
+    ///   supply-drop-bbs node set-meshtastic-owner
+    #[cfg(feature = "transport-meshtastic")]
+    SetMeshtasticOwner {
+        /// Serial port. Defaults to serial_port in config.toml.
+        #[arg(long)]
+        port: Option<String>,
+        /// Baud rate. Defaults to the value in config.toml or 115200.
+        #[arg(long)]
+        baud: Option<u32>,
+        /// TCP address. Defaults to addr in config.toml.
+        #[arg(long)]
+        addr: Option<String>,
+    },
 }
 
 // ── Entry point ───────────────────────────────────────────────────────────────
@@ -1872,7 +1918,56 @@ fn save_radio_config(config_path: Option<&std::path::Path>, r: &ResolvedRadio) {
     }
 }
 
+// ── Meshtastic node command handler ──────────────────────────────────────────
+
+#[cfg(feature = "transport-meshtastic")]
+async fn cmd_node_meshtastic(config_path: Option<&std::path::Path>, action: NodeAction) {
+    let cfg = config::load(config_path).unwrap_or_default();
+    let mt_cfg = &cfg.plugins.meshtastic;
+
+    let (port_flag, baud_flag, addr_flag, is_set_radio) = match &action {
+        NodeAction::SetMeshtasticRadio { port, baud, addr } => {
+            (port.clone(), *baud, addr.clone(), true)
+        }
+        NodeAction::SetMeshtasticOwner { port, baud, addr } => {
+            (port.clone(), *baud, addr.clone(), false)
+        }
+        _ => unreachable!(),
+    };
+
+    let result = if is_set_radio {
+        bbs_meshtastic::apply_radio_from_config(mt_cfg, port_flag, baud_flag, addr_flag).await
+    } else {
+        bbs_meshtastic::apply_owner_from_config(mt_cfg, port_flag, baud_flag, addr_flag).await
+    };
+
+    match result {
+        Ok(()) => {
+            if is_set_radio {
+                eprintln!("Meshtastic radio config applied successfully.");
+            } else {
+                eprintln!("Meshtastic owner info applied successfully.");
+            }
+        }
+        Err(e) => {
+            eprintln!("error: {e}");
+            std::process::exit(1);
+        }
+    }
+}
+
 async fn cmd_node(config_path: Option<&std::path::Path>, action: NodeAction) {
+    // ── Meshtastic node commands ──────────────────────────────────────────────
+    #[cfg(feature = "transport-meshtastic")]
+    match &action {
+        NodeAction::SetMeshtasticRadio { .. } | NodeAction::SetMeshtasticOwner { .. } => {
+            cmd_node_meshtastic(config_path, action).await;
+            return;
+        }
+        _ => {}
+    }
+
+    // ── MeshCore node commands ────────────────────────────────────────────────
     #[cfg(feature = "transport-mesh")]
     {
         use meshcore_companion::{
@@ -1913,6 +2008,8 @@ async fn cmd_node(config_path: Option<&std::path::Path>, action: NodeAction) {
             NodeAction::ExportKey { port, baud } => (port.clone(), *baud),
             NodeAction::ImportKey { port, baud, .. } => (port.clone(), *baud),
             NodeAction::SetRadio { port, baud, .. } => (port.clone(), *baud),
+            // Meshtastic commands are intercepted and returned-from early above.
+            _ => unreachable!("Meshtastic commands should have been handled above"),
         };
 
         let port = match port_flag.or_else(|| {
@@ -2022,6 +2119,8 @@ async fn cmd_node(config_path: Option<&std::path::Path>, action: NodeAction) {
                 // Placeholder — the actual send is handled specially below.
                 OutboundFrame::GetBattAndStorage
             }
+            // Meshtastic commands are handled before this block — unreachable here.
+            _ => unreachable!("Meshtastic commands should have been handled above"),
         };
 
         let serial_cfg = SerialConfig {

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -1852,18 +1852,22 @@ fn build_toml(p: &TomlParams<'_>) -> String {
             }
         }
     }
-    // [plugins.meshtastic.radio] — only when Meshtastic is enabled and params chosen
+    // [plugins.meshtastic.radio] — written whenever Meshtastic is enabled so the
+    // recommended radio defaults are present and editable.
     #[cfg(feature = "transport-meshtastic")]
-    if p.use_meshtastic
-        && (p.meshtastic_radio_region.is_some() || p.meshtastic_radio_preset.is_some())
-    {
+    if p.use_meshtastic {
         writeln!(s, "\n[plugins.meshtastic.radio]").unwrap();
         if let Some(region) = p.meshtastic_radio_region {
-            writeln!(s, "region       = {}", toml_str(region)).unwrap();
+            writeln!(s, "region          = {}", toml_str(region)).unwrap();
         }
         if let Some(preset) = p.meshtastic_radio_preset {
-            writeln!(s, "modem_preset = {}", toml_str(preset)).unwrap();
+            writeln!(s, "modem_preset    = {}", toml_str(preset)).unwrap();
         }
+        // Recommended defaults, applied to the device automatically on connect.
+        writeln!(s, "rx_boosted_gain = true").unwrap();
+        writeln!(s, "hops            = 3").unwrap();
+        writeln!(s, "ignore_mqtt     = true").unwrap();
+        writeln!(s, "tx_enabled      = true").unwrap();
     }
 
     // Suppress unused-variable warnings when feature is off.

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -1169,6 +1169,59 @@ pub fn run_wizard(config_out: Option<&Path>) {
         println!("HAT config written to {}.", yaml_path.display());
     }
 
+    // ── Apply Meshtastic settings to device ───────────────────────────────────
+    //
+    // The device is connected right now (user just configured the serial port),
+    // so we push the settings immediately.  If the push fails (device not
+    // present, wrong port, etc.) we warn and continue — the user can run the
+    // CLI commands later.
+    #[cfg(feature = "transport-meshtastic")]
+    if use_meshtastic {
+        let has_radio = meshtastic_radio_region.is_some() || meshtastic_radio_preset.is_some();
+        let has_owner = meshtastic_short_name.is_some() || meshtastic_long_name.is_some();
+        if has_radio || has_owner {
+            section("Applying Meshtastic settings to device");
+            // Load the config we just wrote so the push functions see the
+            // correct connection type, serial port, baud rate, etc.
+            let loaded = crate::config::load(Some(&out_path)).unwrap_or_default();
+            let mt_cfg = &loaded.plugins.meshtastic;
+
+            if has_radio {
+                println!("Pushing radio config (region / modem preset)…");
+                let result = tokio::task::block_in_place(|| {
+                    tokio::runtime::Handle::current().block_on(
+                        bbs_meshtastic::apply_radio_from_config(mt_cfg, None, None, None),
+                    )
+                });
+                match result {
+                    Ok(()) => println!("  ✓  Radio configuration applied."),
+                    Err(e) => {
+                        println!("  ✗  Could not apply radio config: {e}");
+                        println!("     Run later with: supply-drop-bbs node set-meshtastic-radio");
+                    }
+                }
+                println!();
+            }
+
+            if has_owner {
+                println!("Pushing node name…");
+                let result = tokio::task::block_in_place(|| {
+                    tokio::runtime::Handle::current().block_on(
+                        bbs_meshtastic::apply_owner_from_config(mt_cfg, None, None, None),
+                    )
+                });
+                match result {
+                    Ok(()) => println!("  ✓  Node name applied."),
+                    Err(e) => {
+                        println!("  ✗  Could not apply node name: {e}");
+                        println!("     Run later with: supply-drop-bbs node set-meshtastic-owner");
+                    }
+                }
+                println!();
+            }
+        }
+    }
+
     // ── Next steps ────────────────────────────────────────────────────────────
     section("Next steps");
     print_next_steps(

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -41,6 +41,8 @@ struct Existing {
     meshtastic_connection_type: String,
     meshtastic_serial_port: Option<String>,
     meshtastic_baud_rate: u32,
+    meshtastic_radio_region: Option<String>,
+    meshtastic_radio_preset: Option<String>,
     // Web
     web_enabled: bool,
     web_bind: String,
@@ -136,6 +138,16 @@ fn load_existing(out_path: &Path) -> Existing {
         .and_then(|v| v.as_integer())
         .map(|v| v as u32)
         .unwrap_or(115_200);
+    let meshtastic_radio_region = meshtastic
+        .and_then(|m| m.get("radio"))
+        .and_then(|r| r.get("region"))
+        .and_then(|v| v.as_str())
+        .map(str::to_owned);
+    let meshtastic_radio_preset = meshtastic
+        .and_then(|m| m.get("radio"))
+        .and_then(|r| r.get("modem_preset"))
+        .and_then(|v| v.as_str())
+        .map(str::to_owned);
 
     // Web
     let web_enabled = web
@@ -234,6 +246,8 @@ fn load_existing(out_path: &Path) -> Existing {
         meshtastic_connection_type,
         meshtastic_serial_port,
         meshtastic_baud_rate,
+        meshtastic_radio_region,
+        meshtastic_radio_preset,
         web_enabled,
         web_bind,
         web_backup_dir,
@@ -741,6 +755,108 @@ pub fn run_wizard(config_out: Option<&Path>) {
         meshtastic_addr = None;
     }
 
+    // ── Meshtastic radio parameters ───────────────────────────────────────────
+
+    /// (code, display label)
+    const MESHTASTIC_REGIONS: &[(&str, &str)] = &[
+        ("US", "United States"),
+        ("EU_433", "Europe 433 MHz"),
+        ("EU_868", "Europe 868 MHz"),
+        ("ANZ", "Australia / New Zealand"),
+        ("JP", "Japan"),
+        ("CN", "China"),
+        ("KR", "South Korea"),
+        ("TW", "Taiwan"),
+        ("RU", "Russia"),
+        ("IN", "India"),
+        ("NZ_865", "New Zealand 865 MHz"),
+        ("TH", "Thailand"),
+        ("LORA_24", "2.4 GHz LoRa"),
+        ("UA_433", "Ukraine 433 MHz"),
+        ("UA_868", "Ukraine 868 MHz"),
+        ("MY_433", "Malaysia 433 MHz"),
+        ("MY_919", "Malaysia 919 MHz"),
+        ("SG_923", "Singapore 923 MHz"),
+    ];
+
+    /// (code, display label)
+    const MESHTASTIC_PRESETS: &[(&str, &str)] = &[
+        (
+            "LONG_FAST",
+            "Long range, fast      (default — good starting point)",
+        ),
+        ("LONG_MODERATE", "Long range, moderate"),
+        ("MEDIUM_SLOW", "Medium range, slow"),
+        ("MEDIUM_FAST", "Medium range, fast"),
+        ("SHORT_SLOW", "Short range, slow"),
+        ("SHORT_FAST", "Short range, fast"),
+        ("LONG_SLOW", "Long range, slow      (very slow data rate)"),
+        (
+            "MAX_RANGE",
+            "Maximum range         (extremely slow data rate)",
+        ),
+        ("SHORT_TURBO", "Short range, turbo    (high data rate)"),
+    ];
+
+    let (meshtastic_radio_region, meshtastic_radio_preset): (Option<String>, Option<String>) =
+        if use_meshtastic {
+            section("Meshtastic radio parameters");
+
+            println!("Select the region and modem preset for your Meshtastic device.");
+            println!("These are saved to config.toml and can be pushed to the device");
+            println!("at any time via the web admin (Settings → Meshtastic radio).");
+            println!("Skip if the device is already configured correctly.");
+            println!();
+
+            let configure = Confirm::with_theme(&theme)
+                .with_prompt("Configure Meshtastic radio parameters now?")
+                .default(ex.meshtastic_radio_region.is_some())
+                .interact()
+                .unwrap_or_else(|_| cancelled());
+
+            if configure {
+                let region_labels: Vec<String> = MESHTASTIC_REGIONS
+                    .iter()
+                    .map(|(code, name)| format!("{code:<10} {name}"))
+                    .collect();
+                let default_region = ex
+                    .meshtastic_radio_region
+                    .as_deref()
+                    .and_then(|r| MESHTASTIC_REGIONS.iter().position(|(c, _)| *c == r))
+                    .unwrap_or(0); // US
+                let region_choice =
+                    prompt_select(&theme, "Select your region", &region_labels, default_region);
+                let region = MESHTASTIC_REGIONS[region_choice].0.to_owned();
+
+                println!();
+                let preset_labels: Vec<String> = MESHTASTIC_PRESETS
+                    .iter()
+                    .map(|(_, d)| d.to_string())
+                    .collect();
+                let default_preset = ex
+                    .meshtastic_radio_preset
+                    .as_deref()
+                    .and_then(|p| MESHTASTIC_PRESETS.iter().position(|(c, _)| *c == p))
+                    .unwrap_or(0); // LONG_FAST
+                let preset_choice = prompt_select(
+                    &theme,
+                    "Select modem preset",
+                    &preset_labels,
+                    default_preset,
+                );
+                let preset = MESHTASTIC_PRESETS[preset_choice].0.to_owned();
+
+                (Some(region), Some(preset))
+            } else {
+                (
+                    ex.meshtastic_radio_region.clone(),
+                    ex.meshtastic_radio_preset.clone(),
+                )
+            }
+        } else {
+            (None, None)
+        };
+
     // ── Web admin ─────────────────────────────────────────────────────────────
     section("Web admin UI");
 
@@ -877,6 +993,8 @@ pub fn run_wizard(config_out: Option<&Path>) {
         meshtastic_serial_port: meshtastic_serial_port.as_deref(),
         meshtastic_baud_rate,
         meshtastic_addr: meshtastic_addr.as_deref(),
+        meshtastic_radio_region: meshtastic_radio_region.as_deref(),
+        meshtastic_radio_preset: meshtastic_radio_preset.as_deref(),
         web_enabled,
         web_bind: web_bind.as_deref(),
         web_backup_dir: web_backup_dir.as_deref(),
@@ -1520,6 +1638,8 @@ struct TomlParams<'a> {
     meshtastic_serial_port: Option<&'a str>,
     meshtastic_baud_rate: Option<u32>,
     meshtastic_addr: Option<&'a str>,
+    meshtastic_radio_region: Option<&'a str>,
+    meshtastic_radio_preset: Option<&'a str>,
     // Web
     web_enabled: bool,
     web_bind: Option<&'a str>,
@@ -1655,6 +1775,20 @@ fn build_toml(p: &TomlParams<'_>) -> String {
             }
         }
     }
+    // [plugins.meshtastic.radio] — only when Meshtastic is enabled and params chosen
+    #[cfg(feature = "transport-meshtastic")]
+    if p.use_meshtastic
+        && (p.meshtastic_radio_region.is_some() || p.meshtastic_radio_preset.is_some())
+    {
+        writeln!(s, "\n[plugins.meshtastic.radio]").unwrap();
+        if let Some(region) = p.meshtastic_radio_region {
+            writeln!(s, "region       = {}", toml_str(region)).unwrap();
+        }
+        if let Some(preset) = p.meshtastic_radio_preset {
+            writeln!(s, "modem_preset = {}", toml_str(preset)).unwrap();
+        }
+    }
+
     // Suppress unused-variable warnings when feature is off.
     #[cfg(not(feature = "transport-meshtastic"))]
     {
@@ -1664,6 +1798,8 @@ fn build_toml(p: &TomlParams<'_>) -> String {
             p.meshtastic_serial_port,
             p.meshtastic_baud_rate,
             p.meshtastic_addr,
+            p.meshtastic_radio_region,
+            p.meshtastic_radio_preset,
         );
     }
 

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -43,6 +43,8 @@ struct Existing {
     meshtastic_baud_rate: u32,
     meshtastic_radio_region: Option<String>,
     meshtastic_radio_preset: Option<String>,
+    meshtastic_short_name: Option<String>,
+    meshtastic_long_name: Option<String>,
     // Web
     web_enabled: bool,
     web_bind: String,
@@ -148,6 +150,14 @@ fn load_existing(out_path: &Path) -> Existing {
         .and_then(|r| r.get("modem_preset"))
         .and_then(|v| v.as_str())
         .map(str::to_owned);
+    let meshtastic_short_name = meshtastic
+        .and_then(|m| m.get("short_name"))
+        .and_then(|v| v.as_str())
+        .map(str::to_owned);
+    let meshtastic_long_name = meshtastic
+        .and_then(|m| m.get("long_name"))
+        .and_then(|v| v.as_str())
+        .map(str::to_owned);
 
     // Web
     let web_enabled = web
@@ -248,6 +258,8 @@ fn load_existing(out_path: &Path) -> Existing {
         meshtastic_baud_rate,
         meshtastic_radio_region,
         meshtastic_radio_preset,
+        meshtastic_short_name,
+        meshtastic_long_name,
         web_enabled,
         web_bind,
         web_backup_dir,
@@ -857,6 +869,56 @@ pub fn run_wizard(config_out: Option<&Path>) {
             (None, None)
         };
 
+    // ── Meshtastic node name ──────────────────────────────────────────────────
+
+    let (meshtastic_short_name, meshtastic_long_name): (Option<String>, Option<String>) =
+        if use_meshtastic {
+            section("Meshtastic node name");
+
+            println!("Set the long name (full display name) and short name (≤ 4 chars,");
+            println!("shown on mesh maps). These are saved to config.toml and can be");
+            println!("pushed to the device via the web admin UI at any time.");
+            println!();
+
+            let configure = Confirm::with_theme(&theme)
+                .with_prompt("Configure Meshtastic node name?")
+                .default(ex.meshtastic_short_name.is_some() || ex.meshtastic_long_name.is_some())
+                .interact()
+                .unwrap_or_else(|_| cancelled());
+
+            if configure {
+                let long: String = Input::with_theme(&theme)
+                    .with_prompt("Long name (full display name)")
+                    .default(ex.meshtastic_long_name.clone().unwrap_or_default())
+                    .interact_text()
+                    .unwrap_or_else(|_| cancelled());
+
+                let short: String = Input::with_theme(&theme)
+                    .with_prompt("Short name (≤ 4 chars, shown on maps)")
+                    .default(ex.meshtastic_short_name.clone().unwrap_or_default())
+                    .validate_with(|v: &String| {
+                        if v.chars().count() <= 4 {
+                            Ok(())
+                        } else {
+                            Err("Short name must be 4 characters or fewer")
+                        }
+                    })
+                    .interact_text()
+                    .unwrap_or_else(|_| cancelled());
+
+                let ln = if long.is_empty() { None } else { Some(long) };
+                let sn = if short.is_empty() { None } else { Some(short) };
+                (sn, ln)
+            } else {
+                (
+                    ex.meshtastic_short_name.clone(),
+                    ex.meshtastic_long_name.clone(),
+                )
+            }
+        } else {
+            (None, None)
+        };
+
     // ── Web admin ─────────────────────────────────────────────────────────────
     section("Web admin UI");
 
@@ -995,6 +1057,8 @@ pub fn run_wizard(config_out: Option<&Path>) {
         meshtastic_addr: meshtastic_addr.as_deref(),
         meshtastic_radio_region: meshtastic_radio_region.as_deref(),
         meshtastic_radio_preset: meshtastic_radio_preset.as_deref(),
+        meshtastic_short_name: meshtastic_short_name.as_deref(),
+        meshtastic_long_name: meshtastic_long_name.as_deref(),
         web_enabled,
         web_bind: web_bind.as_deref(),
         web_backup_dir: web_backup_dir.as_deref(),
@@ -1640,6 +1704,8 @@ struct TomlParams<'a> {
     meshtastic_addr: Option<&'a str>,
     meshtastic_radio_region: Option<&'a str>,
     meshtastic_radio_preset: Option<&'a str>,
+    meshtastic_short_name: Option<&'a str>,
+    meshtastic_long_name: Option<&'a str>,
     // Web
     web_enabled: bool,
     web_bind: Option<&'a str>,
@@ -1773,6 +1839,12 @@ fn build_toml(p: &TomlParams<'_>) -> String {
                 }
                 _ => {}
             }
+            if let Some(sn) = p.meshtastic_short_name {
+                writeln!(s, "short_name = {}", toml_str(sn)).unwrap();
+            }
+            if let Some(ln) = p.meshtastic_long_name {
+                writeln!(s, "long_name  = {}", toml_str(ln)).unwrap();
+            }
         }
     }
     // [plugins.meshtastic.radio] — only when Meshtastic is enabled and params chosen
@@ -1800,6 +1872,8 @@ fn build_toml(p: &TomlParams<'_>) -> String {
             p.meshtastic_addr,
             p.meshtastic_radio_region,
             p.meshtastic_radio_preset,
+            p.meshtastic_short_name,
+            p.meshtastic_long_name,
         );
     }
 

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -386,6 +386,31 @@ pub fn run_wizard(config_out: Option<&Path>) {
 
     let ex = load_existing(&out_path);
 
+    // ── BBS identity ──────────────────────────────────────────────────────────
+    //
+    // Collected first so it is clear there is exactly one BBS instance.
+    // All radio transports (MeshCore, Meshtastic, …) configured below are
+    // simply different ways to reach the same BBS — they do not have
+    // separate identities.
+    section("BBS identity");
+
+    let bbs_name: String = Input::with_theme(&theme)
+        .with_prompt("BBS name")
+        .default(ex.bbs_name.clone())
+        .interact_text()
+        .unwrap_or_else(|_| cancelled());
+
+    // ── Data storage ──────────────────────────────────────────────────────────
+    section("Data storage");
+
+    let data_dir_str: String = Input::with_theme(&theme)
+        .with_prompt("Data directory")
+        .default(ex.data_dir.clone())
+        .interact_text()
+        .unwrap_or_else(|_| cancelled());
+
+    let data_dir = PathBuf::from(&data_dir_str);
+
     // ── Protocol selection ────────────────────────────────────────────────────
     //
     // Which protocols appear here is determined by compiled-in features:
@@ -715,26 +740,6 @@ pub fn run_wizard(config_out: Option<&Path>) {
         meshtastic_baud_rate = None;
         meshtastic_addr = None;
     }
-
-    // ── BBS identity ──────────────────────────────────────────────────────────
-    section("BBS identity");
-
-    let bbs_name: String = Input::with_theme(&theme)
-        .with_prompt("BBS name")
-        .default(ex.bbs_name.clone())
-        .interact_text()
-        .unwrap_or_else(|_| cancelled());
-
-    // ── Data storage ──────────────────────────────────────────────────────────
-    section("Data storage");
-
-    let data_dir_str: String = Input::with_theme(&theme)
-        .with_prompt("Data directory")
-        .default(ex.data_dir.clone())
-        .interact_text()
-        .unwrap_or_else(|_| cancelled());
-
-    let data_dir = PathBuf::from(&data_dir_str);
 
     // ── Web admin ─────────────────────────────────────────────────────────────
     section("Web admin UI");

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -1169,58 +1169,10 @@ pub fn run_wizard(config_out: Option<&Path>) {
         println!("HAT config written to {}.", yaml_path.display());
     }
 
-    // ── Apply Meshtastic settings to device ───────────────────────────────────
-    //
-    // The device is connected right now (user just configured the serial port),
-    // so we push the settings immediately.  If the push fails (device not
-    // present, wrong port, etc.) we warn and continue — the user can run the
-    // CLI commands later.
-    #[cfg(feature = "transport-meshtastic")]
-    if use_meshtastic {
-        let has_radio = meshtastic_radio_region.is_some() || meshtastic_radio_preset.is_some();
-        let has_owner = meshtastic_short_name.is_some() || meshtastic_long_name.is_some();
-        if has_radio || has_owner {
-            section("Applying Meshtastic settings to device");
-            // Load the config we just wrote so the push functions see the
-            // correct connection type, serial port, baud rate, etc.
-            let loaded = crate::config::load(Some(&out_path)).unwrap_or_default();
-            let mt_cfg = &loaded.plugins.meshtastic;
-
-            if has_radio {
-                println!("Pushing radio config (region / modem preset)…");
-                let result = tokio::task::block_in_place(|| {
-                    tokio::runtime::Handle::current().block_on(
-                        bbs_meshtastic::apply_radio_from_config(mt_cfg, None, None, None),
-                    )
-                });
-                match result {
-                    Ok(()) => println!("  ✓  Radio configuration applied."),
-                    Err(e) => {
-                        println!("  ✗  Could not apply radio config: {e}");
-                        println!("     Run later with: supply-drop-bbs node set-meshtastic-radio");
-                    }
-                }
-                println!();
-            }
-
-            if has_owner {
-                println!("Pushing node name…");
-                let result = tokio::task::block_in_place(|| {
-                    tokio::runtime::Handle::current().block_on(
-                        bbs_meshtastic::apply_owner_from_config(mt_cfg, None, None, None),
-                    )
-                });
-                match result {
-                    Ok(()) => println!("  ✓  Node name applied."),
-                    Err(e) => {
-                        println!("  ✗  Could not apply node name: {e}");
-                        println!("     Run later with: supply-drop-bbs node set-meshtastic-owner");
-                    }
-                }
-                println!();
-            }
-        }
-    }
+    // Meshtastic radio and node-name settings are applied to the device
+    // automatically by the transport when the BBS connects (see the
+    // auto-apply-on-connect logic in bbs-meshtastic).  No setup-time push is
+    // needed — the operator just starts the BBS and the settings take effect.
 
     // ── Next steps ────────────────────────────────────────────────────────────
     section("Next steps");
@@ -2082,17 +2034,14 @@ fn print_next_steps(
         println!();
     }
 
-    // Meshtastic settings push hint
+    // Meshtastic settings note
     if use_meshtastic {
         println!("Meshtastic radio and node settings:");
         println!();
         println!("  The region, modem preset, and node name were saved to config.toml.");
-        println!("  To push them to the device now (BBS must NOT be running):");
-        println!();
-        println!("    supply-drop-bbs node set-meshtastic-radio");
-        println!("    supply-drop-bbs node set-meshtastic-owner");
-        println!();
-        println!("  Or push them later from Settings in the web admin UI.");
+        println!("  They are applied to the device automatically when the BBS connects —");
+        println!("  just start the BBS and they take effect. You can change them any time");
+        println!("  from Settings in the web admin UI (also applied automatically).");
         println!();
     }
 

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -2029,6 +2029,20 @@ fn print_next_steps(
         println!();
     }
 
+    // Meshtastic settings push hint
+    if use_meshtastic {
+        println!("Meshtastic radio and node settings:");
+        println!();
+        println!("  The region, modem preset, and node name were saved to config.toml.");
+        println!("  To push them to the device now (BBS must NOT be running):");
+        println!();
+        println!("    supply-drop-bbs node set-meshtastic-radio");
+        println!("    supply-drop-bbs node set-meshtastic-owner");
+        println!();
+        println!("  Or push them later from Settings in the web admin UI.");
+        println!();
+    }
+
     if cfg!(target_os = "linux") {
         println!("To run Supply Drop BBS as a systemd service:");
         println!();

--- a/supply-drop-bbs.service
+++ b/supply-drop-bbs.service
@@ -13,7 +13,10 @@ Group=supply-drop
 # dialout gives access to the radio's serial port
 SupplementaryGroups=dialout
 ExecStart=/usr/local/bin/supply-drop-bbs run --config /etc/supply-drop-bbs/config.toml
-Restart=on-failure
+# `always` so the web-UI "restart service" (which works by exiting the process,
+# since NoNewPrivileges blocks `sudo systemctl`) reliably brings the service
+# back, and so the BBS auto-recovers from any unexpected exit.
+Restart=always
 RestartSec=5s
 StandardOutput=journal
 StandardError=journal


### PR DESCRIPTION
Consolidates a large run of Meshtastic device-management work, advert-list improvements, settings UX, and a service-restart fix. All changes verified to build with fmt/clippy(`-D warnings`)/tests/frontend green; Meshtastic protocol field numbers verified against `meshtastic/protobufs`.

## Adverts list
- **Transport column** showing which radio network each node was heard on (`meshcore` / `meshtastic`).
- **Filter dropdowns** for transport and type (plus the existing substring search).
- **Meshtastic role as type** — meshtastic nodes show their device role (`client` / `router` / `repeater` / `tracker` / `sensor` / …) from `User.role`, instead of always "unknown".
- Fixed the unreadable **clear-list** button contrast.

## Meshtastic device management
- **Admin reads & writes actually work**: correct admin packet framing, and **varied packet IDs** so the device doesn't silently dedup our admin requests (the GETs were timing out).
- **Apply-on-connect** for region / preset / hops / TX-enabled / RX-boosted-gain / ignore-MQTT — built by **merging onto the device's current config** (never a zeroed default, which previously clobbered `tx_enabled`/`hop_limit`), with **skip-if-unchanged** so the radio only writes (and reboots) when something actually changed.
- **Skip redundant `SetOwner`** — it was rebooting the radio on every connect.
- **Sync device time** and **manage fixed position** from `[location]` on connect.
- **`node_info_broadcast_secs = 3600`** (firmware minimum) so the node re-announces itself hourly — the firmware-native discovery mechanism.
- **Removed the no-op injected NodeInfo advert**: firmware only originates NodeInfo itself and does not retransmit a client-injected `NODEINFO_APP` packet, so the self-advert never reached the mesh.
- **"Reboot radio" button** to force an on-demand re-announce (boot-time NodeInfo broadcast) from the web UI.
- **Cached device snapshot** (LoRa + owner + security) served in one instant call from the connect-time sync — no per-section live round-trips.

## Settings UX
- **Tabbed settings page** (General / MeshCore / Meshtastic / System), grouping each transport's radio + identity together.
- Simplified Meshtastic radio form: region **auto-loads**, preset-derived fields hidden, **derived operating frequency** shown.
- **Node name always editable** (no longer gated behind a successful device read).

## Service
- Web **"restart service"** now restarts by **exiting for systemd** (the unit runs `NoNewPrivileges=yes` as a non-root user, so `sudo systemctl restart` could never escalate); unit `Restart=always`, dead sudoers rule removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
