### PR TITLE
fix(auth): check banned/deleted status in DB re-read path

### DIFF
--- a/crates/bbs-core/src/host.rs
+++ b/crates/bbs-core/src/host.rs
@@ -2535,13 +2535,21 @@ impl BbsHost {
         }
 
         // Level is Unvalidated — re-read from DB in case an out-of-process
-        // tool (CLI, direct DB edit) promoted this user since they logged in.
-        let fresh_level = UserStore::get_by_id(&self.db, user_id)
-            .await
-            .ok()
-            .flatten()
-            .map(|u| u.permission_level)
-            .unwrap_or(level);
+        // tool (CLI, direct DB edit) promoted or banned this user since login.
+        let fresh = UserStore::get_by_id(&self.db, user_id).await.ok().flatten();
+
+        // Reject banned/deleted accounts found during the re-read.
+        if let Some(ref u) = fresh {
+            if !u.is_active() {
+                let mut sessions = self.sessions.write().await;
+                sessions.remove(&session);
+                return Err(Response::Text(
+                    "Your account has been suspended. Please contact the sysop.".into(),
+                ));
+            }
+        }
+
+        let fresh_level = fresh.map(|u| u.permission_level).unwrap_or(level);
 
         if fresh_level >= PermissionLevel::User {
             // Refresh the in-memory session so subsequent commands don't DB-check again.


### PR DESCRIPTION
## Summary

- **SYN-15** — `session_auth_user` re-reads the DB when the cached session level is `Unvalidated`, but only extracted `permission_level` from the fresh row, discarding `status`. An `Unvalidated` user who was banned (or whose level was raised *and* banned simultaneously) could pass authentication because `is_active()` was never called on the fresh DB row.

## Root cause

```rust
// BEFORE (vulnerable):
let fresh_level = UserStore::get_by_id(&self.db, user_id)
    .await.ok().flatten()
    .map(|u| u.permission_level)  // status silently discarded
    .unwrap_or(level);
```

## Fix

Split the fetch from the level extraction, check `is_active()` on the fresh row, and remove the session + return an auth error if the account is banned or deleted.

```rust
let fresh = UserStore::get_by_id(&self.db, user_id).await.ok().flatten();
if let Some(ref u) = fresh {
    if !u.is_active() {
        let mut sessions = self.sessions.write().await;
        sessions.remove(&session);
        return Err(Response::Text("Your account has been suspended...".into()));
    }
}
let fresh_level = fresh.map(|u| u.permission_level).unwrap_or(level);
```

Note: the `level >= User` early-return path (already-verified sessions) is covered by session eviction on ban (PR #73); this fix closes the narrower gap in the Unvalidated re-read path.

## Testing

All 73 bbs-core host tests and full workspace pass.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>