### PR TITLE
fix(companion): reconnect on unexpected reader task exit (SYN-38b)

### DIFF
--- a/crates/bbs-meshtastic/src/stream.rs
+++ b/crates/bbs-meshtastic/src/stream.rs
@@ -216,7 +216,10 @@ where
                     }
                 }
                 Some(Err(e)) => return SessionOutcome::IoError(e),
-                None => return SessionOutcome::Shutdown,
+                None => return SessionOutcome::IoError(io::Error::new(
+                    io::ErrorKind::BrokenPipe,
+                    "reader task exited unexpectedly",
+                )),
             },
             cmd = cmd_rx.recv() => match cmd {
                 Some(cmd) => {

--- a/crates/meshcore-companion/src/client.rs
+++ b/crates/meshcore-companion/src/client.rs
@@ -555,7 +555,10 @@ where
                         }
                     }
                     Some(Err(e)) => return SessionOutcome::IoError(e, false),
-                    None => return SessionOutcome::Shutdown,
+                    None => return SessionOutcome::IoError(
+                        io::Error::new(io::ErrorKind::BrokenPipe, "reader task exited unexpectedly"),
+                        false,
+                    ),
                 }
             }
 


### PR DESCRIPTION
## Summary

- When the dedicated reader task in `meshcore-companion` or `bbs-meshtastic` exits without sending a frame (e.g. due to a panic), `frame_rx.recv()` returns `None`
- The previous code mapped `None` → `SessionOutcome::Shutdown`, which caused the outer reconnect loop to **break permanently** — the device would never be contacted again, and no further adverts would arrive
- The deliberate-shutdown path is handled by `cmd_rx` returning `None`; the `frame_rx` returning `None` can only happen if the reader task died unexpectedly
- Fix: map to `SessionOutcome::IoError(BrokenPipe)` so the reconnect loop retries, same as any other I/O failure
- Same fix applied to the equivalent path in `bbs-meshtastic/src/stream.rs`

## Test plan

- [ ] Deploy to device with MeshCore radio — adverts should appear within the first advert cycle
- [ ] Confirm server does not crash if the reader task exits
- [ ] CI passes (all 166 tests passing locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)