### PR TITLE
fix(auth): use full 32-byte pubkey for node credentials (SYN-11)

### DIFF
--- a/crates/bbs-core/migrations/0010_node_credential_full_pubkey.sql
+++ b/crates/bbs-core/migrations/0010_node_credential_full_pubkey.sql
@@ -1,0 +1,20 @@
+-- Replace 6-byte pubkey_prefix primary key with the full 32-byte pubkey (SYN-11).
+--
+-- The previous schema stored only the first 6 bytes of each node's Ed25519
+-- public key as the credential identifier.  A 48-bit identifier space is
+-- small enough that two nodes in the same mesh could share a prefix
+-- (birthday bound ~1/(2^48)); when they do, one node's credential slot
+-- silently overwrites the other's via ON CONFLICT DO UPDATE.
+--
+-- Existing rows cannot be migrated because the full 32-byte pubkeys are not
+-- stored anywhere — only the 6-byte prefixes.  All stored bindings are
+-- therefore dropped.  Users will need to log in once after this upgrade to
+-- re-establish their auto-login credential.
+
+DROP TABLE IF EXISTS node_credentials;
+
+CREATE TABLE node_credentials (
+    pubkey    BLOB    NOT NULL PRIMARY KEY,  -- full 32-byte Ed25519 public key
+    user_id   INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    last_auth TEXT    NOT NULL
+);

--- a/crates/bbs-core/src/db/node_credential_store.rs
+++ b/crates/bbs-core/src/db/node_credential_store.rs
@@ -17,21 +17,21 @@ impl<'db> NodeCredentialStore<'db> {
         Self { db }
     }
 
