### PR TITLE
fix(bbs-mesh): combine welcome banner and command response into one frame (#94)

### DIFF
--- a/crates/bbs-core/src/host.rs
+++ b/crates/bbs-core/src/host.rs
@@ -445,9 +445,7 @@ impl Host for BbsHost {
                     Ok(Response::Text("Unknown command. Type H for help.".into()))
                 } else {
                     Ok(Response::Text(
-                        "Not recognized. Type 'register <username>' to create an account\n\
-                         or 'login <username>' if you already have one.\n\
-                         Type H for a list of commands."
+                        "Type 'register <username>' or 'login <username>'.\nType H for commands."
                             .into(),
                     ))
                 }

--- a/crates/bbs-core/src/host.rs
+++ b/crates/bbs-core/src/host.rs
@@ -444,10 +444,7 @@ impl Host for BbsHost {
                 if is_authed {
                     Ok(Response::Text("Unknown command. Type H for help.".into()))
                 } else {
-                    Ok(Response::Text(
-                        "Type 'register <username>' or 'login <username>'.\nType H for commands."
-                            .into(),
-                    ))
+                    Ok(Response::Text(HELP_QUICK_ANON.into()))
                 }
             }
             _ => Ok(Response::Error("Command not yet supported.".into())),
@@ -5987,8 +5984,9 @@ mod tests {
         let Response::Text(text) = resp else {
             panic!("expected Text, got {resp:?}");
         };
+        let lower = text.to_lowercase();
         assert!(
-            text.contains("register") || text.contains("login"),
+            lower.contains("register") || lower.contains("login"),
             "pre-auth unknown-command response should mention register/login, got: {text:?}"
         );
     }

--- a/crates/bbs-mesh/src/transport.rs
+++ b/crates/bbs-mesh/src/transport.rs
@@ -1047,21 +1047,14 @@ async fn dispatch_message(
         .expect("state mutex poisoned")
         .get_full_pubkey(&sender_prefix);
 
-    // Determine whether this node already has an authenticated BBS session.
-    // We greet unauthenticated nodes every time they contact us so they always
-    // see the welcome message and know how to register/log in — not just the
-    // very first time.
-    let already_authenticated = !is_new
-        && host
-            .permission_ctx(session)
-            .await
-            .map(|ctx| ctx.username().is_some())
-            .unwrap_or(false);
-
-    if !already_authenticated {
-        // Attempt auto-login via stored node credential (new sessions only;
-        // skip when TTL = 0, the session already exists, or full pubkey unknown).
-        let auto_username = if is_new && node_credential_ttl_days > 0 {
+    // Only send the welcome banner on first contact (new session).
+    // Returning unauthenticated nodes get their command response directly;
+    // greeting them on every message causes the banner to precede every
+    // response and masks the actual reply when only one frame is delivered.
+    if is_new {
+        // Attempt auto-login via stored node credential (skip when TTL = 0
+        // or full pubkey unknown).
+        let auto_username = if node_credential_ttl_days > 0 {
             if let Some(pubkey) = full_pubkey {
                 match host
                     .mesh_node_restore(session, pubkey, node_credential_ttl_days)

--- a/crates/bbs-mesh/src/transport.rs
+++ b/crates/bbs-mesh/src/transport.rs
@@ -1047,14 +1047,30 @@ async fn dispatch_message(
         .expect("state mutex poisoned")
         .get_full_pubkey(&sender_prefix);
 
-    // Only send the welcome banner on first contact (new session).
-    // Returning unauthenticated nodes get their command response directly;
-    // greeting them on every message causes the banner to precede every
-    // response and masks the actual reply when only one frame is delivered.
-    if is_new {
-        // Attempt auto-login via stored node credential (skip when TTL = 0
-        // or full pubkey unknown).
-        let auto_username = if node_credential_ttl_days > 0 {
+    // ── Determine if we're awaiting a workflow reply ──────────────────────────
+    let awaiting_reply = state
+        .lock()
+        .expect("state mutex poisoned")
+        .is_awaiting_reply(&sender_prefix);
+
+    // ── Build greeting for unauthenticated nodes ──────────────────────────────
+    // Show the welcome banner to any unauthenticated node on every message so
+    // they always have context for how to register or log in.  The greeting is
+    // NOT sent as a separate frame here — it is prepended to the first response
+    // frame below so both arrive in a single radio transmission.
+    //
+    // Skip during active workflows: the node is mid-flow (e.g. entering a
+    // password) and seeing the banner again would be confusing.
+    let already_authenticated = host
+        .permission_ctx(session)
+        .await
+        .map(|ctx| ctx.username().is_some())
+        .unwrap_or(false);
+
+    let pending_greeting: Option<String> = if !already_authenticated && !awaiting_reply {
+        // Attempt auto-login via stored node credential (new sessions only;
+        // skip when TTL = 0 or full pubkey unknown).
+        let auto_username = if is_new && node_credential_ttl_days > 0 {
             if let Some(pubkey) = full_pubkey {
                 match host
                     .mesh_node_restore(session, pubkey, node_credential_ttl_days)
@@ -1073,9 +1089,8 @@ async fn dispatch_message(
             None
         };
 
-        // Resolve {name} — prefer the auto-login username, fall back to the
-        // node's advertised display name, and finally an empty string so the
-        // placeholder is always removed from the message.
+        // Resolve {name} — prefer auto-login username, then advertised display
+        // name, then empty so the placeholder is always removed.
         let name = auto_username
             .as_ref()
             .map(|u| u.as_str().to_owned())
@@ -1084,8 +1099,6 @@ async fn dispatch_message(
 
         let welcome = welcome_message.replace("{name}", &name);
 
-        // For auto-login: prepend the welcome message and append the
-        // "Welcome back" line so the user gets both context and confirmation.
         let greeting = match &auto_username {
             Some(username) if !welcome.is_empty() => {
                 format!("{welcome}\nWelcome back, {username}! Type 'H' for commands.")
@@ -1096,40 +1109,14 @@ async fn dispatch_message(
             None => welcome,
         };
 
-        let greeting_empty = greeting.is_empty();
-        let welcome_sent = !greeting_empty
-            && cmd_tx
-                .send(OutboundFrame::SendTxtMsg {
-                    txt_type: TXT_TYPE_PLAIN,
-                    attempt: 0,
-                    timestamp: now_unix_secs(),
-                    pubkey_prefix: sender_prefix,
-                    text: greeting,
-                })
-                .await
-                .is_ok();
-        if !welcome_sent && !greeting_empty {
-            warn!(
-                ?session,
-                "mesh: could not enqueue welcome — cmd channel closed"
-            );
+        if greeting.is_empty() {
+            None
+        } else {
+            Some(greeting)
         }
-        if welcome_sent && flood_after_send {
-            let pubkey = state
-                .lock()
-                .expect("state mutex poisoned")
-                .get_full_pubkey(&sender_prefix);
-            if let Some(pubkey) = pubkey {
-                let _ = cmd_tx.send(OutboundFrame::ResetPath { pubkey }).await;
-            }
-        }
-    }
-
-    // ── Determine if we're awaiting a workflow reply ──────────────────────────
-    let awaiting_reply = state
-        .lock()
-        .expect("state mutex poisoned")
-        .is_awaiting_reply(&sender_prefix);
+    } else {
+        None
+    };
 
     // ── Dedup radio retransmissions of all inbound messages ──────────────────
     // The radio layer retransmits packets; process only the first copy within
@@ -1272,14 +1259,31 @@ async fn dispatch_message(
     // ── Collect frames to send back ───────────────────────────────────────────
     // MultiText delivers each element as a separate radio frame.
     // All other variants produce a single frame via format_response.
-    let frames: Vec<String> = if let Response::MultiText(parts) = &response {
+    //
+    // If a greeting was built above, prepend it to the first frame so the
+    // welcome banner and the command response arrive as one radio transmission
+    // rather than two.  When the response carries no text (format_response
+    // returns None) the greeting is sent on its own.
+    let mut frames: Vec<String> = if let Response::MultiText(parts) = &response {
         parts.clone()
     } else {
         match format_response(&response) {
             Some(t) => vec![t],
-            None => return,
+            None => vec![],
         }
     };
+
+    if let Some(greeting) = pending_greeting {
+        if let Some(first) = frames.first_mut() {
+            *first = format!("{greeting}\n{first}");
+        } else {
+            frames.push(greeting);
+        }
+    }
+
+    if frames.is_empty() {
+        return;
+    }
 
     let frame_count = frames.len();
     for (i, reply_text) in frames.into_iter().enumerate() {


### PR DESCRIPTION
## Summary

- Removes the separate pre-response `SendTxtMsg` for the welcome banner
- Builds a `pending_greeting` for unauthenticated, non-workflow messages and prepends it to the first response frame so banner + command result arrive in a single radio transmission
- Shortens the unauthenticated unknown-command response to fit within the 126-byte MeshCore frame limit
- Unifies the unknown-command and `H`-command responses so unauthenticated users see the same text regardless of what they typed

## Problem (closes #94)

Every message from an unauthenticated node sent two outbound frames in rapid succession: the welcome banner first, then the command response. On marginal radio paths only the first frame arrives reliably, so users saw the banner with no indication their command was processed. Sending `H` showed the menu, then quitting and reconnecting would show only the banner with no menu.

## Test plan

- [x] Sending any message as unauthenticated user → single frame with banner + command response, no truncation warning in logs
- [x] `H` → banner + help menu in one message
- [x] `REGISTER <name>` → banner + registration prompt in one message  
- [x] Authenticated user → no banner, command response only (unchanged)
- [x] All 168 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)