### PR TITLE
fix(config): default rate-limit keys to 0 to avoid false-positive startup warning

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -432,15 +432,15 @@ pub struct SecurityConfig {
     /// Reserved for future rate-limiting: maximum failed login attempts per
     /// minute per source.  **Not yet implemented** — this value is parsed and
     /// stored but no throttling code exists.  Setting a non-zero value has no
-    /// effect on login attempts today (SYN-3).
-    #[serde(default = "default_login_rate_per_min")]
+    /// effect on login attempts today (SYN-3).  Default is `0` (disabled).
+    #[serde(default)]
     pub login_rate_per_min: u32,
 
     /// Reserved for future rate-limiting: maximum commands per minute per
     /// session.  **Not yet implemented** — this value is parsed and stored but
-    /// no throttling code exists.  Setting a non-default value has no effect
-    /// on command throughput today (SYN-3).
-    #[serde(default = "default_command_rate_per_min")]
+    /// no throttling code exists.  Setting a non-zero value has no effect
+    /// on command throughput today (SYN-3).  Default is `0` (disabled).
+    #[serde(default)]
     pub command_rate_per_min: u32,
 }
 
@@ -452,8 +452,8 @@ impl Default for SecurityConfig {
             argon2_parallelism: default_argon2_parallelism(),
             session_lifetime_web_secs: default_session_lifetime_web_secs(),
             session_lifetime_mesh_secs: default_session_lifetime_mesh_secs(),
-            login_rate_per_min: default_login_rate_per_min(),
-            command_rate_per_min: default_command_rate_per_min(),
+            login_rate_per_min: 0,
+            command_rate_per_min: 0,
         }
     }
 }
@@ -472,12 +472,6 @@ fn default_session_lifetime_web_secs() -> u64 {
 }
 fn default_session_lifetime_mesh_secs() -> u64 {
     3 * 24 * 60 * 60 // 3 days
-}
-fn default_login_rate_per_min() -> u32 {
-    5
-}
-fn default_command_rate_per_min() -> u32 {
-    60
 }
 
 // ── [backup] ──────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- PR #70 added a startup warning when `login_rate_per_min` or `command_rate_per_min` are non-zero, since rate limiting is not yet implemented
- However, both keys defaulted to `5` and `60` respectively — so the warning fired on **every fresh install** even when the operator had not set them
- This is a false positive: operators who never touched the config would see alarming warnings about an unimplemented feature they never enabled

## Changes

- Changed `default_login_rate_per_min()` → `0` (via `#[serde(default)]`)
- Changed `default_command_rate_per_min()` → `0` (via `#[serde(default)]`)
- Updated doc comments to say "Default is `0` (disabled)"
- Removed now-unused `default_login_rate_per_min()` / `default_command_rate_per_min()` helper fns

The warning in `main.rs` (`if sec.login_rate_per_min != 0`) remains unchanged and is now correct: it only fires when an operator has explicitly set a non-zero value.

## Audit finding

SYN-3b (medium) — misleading false-positive warning on default config, found during hostile accuracy audit

## Test plan

- [ ] CI passes
- [ ] Fresh install with no `[security]` block in `config.toml` produces no rate-limit warning at startup
- [ ] Setting `login_rate_per_min = 10` in config still produces the warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)