### PR TITLE
fix(config): document unimplemented rate-limit keys and warn at startup (SYN-3)

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -429,11 +429,17 @@ pub struct SecurityConfig {
     #[serde(default = "default_session_lifetime_mesh_secs")]
     pub session_lifetime_mesh_secs: u64,
 
-    /// Maximum failed login attempts per minute per source.
+    /// Reserved for future rate-limiting: maximum failed login attempts per
+    /// minute per source.  **Not yet implemented** — this value is parsed and
+    /// stored but no throttling code exists.  Setting a non-zero value has no
+    /// effect on login attempts today (SYN-3).
     #[serde(default = "default_login_rate_per_min")]
     pub login_rate_per_min: u32,
 
-    /// Maximum commands per minute per session.
+    /// Reserved for future rate-limiting: maximum commands per minute per
+    /// session.  **Not yet implemented** — this value is parsed and stored but
+    /// no throttling code exists.  Setting a non-default value has no effect
+    /// on command throughput today (SYN-3).
     #[serde(default = "default_command_rate_per_min")]
     pub command_rate_per_min: u32,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -578,6 +578,27 @@ async fn cmd_run(cli: &Cli) {
         "supply-drop-bbs starting"
     );
 
+    // SYN-3: warn operators whose configs set rate-limit keys that are not yet
+    // implemented, so they are not under the false impression these keys provide
+    // brute-force protection.
+    {
+        let sec = &cfg.security;
+        if sec.login_rate_per_min != 0 {
+            warn!(
+                login_rate_per_min = sec.login_rate_per_min,
+                "security.login_rate_per_min is set but rate limiting is NOT YET \
+                 IMPLEMENTED — login attempts are not throttled"
+            );
+        }
+        if sec.command_rate_per_min != 0 {
+            warn!(
+                command_rate_per_min = sec.command_rate_per_min,
+                "security.command_rate_per_min is set but rate limiting is NOT YET \
+                 IMPLEMENTED — command throughput is not throttled"
+            );
+        }
+    }
+
     // ── 3. Data directory ─────────────────────────────────────────────────────
     let data_dir = cfg
         .bbs


### PR DESCRIPTION
## Summary

\`security.login_rate_per_min\` and \`security.command_rate_per_min\` are parsed, stored, and round-tripped by the web API, but **no throttling code exists anywhere in the workspace**. A documented brute-force protection that silently does nothing is a security vulnerability (SYN-3).

- Updated the doc comments on both fields to clearly state they are **NOT YET IMPLEMENTED** and have no effect on actual behavior.
- Added a \`tracing::warn!\` at startup for each field if it is set to a non-zero value, so operators are not misled into believing these keys provide active protection.
- Keys are preserved (not removed) to avoid breaking existing configs and to serve as the implementation anchor when rate limiting is built.

## Test plan

- [x] \`cargo fmt\` clean
- [x] \`cargo clippy\` clean
- [x] Full workspace test suite passes

Generated with Claude Code