### PR TITLE
fix(auth): evict sessions on ban and invalidate web token cache (SYN-2, SYN-23)

### DIFF
--- a/crates/bbs-core/src/host.rs
+++ b/crates/bbs-core/src/host.rs
@@ -967,17 +967,32 @@ impl Host for BbsHost {
             .await
             .map_err(|e| HostError::Storage(format!("{e}")))?;
 
-        // If banning, kick any live sessions for this user.
-        if matches!(new_status, Some(UserStatus::Banned)) {
-            let mut sessions = self.sessions.write().await;
-            for r in sessions.values_mut() {
-                if r.username.as_ref().map(|u| u.as_str()) == Some(username) {
-                    r.workflow = crate::host::Workflow::None;
+        // If banning or deleting, forcibly remove all live sessions and fire SessionEnded.
+        if matches!(
+            new_status,
+            Some(UserStatus::Banned) | Some(UserStatus::Deleted)
+        ) {
+            let to_end: Vec<SessionId> = {
+                let mut sessions = self.sessions.write().await;
+                let ids: Vec<SessionId> = sessions
+                    .iter()
+                    .filter(|(_, r)| r.username.as_ref().map(|u| u.as_str()) == Some(username))
+                    .map(|(id, _)| *id)
+                    .collect();
+                for id in &ids {
+                    sessions.remove(id);
                 }
+                ids
+            };
+            for id in to_end {
+                let _ = self.events_tx.send(DomainEvent::SessionEnded {
+                    session: id,
+                    reason: "user banned".into(),
+                });
             }
         }
 
-        // If validating (level change from Unvalidated → something higher), update live sessions.
+        // If the permission level changed, update in-memory session state for live sessions.
         if let Some(level) = new_level {
             let mut sessions = self.sessions.write().await;
             for r in sessions.values_mut() {
@@ -4040,16 +4055,23 @@ impl BbsHost {
         .map_err(|e| HostError::Storage(format!("{e}")))?;
 
         // Force-end any active sessions for this user.
-        {
+        let to_end: Vec<SessionId> = {
             let mut sessions = self.sessions.write().await;
-            let to_end: Vec<SessionId> = sessions
+            let ids: Vec<SessionId> = sessions
                 .iter()
                 .filter(|(_, r)| r.username.as_ref() == Some(&username))
                 .map(|(id, _)| *id)
                 .collect();
-            for id in to_end {
-                sessions.remove(&id);
+            for id in &ids {
+                sessions.remove(id);
             }
+            ids
+        };
+        for id in to_end {
+            let _ = self.events_tx.send(DomainEvent::SessionEnded {
+                session: id,
+                reason: "user banned".into(),
+            });
         }
 
         if let Err(e) = self
@@ -5802,6 +5824,99 @@ mod tests {
                 "verified user should land in Lobby after login"
             );
         }
+    }
+
+    #[tokio::test]
+    async fn admin_update_user_ban_evicts_live_session() {
+        let (host, _db) = make_host().await;
+        let mut ev_rx = host.events_tx.subscribe();
+
+        // Register + log in "alice".
+        let sid = host.create_session("test").await.unwrap();
+        let uname = Username::new("alice").unwrap();
+        register_and_login(&host, sid, &uname, "hunter99").await;
+
+        // Confirm the session is authenticated.
+        let ctx = host.permission_ctx(sid).await.unwrap();
+        assert!(ctx.username.is_some(), "alice should be logged in");
+
+        // Drain the SessionCreated + SessionAuthenticated events fired above.
+        while ev_rx.try_recv().is_ok() {}
+
+        // Ban alice via the web-API path.
+        host.admin_update_user("alice", Some(1), None)
+            .await
+            .unwrap();
+
+        // Session must be gone from the map.
+        assert!(
+            host.sessions.read().await.get(&sid).is_none(),
+            "banned user's session must be removed"
+        );
+
+        // SessionEnded event must have been fired.
+        let ended = ev_rx.try_recv().expect("SessionEnded event expected");
+        assert!(
+            matches!(ended, DomainEvent::SessionEnded { session, .. } if session == sid),
+            "expected SessionEnded for alice's session, got {ended:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn ban_command_evicts_live_session_and_fires_event() {
+        let (host, _db) = make_host().await;
+        let mut ev_rx = host.events_tx.subscribe();
+
+        // Register a sysop.
+        let sysop_sid = host.create_session("test").await.unwrap();
+        let sysop = Username::new("sysop").unwrap();
+        register_and_login(&host, sysop_sid, &sysop, "pass12345678").await;
+        // First registrant auto-gets sysop — verify.
+        assert_eq!(
+            host.permission_ctx(sysop_sid).await.unwrap().level,
+            PermissionLevel::Sysop
+        );
+
+        // Register alice.
+        let alice_sid = host.create_session("test").await.unwrap();
+        let alice = Username::new("alice").unwrap();
+        register_and_login(&host, alice_sid, &alice, "hunter99").await;
+
+        // Drain events so far.
+        while ev_rx.try_recv().is_ok() {}
+
+        // Sysop bans alice via the in-BBS command.
+        let resp = host
+            .process_command(
+                sysop_sid,
+                Command::BanUser {
+                    username: alice.clone(),
+                },
+            )
+            .await
+            .unwrap();
+        assert!(
+            matches!(resp, Response::Text(_)),
+            "ban should return Text, got {resp:?}"
+        );
+
+        // Alice's session must be removed.
+        assert!(
+            host.sessions.read().await.get(&alice_sid).is_none(),
+            "banned alice's session must be removed"
+        );
+
+        // Drain events until we see SessionEnded for alice's session.
+        let found = loop {
+            match ev_rx.try_recv() {
+                Ok(DomainEvent::SessionEnded { session, .. }) if session == alice_sid => {
+                    break true;
+                }
+                Ok(_) => continue,
+                Err(_) => break false,
+            }
+        };
+        assert!(found, "SessionEnded for alice's session was not fired");
     }
 
     // ── Test helper: register + login in one call ─────────────────────────────

--- a/crates/bbs-web/src/lib.rs
+++ b/crates/bbs-web/src/lib.rs
@@ -317,6 +317,15 @@ impl AppState {
             .expect("sessions poisoned")
             .remove(token);
     }
+
+    /// Remove all web sessions for `username` — called after ban or permission change
+    /// so stale cached `permission_level` values cannot be exploited.
+    fn invalidate_sessions_for(&self, username: &str) {
+        self.sessions
+            .lock()
+            .expect("sessions poisoned")
+            .retain(|_, s| s.username != username);
+    }
 }
 
 // ── WebPlugin ─────────────────────────────────────────────────────────────────
@@ -1178,6 +1187,11 @@ async fn api_update_user(
             .await
         {
             Ok(()) => {
+                // Invalidate web sessions whenever status or permission level changes so
+                // a banned or demoted user cannot continue using a cached web token.
+                if body.status.is_some() || body.permission_level.is_some() {
+                    state.invalidate_sessions_for(&username);
+                }
                 if let Some(s) = body.status {
                     let action = if s == 1 { "ban" } else { "unban" };
                     if let Err(e) = state


### PR DESCRIPTION
## Summary

- **SYN-2**: `admin_update_user` (web-API ban path) only reset session workflow state — the banned user could continue issuing commands until their session naturally expired. `handle_ban_user` (in-BBS BAN command) removed sessions from the map but never fired `DomainEvent::SessionEnded`, so connected transports kept the socket open.
- **SYN-23**: `api_update_user` never invalidated the `bbs-web` session token cache on ban or permission-level change. A banned or demoted sysop retained full web-admin access for up to 12 hours.

### Changes

**`crates/bbs-core/src/host.rs`**
- `admin_update_user`: on ban/delete, collect matching session IDs, remove them from the sessions map, and fire `DomainEvent::SessionEnded` for each
- `handle_ban_user`: same — was removing sessions but not firing the event

**`crates/bbs-web/src/lib.rs`**
- Added `AppState::invalidate_sessions_for(username)` which drops all cached web tokens for that user
- `api_update_user`: calls `invalidate_sessions_for` after any successful status or permission_level change

Two new tests added:
- `admin_update_user_ban_evicts_live_session`
- `ban_command_evicts_live_session_and_fires_event`

## Test plan

- [x] `cargo test -p bbs-core` — 73 tests pass (was 71 before new tests)
- [x] Full workspace `cargo test` — 265 tests pass
- [x] `cargo clippy` — clean
- [x] `cargo fmt` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)