-    /// Insert or refresh the binding for a node pubkey prefix.
+    /// Insert or refresh the binding for a node's full 32-byte public key.
     pub(crate) async fn upsert(
         &self,
-        prefix: &[u8; 6],
+        pubkey: &[u8; 32],
         user_id: UserId,
         now: Timestamp,
     ) -> Result<(), StoreError> {
-        let blob: &[u8] = prefix;
+        let blob: &[u8] = pubkey;
         let uid = user_id.as_i64();
         let ts = now.to_rfc3339();
         sqlx::query(
             r#"
-            INSERT INTO node_credentials (pubkey_prefix, user_id, last_auth)
+            INSERT INTO node_credentials (pubkey, user_id, last_auth)
             VALUES (?, ?, ?)
-            ON CONFLICT(pubkey_prefix) DO UPDATE
+            ON CONFLICT(pubkey) DO UPDATE
               SET user_id   = excluded.user_id,
                   last_auth = excluded.last_auth
             "#,
@@ -44,20 +44,20 @@ impl<'db> NodeCredentialStore<'db> {
         Ok(())
     }
 
-    /// Look up the user bound to this prefix, enforcing `ttl_days`.
+    /// Look up the user bound to this full 32-byte public key, enforcing `ttl_days`.
     ///
     /// Returns `None` when no binding exists or it has expired.
     pub(crate) async fn lookup(
         &self,
-        prefix: &[u8; 6],
+        pubkey: &[u8; 32],
         ttl_days: u32,
     ) -> Result<Option<UserId>, StoreError> {
-        let blob: &[u8] = prefix;
+        let blob: &[u8] = pubkey;
         let ttl = format!("-{ttl_days} days");
         let row = sqlx::query(
             r#"
             SELECT user_id FROM node_credentials
-            WHERE pubkey_prefix = ?
+            WHERE pubkey = ?
               AND last_auth >= datetime('now', ?)
             "#,
         )
@@ -75,10 +75,10 @@ impl<'db> NodeCredentialStore<'db> {
         }
     }
 
-    /// Remove the binding for this prefix (called on explicit logout).
-    pub(crate) async fn delete(&self, prefix: &[u8; 6]) -> Result<(), StoreError> {
-        let blob: &[u8] = prefix;
-        sqlx::query("DELETE FROM node_credentials WHERE pubkey_prefix = ?")
+    /// Remove the binding for this full 32-byte public key (called on explicit logout).
+    pub(crate) async fn delete(&self, pubkey: &[u8; 32]) -> Result<(), StoreError> {
+        let blob: &[u8] = pubkey;
+        sqlx::query("DELETE FROM node_credentials WHERE pubkey = ?")
             .bind(blob)
             .execute(&self.db.write_pool)
             .await?;

--- a/crates/bbs-core/src/host.rs
+++ b/crates/bbs-core/src/host.rs
@@ -1339,14 +1339,14 @@ impl Host for BbsHost {
     async fn mesh_node_restore(
         &self,
         session: SessionId,
-        prefix: [u8; 6],
+        pubkey: [u8; 32],
         ttl_days: u32,
     ) -> Result<Option<Username>, HostError> {
         // Look up a still-valid binding.
         let user_id = self
             .db
             .node_credentials()
-            .lookup(&prefix, ttl_days)
+            .lookup(&pubkey, ttl_days)
             .await
             .map_err(|e| HostError::Storage(format!("node_credential lookup: {e}")))?;
 
@@ -1381,7 +1381,7 @@ impl Host for BbsHost {
         // Refresh last_auth so the TTL clock resets on each successful auto-login.
         self.db
             .node_credentials()
-            .upsert(&prefix, user_id, Timestamp::now())
+            .upsert(&pubkey, user_id, Timestamp::now())
             .await
             .map_err(|e| HostError::Storage(format!("node_credential upsert: {e}")))?;
 
@@ -1389,7 +1389,7 @@ impl Host for BbsHost {
         Ok(Some(user.username))
     }
 
-    async fn mesh_node_bind(&self, session: SessionId, prefix: [u8; 6]) -> Result<(), HostError> {
+    async fn mesh_node_bind(&self, session: SessionId, pubkey: [u8; 32]) -> Result<(), HostError> {
         let user_id = {
             let sessions = self.sessions.read().await;
             sessions.get(&session).and_then(|r| r.user_id)
@@ -1399,15 +1399,15 @@ impl Host for BbsHost {
         };
         self.db
             .node_credentials()
-            .upsert(&prefix, user_id, Timestamp::now())
+            .upsert(&pubkey, user_id, Timestamp::now())
             .await
             .map_err(|e| HostError::Storage(format!("node_credential upsert: {e}")))
     }
 
-    async fn mesh_node_unbind(&self, prefix: [u8; 6]) -> Result<(), HostError> {
+    async fn mesh_node_unbind(&self, pubkey: [u8; 32]) -> Result<(), HostError> {
         self.db
             .node_credentials()
-            .delete(&prefix)
+            .delete(&pubkey)
             .await
             .map_err(|e| HostError::Storage(format!("node_credential delete: {e}")))
     }

--- a/crates/bbs-mesh/src/transport.rs
+++ b/crates/bbs-mesh/src/transport.rs
@@ -1040,6 +1040,13 @@ async fn dispatch_message(
         debug!(?session, prefix = ?sender_prefix, "mesh: new session minted");
     }
 
+    // Resolve the full 32-byte pubkey for this node (populated by advert/contact frames).
+    // Credential operations require the full key; if unavailable, they are skipped.
+    let full_pubkey: Option<[u8; 32]> = state
+        .lock()
+        .expect("state mutex poisoned")
+        .get_full_pubkey(&sender_prefix);
+
     // Determine whether this node already has an authenticated BBS session.
     // We greet unauthenticated nodes every time they contact us so they always
     // see the welcome message and know how to register/log in — not just the
@@ -1053,17 +1060,21 @@ async fn dispatch_message(
 
     if !already_authenticated {
         // Attempt auto-login via stored node credential (new sessions only;
-        // skip when TTL = 0 or the session already exists).
+        // skip when TTL = 0, the session already exists, or full pubkey unknown).
         let auto_username = if is_new && node_credential_ttl_days > 0 {
-            match host
-                .mesh_node_restore(session, sender_prefix, node_credential_ttl_days)
-                .await
-            {
-                Ok(u) => u,
-                Err(e) => {
-                    warn!(?session, "mesh: node_restore error: {e}");
-                    None
+            if let Some(pubkey) = full_pubkey {
+                match host
+                    .mesh_node_restore(session, pubkey, node_credential_ttl_days)
+                    .await
+                {
+                    Ok(u) => u,
+                    Err(e) => {
+                        warn!(?session, "mesh: node_restore error: {e}");
+                        None
+                    }
                 }
+            } else {
+                None
             }
         } else {
             None
@@ -1202,11 +1213,13 @@ async fn dispatch_message(
             active_sid = fresh_sid;
             // Attempt auto-login on the refreshed session before replaying the command.
             if node_credential_ttl_days > 0 {
-                if let Err(e) = host
-                    .mesh_node_restore(fresh_sid, sender_prefix, node_credential_ttl_days)
-                    .await
-                {
-                    warn!(?fresh_sid, "mesh: node_restore on refresh error: {e}");
+                if let Some(pubkey) = full_pubkey {
+                    if let Err(e) = host
+                        .mesh_node_restore(fresh_sid, pubkey, node_credential_ttl_days)
+                        .await
+                    {
+                        warn!(?fresh_sid, "mesh: node_restore on refresh error: {e}");
+                    }
                 }
             }
             // The original command was parsed with the stale transport state
@@ -1237,19 +1250,22 @@ async fn dispatch_message(
     };
 
     // ── Persist / clear node credential on auth state changes ────────────────
+    // Only operate when the full 32-byte pubkey is known; skip silently otherwise.
     if node_credential_ttl_days > 0 {
-        match &response {
-            Response::LoggedIn { .. } => {
-                if let Err(e) = host.mesh_node_bind(active_sid, sender_prefix).await {
-                    warn!(?active_sid, "mesh: node_bind error: {e}");
+        if let Some(pubkey) = full_pubkey {
+            match &response {
+                Response::LoggedIn { .. } => {
+                    if let Err(e) = host.mesh_node_bind(active_sid, pubkey).await {
+                        warn!(?active_sid, "mesh: node_bind error: {e}");
+                    }
                 }
-            }
-            Response::LoggedOut => {
-                if let Err(e) = host.mesh_node_unbind(sender_prefix).await {
-                    warn!("mesh: node_unbind error: {e}");
+                Response::LoggedOut => {
+                    if let Err(e) = host.mesh_node_unbind(pubkey).await {
+                        warn!("mesh: node_unbind error: {e}");
+                    }
                 }
+                _ => {}
             }
-            _ => {}
         }
     }
 

--- a/crates/bbs-meshtastic/src/lib.rs
+++ b/crates/bbs-meshtastic/src/lib.rs
@@ -36,9 +36,9 @@ use crate::{
         admin_get_lora_config, admin_get_owner, admin_get_security_config, admin_get_session_key,
         admin_message, admin_reboot, admin_remove_fixed_position, admin_set_device_config,
         admin_set_fixed_position, admin_set_lora_config, admin_set_owner, admin_set_time,
-        direct_text_packet, from_radio, mesh_packet, mt_config, node_key, synthetic_pubkey,
-        AdminMessage, Data, LoRaConfig, MeshPacket, MtConfig, NodeInfo, BROADCAST_ADDR,
-        PORT_ADMIN_APP, PORT_NODEINFO_APP, PORT_TEXT_MESSAGE_APP,
+        direct_text_packet, from_radio, mesh_packet, mt_config, synthetic_pubkey, AdminMessage,
+        Data, LoRaConfig, MeshPacket, MtConfig, NodeInfo, BROADCAST_ADDR, PORT_ADMIN_APP,
+        PORT_NODEINFO_APP, PORT_TEXT_MESSAGE_APP,
     },
     session::SessionState,
     stream::{ClientEvent, MeshtasticClient, SerialConfig, TcpConfig},
@@ -1889,7 +1889,11 @@ async fn dispatch_message(
     if is_new {
         let auto_username = if node_credential_ttl_days > 0 {
             match host
-                .mesh_node_restore(session, node_key(node_num), node_credential_ttl_days)
+                .mesh_node_restore(
+                    session,
+                    synthetic_pubkey(node_num),
+                    node_credential_ttl_days,
+                )
                 .await
             {
                 Ok(username) => username,
@@ -1980,7 +1984,7 @@ async fn dispatch_message(
                 .get_or_insert(node_num, fresh);
             if node_credential_ttl_days > 0 {
                 let _ = host
-                    .mesh_node_restore(fresh, node_key(node_num), node_credential_ttl_days)
+                    .mesh_node_restore(fresh, synthetic_pubkey(node_num), node_credential_ttl_days)
                     .await;
             }
             match host.process_command(fresh, cmd).await {
@@ -1994,12 +1998,15 @@ async fn dispatch_message(
     if node_credential_ttl_days > 0 {
         match &response {
             Response::LoggedIn { .. } => {
-                if let Err(e) = host.mesh_node_bind(session, node_key(node_num)).await {
+                if let Err(e) = host
+                    .mesh_node_bind(session, synthetic_pubkey(node_num))
+                    .await
+                {
                     warn!(?session, "meshtastic: node_bind error: {e}");
                 }
             }
             Response::LoggedOut => {
-                if let Err(e) = host.mesh_node_unbind(node_key(node_num)).await {
+                if let Err(e) = host.mesh_node_unbind(synthetic_pubkey(node_num)).await {
                     warn!("meshtastic: node_unbind error: {e}");
                 }
             }

--- a/crates/bbs-meshtastic/src/proto.rs
+++ b/crates/bbs-meshtastic/src/proto.rs
@@ -282,6 +282,7 @@ pub fn direct_text_packet(
     }
 }
 
+#[allow(dead_code)]
 pub fn node_key(node_num: u32) -> [u8; 6] {
     let n = node_num.to_be_bytes();
     [b'M', b'T', n[0], n[1], n[2], n[3]]

--- a/crates/bbs-plugin-api/src/host.rs
+++ b/crates/bbs-plugin-api/src/host.rs
@@ -570,7 +570,7 @@ pub trait Host: Send + Sync {
     /// Check whether a mesh node has a valid stored credential and, if so,
     /// auto-bind the session to that user.
     ///
-    /// `prefix` is the first 6 bytes of the node's Ed25519 public key.
+    /// `pubkey` is the node's full 32-byte Ed25519 public key.
     /// `ttl_days` is the maximum age of a valid credential.
     ///
     /// Returns `Some(username)` on a successful restore (the session is now
@@ -579,10 +579,10 @@ pub trait Host: Send + Sync {
     async fn mesh_node_restore(
         &self,
         session: SessionId,
-        prefix: [u8; 6],
+        pubkey: [u8; 32],
         ttl_days: u32,
     ) -> Result<Option<crate::identity::Username>, HostError> {
-        let _ = (session, prefix, ttl_days);
+        let _ = (session, pubkey, ttl_days);
         Ok(None)
     }
 
@@ -590,16 +590,16 @@ pub trait Host: Send + Sync {
     ///
     /// Called by the mesh transport immediately after it receives
     /// `Response::LoggedIn`.  Idempotent: calling again refreshes `last_auth`.
-    async fn mesh_node_bind(&self, session: SessionId, prefix: [u8; 6]) -> Result<(), HostError> {
-        let _ = (session, prefix);
+    async fn mesh_node_bind(&self, session: SessionId, pubkey: [u8; 32]) -> Result<(), HostError> {
+        let _ = (session, pubkey);
         Ok(())
     }
 
-    /// Remove the stored binding for a node prefix on explicit logout.
+    /// Remove the stored binding for this node on explicit logout.
     ///
     /// Called by the mesh transport when it receives `Response::LoggedOut`.
-    async fn mesh_node_unbind(&self, prefix: [u8; 6]) -> Result<(), HostError> {
-        let _ = prefix;
+    async fn mesh_node_unbind(&self, pubkey: [u8; 32]) -> Result<(), HostError> {
+        let _ = pubkey;
         Ok(())
     }
 }


### PR DESCRIPTION
## Summary

- The `node_credentials` table keyed on a 6-byte pubkey prefix (48-bit space). Two nodes with the same first 6 bytes of their Ed25519 key shared a credential slot — one node's binding would silently overwrite the other's via `ON CONFLICT DO UPDATE`.
- Migration 0010 drops and recreates the table with a full 32-byte primary key. Existing bindings are cleared (6-byte prefixes cannot be expanded to full pubkeys). Users will need to log in once to re-establish auto-login.
- Both transports updated to pass 32-byte keys:
  - **bbs-mesh (MeshCore)**: looks up the full pubkey from in-memory session state (populated on advert/contact frames); skips credential operations when the pubkey is not yet known. Practically: GetContacts runs on connect so all existing nodes have their pubkeys registered before the drain completes.
  - **bbs-meshtastic**: uses the already-present `synthetic_pubkey(node_num)` (32-byte zero-padded `MT` + big-endian node_num) instead of the 6-byte `node_key()`.

## Test plan

- [ ] All pre-commit checks pass (verified: 263 tests, all green)
- [ ] Apply migration against a test DB with existing node_credentials rows — confirm the table is recreated clean
- [ ] Verify auto-login binds successfully after node advert is received: login, logout, restart BBS, wait for GetContacts, send message — should auto-login
- [ ] Verify auto-login is skipped gracefully on first message before advert received — no crash, user prompted to log in normally
- [ ] Verify Meshtastic credential round-trip: login → `synthetic_pubkey` bound → restart → auto-login via same `synthetic_pubkey`
- [ ] No regression: fresh DB (no credentials) runs all tests cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)