### PR TITLE
fix(notifications): use correct 'M' command keyword in mail-waiting notifications

### DIFF
--- a/crates/bbs-cli/src/lib.rs
+++ b/crates/bbs-cli/src/lib.rs
@@ -552,7 +552,7 @@ fn render_notification(notification: &Notification) -> String {
     match notification {
         Notification::Text(t) => t.clone(),
         Notification::MailWaiting { count } => format!(
-            "You have {} unread message{}. Type 'mail' to read.",
+            "You have {} unread message{}. Type 'M' to read.",
             count,
             if *count == 1 { "" } else { "s" }
         ),

--- a/crates/bbs-mesh/src/command.rs
+++ b/crates/bbs-mesh/src/command.rs
@@ -318,7 +318,7 @@ pub fn render_notification(notification: &Notification) -> String {
     match notification {
         Notification::Text(t) => t.clone(),
         Notification::MailWaiting { count } => format!(
-            "You have {} unread message{}. Reply 'mail' to read.",
+            "You have {} unread message{}. Reply 'M' to read.",
             count,
             if *count == 1 { "" } else { "s" }
         ),


### PR DESCRIPTION
## Summary

- **SYN-50** — CLI told users to `type 'mail'` and mesh told users to `Reply 'mail'` to check new mail, but no parser in any crate has a `mail` keyword arm. The correct command is `M`. Users following the notification instruction received `Unknown command`.

## Changes

- `crates/bbs-cli/src/lib.rs`: `"Type 'mail' to read."` → `"Type 'M' to read."`
- `crates/bbs-mesh/src/command.rs`: `"Reply 'mail' to read."` → `"Reply 'M' to read."`

The meshtastic crate delegates `render_notification` to `bbs-mesh`, so it is covered by the mesh change.

## Testing

All 73 bbs-core, 26 bbs-mesh, and full test suite pass locally. The existing `render_mail_waiting_singular` / `render_mail_waiting_plural` tests verify count formatting; no keyword assertion existed (the bug was invisible to tests).

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>