### PR TITLE
fix(web): reject quotes and control chars in backup filename (Content-Disposition injection)

### DIFF
--- a/crates/bbs-web/src/lib.rs
+++ b/crates/bbs-web/src/lib.rs
@@ -3435,8 +3435,15 @@ async fn api_download_backup(
     if caller.permission_level < 100 {
         return (StatusCode::FORBIDDEN, Json(json_error("sysop required"))).into_response();
     }
-    // Path traversal protection.
-    if filename.contains('/') || filename.contains('\\') || filename.contains("..") {
+    // Path traversal + header injection protection.
+    // Reject path separators, parent traversal, double-quotes, and control
+    // characters (any of which could escape the Content-Disposition value).
+    if filename.contains('/')
+        || filename.contains('\\')
+        || filename.contains("..")
+        || filename.contains('"')
+        || filename.chars().any(|c| c.is_ascii_control())
+    {
         return (
             StatusCode::BAD_REQUEST,
             Json(json_error("invalid filename")),
@@ -3463,6 +3470,7 @@ async fn api_download_backup(
                 (header::CONTENT_TYPE, "application/octet-stream".to_owned()),
                 (
                     header::CONTENT_DISPOSITION,
+                    // filename is validated above: no quotes or control chars.
                     format!("attachment; filename=\"{filename}\""),
                 ),
             ],


### PR DESCRIPTION
## Summary

- **SYN-14** — `api_download_backup` built the `Content-Disposition` response header as `format!("attachment; filename=\"{filename}\"")` without validating that `filename` was free of double-quotes or control characters. A crafted filename containing `"`, `\r`, or `\n` would inject new header fields into the response (response-splitting / header injection).

## Root cause

The existing path-traversal guard only checked for `/`, `\`, and `..`. It correctly prevented file-escape attacks but did not protect the header value.

## Fix

Extend the guard to also reject filenames containing:
- `"` — would break out of the quoted `filename=` parameter
- Any ASCII control character (`< 0x20` or `0x7F`) — would fold a new header line

Backup filenames are BBS-generated and never include these characters; a request that passes such a name is either malformed or an attack.

## Testing

Full workspace test suite passes (73 bbs-core + all crates).

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>