### PR TITLE
fix(web): add Referrer-Policy header to security headers middleware

### DIFF
--- a/crates/bbs-web/src/lib.rs
+++ b/crates/bbs-web/src/lib.rs
@@ -576,6 +576,10 @@ async fn security_headers_middleware(
     response
         .headers_mut()
         .insert(header::X_FRAME_OPTIONS, HeaderValue::from_static("DENY"));
+    response.headers_mut().insert(
+        header::REFERRER_POLICY,
+        HeaderValue::from_static("strict-origin-when-cross-origin"),
+    );
     response
 }
 


### PR DESCRIPTION
## Summary

- `security_headers_middleware` emitted CSP, X-Content-Type-Options, and X-Frame-Options but was missing `Referrer-Policy`
- Cross-origin navigations from admin pages would include the full `Referer` URL, potentially leaking admin path structure to third-party servers
- Adds `Referrer-Policy: strict-origin-when-cross-origin` — only sends the origin on cross-origin requests; full URL remains on same-origin

## Audit finding

SYN-9b (medium) — missing security response header, found during hostile accuracy audit

## Test plan

- [ ] CI passes
- [ ] `curl -si http://localhost:PORT/health | grep -i referrer-policy` returns `strict-origin-when-cross-origin`
- [ ] Existing security header tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)