### PR TITLE
fix(tests): update PermissionCtx field accesses to use accessor methods

### DIFF
--- a/crates/bbs-core/src/host.rs
+++ b/crates/bbs-core/src/host.rs
@@ -5838,7 +5838,7 @@ mod tests {
 
         // Confirm the session is authenticated.
         let ctx = host.permission_ctx(sid).await.unwrap();
-        assert!(ctx.username.is_some(), "alice should be logged in");
+        assert!(ctx.username().is_some(), "alice should be logged in");
 
         // Drain the SessionCreated + SessionAuthenticated events fired above.
         while ev_rx.try_recv().is_ok() {}
@@ -5873,7 +5873,7 @@ mod tests {
         register_and_login(&host, sysop_sid, &sysop, "pass12345678").await;
         // First registrant auto-gets sysop — verify.
         assert_eq!(
-            host.permission_ctx(sysop_sid).await.unwrap().level,
+            host.permission_ctx(sysop_sid).await.unwrap().level(),
             PermissionLevel::Sysop
         );
 


### PR DESCRIPTION
## Summary

- PR #69 made `PermissionCtx` fields private and added public accessor methods
- Two test assertions in `crates/bbs-core/src/host.rs` were not updated and continued to access `.username` and `.level` as direct fields
- This broke `cargo test` on the `main` branch for all subsequent work

## Changes

- `ctx.username.is_some()` → `ctx.username().is_some()`
- `host.permission_ctx(sysop_sid).await.unwrap().level` → `.level()`

## Test plan

- [ ] CI passes (`cargo test` no longer fails to compile `bbs-core`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)