### PR TITLE
fix(web,setup): write config and zip backups atomically (SYN-25, SYN-26)

### DIFF
--- a/crates/bbs-web/src/lib.rs
+++ b/crates/bbs-web/src/lib.rs
@@ -910,7 +910,7 @@ async fn api_update_native_plugin(
 
     doc["plugins"][name.as_str()]["enabled"] = toml_edit::value(enabled);
 
-    if let Err(e) = std::fs::write(&path, doc.to_string()) {
+    if let Err(e) = atomic_write_file(std::path::Path::new(&path), doc.to_string().as_bytes()) {
         return (
             StatusCode::INTERNAL_SERVER_ERROR,
             Json(json_error(&format!("could not write config file: {e}"))),
@@ -2212,7 +2212,7 @@ async fn api_patch_config(
         doc["logging"]["level"] = toml_edit::value(v.to_ascii_uppercase());
     }
 
-    if let Err(e) = std::fs::write(&path, doc.to_string()) {
+    if let Err(e) = atomic_write_file(std::path::Path::new(&path), doc.to_string().as_bytes()) {
         return (
             StatusCode::INTERNAL_SERVER_ERROR,
             Json(json_error(&format!("could not write config file: {e}"))),
@@ -2523,7 +2523,7 @@ async fn api_patch_radio_config(
         }
     }
 
-    if let Err(e) = std::fs::write(&path, doc.to_string()) {
+    if let Err(e) = atomic_write_file(std::path::Path::new(&path), doc.to_string().as_bytes()) {
         return (
             StatusCode::INTERNAL_SERVER_ERROR,
             Json(json_error(&format!("could not write config file: {e}"))),
@@ -2716,7 +2716,8 @@ fn save_meshtastic_radio_to_config(
         toml_edit::Item::Value(toml_edit::Value::from(tx_enabled)),
     );
 
-    std::fs::write(&path, doc.to_string()).map_err(|e| format!("write error: {e}"))?;
+    atomic_write_file(&path, doc.to_string().as_bytes())
+        .map_err(|e| format!("write error: {e}"))?;
     Ok(true)
 }
 
@@ -2768,7 +2769,8 @@ fn save_meshtastic_owner_to_config(
         );
     }
 
-    std::fs::write(&path, doc.to_string()).map_err(|e| format!("write error: {e}"))?;
+    atomic_write_file(&path, doc.to_string().as_bytes())
+        .map_err(|e| format!("write error: {e}"))?;
     Ok(true)
 }
 
@@ -3239,38 +3241,54 @@ async fn api_trigger_backup(State(state): State<Arc<AppState>>) -> Response {
     let db_entry_name = record.filename.clone();
 
     let zip_result = tokio::task::spawn_blocking(move || -> std::io::Result<u64> {
-        let file = std::fs::File::create(&zip_path)?;
-        let mut zip = zip::ZipWriter::new(file);
-        let opts = SimpleFileOptions::default().compression_method(CompressionMethod::Deflated);
+        // Write to a .tmp sibling; rename over the final path only on success
+        // so a crash mid-write never leaves a corrupt zip visible.
+        let mut tmp_name = zip_path.as_os_str().to_owned();
+        tmp_name.push(".tmp");
+        let tmp_zip_path = std::path::PathBuf::from(tmp_name);
 
-        // Add database.
-        zip.start_file(&db_entry_name, opts)?;
-        zip.write_all(&std::fs::read(&db_path)?)?;
+        let write_result = (|| -> std::io::Result<()> {
+            let file = std::fs::File::create(&tmp_zip_path)?;
+            let mut zip = zip::ZipWriter::new(file);
+            let opts = SimpleFileOptions::default().compression_method(CompressionMethod::Deflated);
 
-        // Add config (best-effort — log a warning if the path doesn't exist).
-        if let Some(ref cfg) = config_path_opt {
-            if !cfg.is_empty() {
-                match std::fs::read(cfg) {
-                    Ok(bytes) => {
-                        zip.start_file("config.toml", opts)?;
-                        zip.write_all(&bytes)?;
-                    }
-                    Err(e) => {
-                        tracing::warn!(
-                            "backup: could not include config file '{}': {} \
-                             — set config_path in [plugins.web] to the full \
-                             path of your config.toml",
-                            cfg,
-                            e
-                        );
+            // Add database.
+            zip.start_file(&db_entry_name, opts)?;
+            zip.write_all(&std::fs::read(&db_path)?)?;
+
+            // Add config (best-effort — log a warning if the path doesn't exist).
+            if let Some(ref cfg) = config_path_opt {
+                if !cfg.is_empty() {
+                    match std::fs::read(cfg) {
+                        Ok(bytes) => {
+                            zip.start_file("config.toml", opts)?;
+                            zip.write_all(&bytes)?;
+                        }
+                        Err(e) => {
+                            tracing::warn!(
+                                "backup: could not include config file '{}': {} \
+                                 — set config_path in [plugins.web] to the full \
+                                 path of your config.toml",
+                                cfg,
+                                e
+                            );
+                        }
                     }
                 }
             }
+
+            let inner = zip.finish()?;
+            inner.sync_all()?;
+            drop(inner);
+            std::fs::rename(&tmp_zip_path, &zip_path)
+        })();
+
+        if write_result.is_err() {
+            let _ = std::fs::remove_file(&tmp_zip_path);
+            return write_result.map(|_| 0);
         }
 
-        zip.finish()?;
-
-        // Remove the raw .db now that it is inside the zip.
+        // Remove the raw .db now that it is safely inside the zip.
         let _ = std::fs::remove_file(&db_path);
 
         Ok(std::fs::metadata(&zip_path)?.len())
@@ -3445,6 +3463,28 @@ async fn spa_handler(uri: axum::http::Uri) -> Response {
         )
             .into_response(),
     }
+}
+
+// ── File helpers ──────────────────────────────────────────────────────────────
+
+/// Write `contents` to `path` atomically: write to a `.tmp` sibling, fsync,
+/// then rename over the destination. The caller's data is never half-visible.
+fn atomic_write_file(path: &std::path::Path, contents: &[u8]) -> std::io::Result<()> {
+    use std::io::Write as _;
+    let mut tmp_name = path.as_os_str().to_owned();
+    tmp_name.push(".tmp");
+    let tmp = std::path::PathBuf::from(tmp_name);
+    let mut f = std::fs::File::create(&tmp)?;
+    if let Err(e) = f.write_all(contents).and_then(|_| f.sync_all()) {
+        let _ = std::fs::remove_file(&tmp);
+        return Err(e);
+    }
+    drop(f);
+    if let Err(e) = std::fs::rename(&tmp, path) {
+        let _ = std::fs::remove_file(&tmp);
+        return Err(e);
+    }
+    Ok(())
 }
 
 // ── Error helpers ─────────────────────────────────────────────────────────────

--- a/src/main.rs
+++ b/src/main.rs
@@ -1210,13 +1210,33 @@ fn open_config_for_edit(
     (path, doc)
 }
 
+/// Write `contents` to `path` atomically: write to a `.tmp` sibling, fsync,
+/// then rename over the destination.
+fn atomic_write_file(path: &std::path::Path, contents: &[u8]) -> std::io::Result<()> {
+    use std::io::Write as _;
+    let mut tmp_name = path.as_os_str().to_owned();
+    tmp_name.push(".tmp");
+    let tmp = std::path::PathBuf::from(tmp_name);
+    let mut f = std::fs::File::create(&tmp)?;
+    if let Err(e) = f.write_all(contents).and_then(|_| f.sync_all()) {
+        let _ = std::fs::remove_file(&tmp);
+        return Err(e);
+    }
+    drop(f);
+    if let Err(e) = std::fs::rename(&tmp, path) {
+        let _ = std::fs::remove_file(&tmp);
+        return Err(e);
+    }
+    Ok(())
+}
+
 fn config_edit_bbs_bool(config_path: Option<&std::path::Path>, key: &str, value: bool) {
     let (path, mut doc) = open_config_for_edit(config_path);
     if doc.get("bbs").is_none() {
         doc["bbs"] = toml_edit::Item::Table(toml_edit::Table::new());
     }
     doc["bbs"][key] = toml_edit::value(value);
-    if let Err(e) = std::fs::write(&path, doc.to_string()) {
+    if let Err(e) = atomic_write_file(&path, doc.to_string().as_bytes()) {
         eprintln!("error writing {}: {e}", path.display());
         std::process::exit(1);
     }
@@ -1228,7 +1248,7 @@ fn config_edit_bbs_string(config_path: Option<&std::path::Path>, key: &str, valu
         doc["bbs"] = toml_edit::Item::Table(toml_edit::Table::new());
     }
     doc["bbs"][key] = toml_edit::value(value);
-    if let Err(e) = std::fs::write(&path, doc.to_string()) {
+    if let Err(e) = atomic_write_file(&path, doc.to_string().as_bytes()) {
         eprintln!("error writing {}: {e}", path.display());
         std::process::exit(1);
     }
@@ -1239,7 +1259,7 @@ fn config_remove_bbs_key(config_path: Option<&std::path::Path>, key: &str) {
     if let Some(bbs) = doc.get_mut("bbs").and_then(|t| t.as_table_mut()) {
         bbs.remove(key);
     }
-    if let Err(e) = std::fs::write(&path, doc.to_string()) {
+    if let Err(e) = atomic_write_file(&path, doc.to_string().as_bytes()) {
         eprintln!("error writing {}: {e}", path.display());
         std::process::exit(1);
     }
@@ -1451,7 +1471,7 @@ fn write_plugin_file_sync(dir: &std::path::Path, cfg: &bbs_plugin_api::ProcessPl
         }
     };
     let path = dir.join(format!("{}.toml", cfg.name));
-    if let Err(e) = std::fs::write(&path, content) {
+    if let Err(e) = atomic_write_file(&path, content.as_bytes()) {
         eprintln!("error: cannot write {}: {e}", path.display());
         std::process::exit(1);
     }
@@ -1513,7 +1533,7 @@ fn write_plugins(
         aot.push(tbl);
     }
     doc["plugins"]["process"] = toml_edit::Item::ArrayOfTables(aot);
-    if let Err(e) = std::fs::write(path, doc.to_string()) {
+    if let Err(e) = atomic_write_file(path, doc.to_string().as_bytes()) {
         eprintln!("error writing config: {e}");
         std::process::exit(1);
     }
@@ -1911,7 +1931,7 @@ fn save_radio_config(config_path: Option<&std::path::Path>, r: &ResolvedRadio) {
     doc["plugins"]["mesh"]["radio"]["coding_rate"] = toml_edit::value(r.coding_rate as i64);
     doc["plugins"]["mesh"]["radio"]["tx_power_dbm"] = toml_edit::value(r.tx_power_dbm as i64);
 
-    if let Err(e) = std::fs::write(&path, doc.to_string()) {
+    if let Err(e) = atomic_write_file(&path, doc.to_string().as_bytes()) {
         eprintln!("warning: --save: could not write {}: {e}", path.display());
     } else {
         eprintln!("Saved radio config to {}.", path.display());

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -22,8 +22,28 @@
 use std::{
     fmt::Write as FmtWrite,
     fs,
+    io::Write as IoWrite,
     path::{Path, PathBuf},
 };
+
+/// Write `contents` to `path` atomically: write to a `.tmp` sibling, fsync,
+/// then rename over the destination.
+fn atomic_write_file(path: &Path, contents: &[u8]) -> std::io::Result<()> {
+    let mut tmp_name = path.as_os_str().to_owned();
+    tmp_name.push(".tmp");
+    let tmp = PathBuf::from(tmp_name);
+    let mut f = fs::File::create(&tmp)?;
+    if let Err(e) = f.write_all(contents).and_then(|_| f.sync_all()) {
+        let _ = fs::remove_file(&tmp);
+        return Err(e);
+    }
+    drop(f);
+    if let Err(e) = fs::rename(&tmp, path) {
+        let _ = fs::remove_file(&tmp);
+        return Err(e);
+    }
+    Ok(())
+}
 
 // ── Existing-config loader ────────────────────────────────────────────────────
 
@@ -1080,7 +1100,7 @@ pub fn run_wizard(config_out: Option<&Path>) {
         }
     }
 
-    if let Err(e) = fs::write(&out_path, &toml) {
+    if let Err(e) = atomic_write_file(&out_path, toml.as_bytes()) {
         eprintln!("error: could not write {}: {e}", out_path.display());
         std::process::exit(1);
     }
@@ -1162,7 +1182,7 @@ pub fn run_wizard(config_out: Option<&Path>) {
     if let Some(ref hat) = hat_params {
         let yaml_path = companion_yaml_path(&out_path);
         let yaml = build_companion_yaml(hat);
-        if let Err(e) = fs::write(&yaml_path, &yaml) {
+        if let Err(e) = atomic_write_file(&yaml_path, yaml.as_bytes()) {
             eprintln!("error: could not write {}: {e}", yaml_path.display());
             std::process::exit(1);
         }


### PR DESCRIPTION
## Summary

**SYN-25**: `api_trigger_backup` wrote the zip directly to its final path. A crash mid-write left a corrupt zip visible as the newest backup.

**SYN-26**: All `std::fs::write` calls in `bbs-web`, the main binary, and the setup wizard wrote config files (and plugin tomls) directly in place. A crash between the kernel's O_TRUNC and the final `write(2)` call could leave a zero-length or truncated config, causing the BBS to fail to start on next boot.

### Changes

Introduced `atomic_write_file(path, contents)` in each of the three affected compilation units:
1. Write to `<path>.tmp`
2. `write_all` + `sync_all` (fsync the data to disk)
3. `rename` over the destination (atomic on POSIX/Windows)
4. On any error: clean up the `.tmp` sibling and return the error

**`crates/bbs-web/src/lib.rs`** — 5 config-write call sites replaced; `api_trigger_backup` zip creation now writes to a `.tmp`, syncs via `zip.finish()` + `sync_all`, and renames atomically.

**`src/main.rs`** — 6 call sites (bbs config knobs, plugin toml writes, radio save).

**`src/setup.rs`** — 2 call sites (config.toml and pymc-companion.yaml written by the setup wizard).

## Test plan

- [x] `cargo test --workspace` — 274 tests pass
- [x] `cargo clippy` — clean
- [x] `cargo fmt` — clean
- [x] `cargo doc` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)