### PR TITLE
fix(meshcore-companion): prevent panic on truncated frame in strip_frame_header (SYN-36)

### DIFF
--- a/crates/meshcore-companion/src/frame.rs
+++ b/crates/meshcore-companion/src/frame.rs
@@ -329,6 +329,13 @@ pub fn strip_frame_header(raw: &[u8]) -> Result<&[u8], FrameDecodeError> {
     if len > MAX_PAYLOAD_SIZE {
         return Err(FrameDecodeError::PayloadTooLarge(len));
     }
+    if raw.len() < 3 + len {
+        return Err(FrameDecodeError::BodyTooShort {
+            type_byte: 0,
+            needed: 3 + len,
+            got: raw.len(),
+        });
+    }
     Ok(&raw[3..3 + len])
 }
 

--- a/crates/meshcore-companion/tests/codec.rs
+++ b/crates/meshcore-companion/tests/codec.rs
@@ -61,6 +61,24 @@ fn strip_header_payload_too_large() {
     assert_eq!(err, FrameDecodeError::PayloadTooLarge(300));
 }
 
+#[test]
+fn strip_header_payload_truncated() {
+    // Header says 10 bytes, buffer has only 5 after the 3-byte header.
+    // Must return BodyTooShort rather than panicking (SYN-36).
+    let len: u16 = 10;
+    let mut raw = vec![FRAME_OUTBOUND_PREFIX, (len & 0xFF) as u8, (len >> 8) as u8];
+    raw.extend(vec![0u8; 5]); // only 5 bytes, not 10
+    let err = strip_frame_header(&raw).unwrap_err();
+    assert_eq!(
+        err,
+        FrameDecodeError::BodyTooShort {
+            type_byte: 0,
+            needed: 13,
+            got: 8,
+        }
+    );
+}
+
 // ── decode_inbound — zero-body frames ─────────────────────────────────────────
 
 #[test]


### PR DESCRIPTION
## Summary

strip_frame_header read the declared payload length from bytes 1-2 and validated it against MAX_PAYLOAD_SIZE, but never checked that the buffer actually contained 3 + len bytes before slicing. A truncated buffer whose declared length exceeded available bytes caused an index-out-of-bounds panic (SYN-36).

- Added bounds check: `if raw.len() < 3 + len { return Err(BodyTooShort { ... }) }` before the slice
- Added regression test `strip_header_payload_truncated` covering the previously-panicking path

## Test plan

- [x] cargo fmt clean
- [x] cargo clippy clean
- [x] New test passes; full 47-test codec suite passes

Generated with Claude Code