### PR TITLE
fix(admin): extend locked flag to cover all five system rooms

### DIFF
--- a/crates/bbs-core/src/db/admin_queries.rs
+++ b/crates/bbs-core/src/db/admin_queries.rs
@@ -87,7 +87,7 @@ impl Database {
                     message_count: r.try_get("message_count")?,
                     created_at: r.try_get("created_at")?,
                     deletable: id > 5,
-                    locked: (2..=4).contains(&id),
+                    locked: id <= 5,
                 })
             })
             .collect::<Result<Vec<_>, sqlx::Error>>()

--- a/crates/bbs-core/src/host.rs
+++ b/crates/bbs-core/src/host.rs
@@ -1302,7 +1302,7 @@ impl Host for BbsHost {
             message_count: count,
             created_at: room.created_at.to_rfc3339(),
             deletable: room_id > 5,
-            locked: (2..=4).contains(&room_id),
+            locked: room_id <= 5,
         })
     }
 

--- a/crates/bbs-plugin-api/src/admin.rs
+++ b/crates/bbs-plugin-api/src/admin.rs
@@ -60,7 +60,7 @@ pub struct AdminRoomSummary {
     /// rooms (Lobby, Mail, Aides, Sysop, System).
     pub deletable: bool,
     /// Whether name, min_permission_level, and read_only are locked and cannot
-    /// be changed. True for Mail (2), Aides (3), and Sysop (4).
+    /// be changed. True for the five built-in system rooms (id <= 5).
     pub locked: bool,
 }
 


### PR DESCRIPTION
## Summary

- **SYN-82** — `AdminRoomSummary.locked` was `(2..=4).contains(&id)`, covering only Mail, Aides, and Sysop rooms. Lobby (1) and System (5) were incorrectly reported as editable, inconsistent with `deletable: id > 5` which already protected all five system rooms.

## Changes

- `crates/bbs-core/src/db/admin_queries.rs`: `(2..=4).contains(&id)` → `id <= 5`
- `crates/bbs-core/src/host.rs`: same change on the single-room get path
- `crates/bbs-plugin-api/src/admin.rs`: doc comment updated to match

## Testing

Full test suite passes (73 bbs-core, full workspace). The locked flag only affects the admin API response — no behavior change to room deletion (guarded separately) or BBS commands.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>