### PR TITLE
fix(cli): delegate parse_command to canonical Command::parse (SYN-45)

### DIFF
--- a/crates/bbs-cli/src/lib.rs
+++ b/crates/bbs-cli/src/lib.rs
@@ -582,6 +582,7 @@ fn apply_socket_mode(path: &std::path::Path, mode_str: &str) {
 #[cfg(all(test, unix))]
 mod tests {
     use super::*;
+    use bbs_plugin_api::identity::Username;
 
     fn cmd(text: &str) -> Command {
         parse_command(text, false)

--- a/crates/bbs-cli/src/lib.rs
+++ b/crates/bbs-cli/src/lib.rs
@@ -605,15 +605,15 @@ mod tests {
 
     #[test]
     fn logout_and_quit() {
-        assert!(matches!(cmd("logout"), Command::Logout));
-        assert!(matches!(cmd("LOGOUT"), Command::Logout));
-        assert!(matches!(cmd("q"), Command::Logout));
-        assert!(matches!(cmd("Q"), Command::Logout));
+        assert!(matches!(cmd("logout"), Command::Quit));
+        assert!(matches!(cmd("LOGOUT"), Command::Quit));
+        assert!(matches!(cmd("q"), Command::Quit));
+        assert!(matches!(cmd("Q"), Command::Quit));
     }
 
     #[test]
-    fn whoami_is_unknown_on_cli() {
-        assert!(matches!(cmd("whoami"), Command::Unknown { .. }));
+    fn whoami_is_recognized_on_cli() {
+        assert!(matches!(cmd("whoami"), Command::Whoami));
     }
 
     #[test]

--- a/crates/bbs-cli/src/lib.rs
+++ b/crates/bbs-cli/src/lib.rs
@@ -59,7 +59,7 @@ use tracing::{debug, error, info, warn};
 
 // Unix-only: command/response types needed by the session implementation.
 #[cfg(unix)]
-use bbs_plugin_api::{identity::Username, Command, Response};
+use bbs_plugin_api::{Command, Response};
 
 // ── Config ────────────────────────────────────────────────────────────────────
 
@@ -511,57 +511,11 @@ async fn end_session(
 /// Parse a raw CLI input line into a [`Command`].
 ///
 /// Unlike the mesh transport there is no command prefix — CLI users type
-/// commands directly.  Workflow replies take priority when `awaiting_reply`
-/// is set.
+/// commands directly.  Delegates to the canonical [`Command::parse`] from
+/// `bbs-plugin-api` so all BBS commands are supported (SYN-45).
 #[cfg(unix)]
 fn parse_command(text: &str, awaiting_reply: bool) -> Command {
-    let text = text.trim();
-
-    if awaiting_reply {
-        return Command::WorkflowReply {
-            reply: text.to_owned(),
-        };
-    }
-
-    if text.is_empty() {
-        return Command::Unknown { raw: String::new() };
-    }
-
-    let (word, rest) = split_first_word(text);
-    let keyword = word.to_ascii_lowercase();
-
-    match keyword.as_str() {
-        "h" | "help" | "?" => Command::Help {
-            topic: rest.map(str::to_owned),
-        },
-        "register" => match rest.and_then(|s| Username::new(s).ok()) {
-            Some(u) => Command::Register { username: u },
-            None => Command::Help {
-                topic: Some("register".to_owned()),
-            },
-        },
-        "login" => match rest.and_then(|s| Username::new(s).ok()) {
-            Some(u) => Command::Login { username: u },
-            None => Command::Help {
-                topic: Some("login".to_owned()),
-            },
-        },
-        "logout" | "q" => Command::Logout,
-        _ => Command::Unknown {
-            raw: text.to_owned(),
-        },
-    }
-}
-
-#[cfg(unix)]
-fn split_first_word(s: &str) -> (&str, Option<&str>) {
-    match s.find(|c: char| c.is_ascii_whitespace()) {
-        None => (s, None),
-        Some(i) => {
-            let rest = s[i..].trim_start();
-            (&s[..i], if rest.is_empty() { None } else { Some(rest) })
-        }
-    }
+    Command::parse(text, awaiting_reply)
 }
 
 // ── Response rendering ────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- **SYN-45** — The CLI transport had a private `parse_command` that handled only `H/HELP/REGISTER/LOGIN/LOGOUT`. Every other authenticated BBS command (`N`, `F`, `R`, `S`, `E`, `D`, `K`, `G`, `C`, `M`, `W`, `B`, `V`, `BAN`, `PASSWD`, `WHOIS`, `.FF`, `.DR`, etc.) fell through to `Command::Unknown` and returned "Unknown command. Type H for help." to the operator via the Unix socket.

Replace the 50-line local parser with a single call to `Command::parse` from `bbs-plugin-api`, which already has the full implementation. The now-unused `split_first_word` helper and the `Username` import are removed.

## Test plan

- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo test --workspace` passes (156 tests, 0 failures)
- [ ] Manual: connect via `supply-drop-bbs connect`, log in, and confirm `N`, `K`, `E`, `D`, etc. work

🤖 Generated with [Claude Code](https://claude.com/claude-code)