### PR TITLE
fix(web): gate backup endpoints behind sysop permission (SYN-1)

### DIFF
--- a/crates/bbs-web/src/lib.rs
+++ b/crates/bbs-web/src/lib.rs
@@ -3210,9 +3210,20 @@ async fn api_sse_events(
 
 // ── Backups ───────────────────────────────────────────────────────────────────
 
-async fn api_trigger_backup(State(state): State<Arc<AppState>>) -> Response {
+async fn api_trigger_backup(
+    State(state): State<Arc<AppState>>,
+    Extension(user): Extension<CurrentUser>,
+) -> Response {
     use std::io::Write as _;
     use zip::{write::SimpleFileOptions, CompressionMethod};
+
+    if user.permission_level < 100 {
+        return (
+            StatusCode::FORBIDDEN,
+            Json(json_error("sysop permission required")),
+        )
+            .into_response();
+    }
 
     let dir = match state.backup_dir() {
         Some(d) => d,
@@ -3293,7 +3304,18 @@ async fn api_trigger_backup(State(state): State<Arc<AppState>>) -> Response {
     }
 }
 
-async fn api_list_backups(State(state): State<Arc<AppState>>) -> Response {
+async fn api_list_backups(
+    State(state): State<Arc<AppState>>,
+    Extension(user): Extension<CurrentUser>,
+) -> Response {
+    if user.permission_level < 100 {
+        return (
+            StatusCode::FORBIDDEN,
+            Json(json_error("sysop permission required")),
+        )
+            .into_response();
+    }
+
     let dir = match state.backup_dir() {
         Some(d) => d,
         None => {
@@ -3312,8 +3334,17 @@ async fn api_list_backups(State(state): State<Arc<AppState>>) -> Response {
 
 async fn api_download_backup(
     State(state): State<Arc<AppState>>,
+    Extension(user): Extension<CurrentUser>,
     Path(filename): Path<String>,
 ) -> Response {
+    if user.permission_level < 100 {
+        return (
+            StatusCode::FORBIDDEN,
+            Json(json_error("sysop permission required")),
+        )
+            .into_response();
+    }
+
     // Path traversal protection.
     if filename.contains('/') || filename.contains('\\') || filename.contains("..") {
         return (
@@ -3357,8 +3388,17 @@ async fn api_download_backup(
 
 async fn api_delete_backup(
     State(state): State<Arc<AppState>>,
+    Extension(user): Extension<CurrentUser>,
     Path(filename): Path<String>,
 ) -> Response {
+    if user.permission_level < 100 {
+        return (
+            StatusCode::FORBIDDEN,
+            Json(json_error("sysop permission required")),
+        )
+            .into_response();
+    }
+
     let dir = match state.backup_dir() {
         Some(d) => d,
         None => {


### PR DESCRIPTION
## Summary

- All four backup API endpoints (`api_trigger_backup`, `api_list_backups`, `api_download_backup`, `api_delete_backup`) now require `permission_level >= 100` (Sysop)
- Adds `Extension(user): Extension<CurrentUser>` extractor to each handler and returns HTTP 403 with `{"error": "sysop permission required"}` for non-sysop callers
- Previously these endpoints were accessible to any authenticated user

## Security

Closes **SYN-1** — unauthenticated/unprivileged access to backup trigger, list, download, and delete endpoints.

## Test plan

- [ ] CI passes (fmt, clippy, tests, docs)
- [ ] Manual: authenticated non-sysop user receives 403 on all four backup endpoints
- [ ] Manual: sysop user can trigger, list, download, and delete backups normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)