### PR TITLE
fix(bbs-mesh): log self-advert send so operators can confirm it fired

### DIFF
--- a/crates/bbs-mesh/src/transport.rs
+++ b/crates/bbs-mesh/src/transport.rs
@@ -244,6 +244,8 @@ impl Plugin for MeshTransport {
                                     .is_err()
                                 {
                                     warn!("mesh: could not enqueue SendSelfAdvert — cmd channel closed");
+                                } else {
+                                    info!(flood, "mesh: sending self-advert");
                                 }
                             }
                             Err(tokio::sync::broadcast::error::RecvError::Lagged(n)) => {

--- a/crates/meshcore-companion/src/client.rs
+++ b/crates/meshcore-companion/src/client.rs
@@ -565,7 +565,7 @@ where
             cmd = cmd_rx.recv() => {
                 match cmd {
                     Some(frame) => {
-                        trace!("companion: tx {frame:?}");
+                        debug!("companion: tx {frame:?}");
                         let wire = encode_outbound(&frame);
                         if let Err(e) = writer.write_all(&wire).await {
                             return SessionOutcome::IoError(e, false);


### PR DESCRIPTION
## Summary

- Add `info!` log in the advert-send task when `SendSelfAdvert` is enqueued: `mesh: sending self-advert flood=true/false`
- Bump companion client outbound frame log from `trace` to `debug` so all frames sent to the radio appear at the default log level

## Problem

When a sysop clicks \"Send Advert\" in the web UI there was no log output to confirm the frame was dispatched to the radio. The only logs were warnings for failure cases. The companion client logged outbound frames at `trace` level (below the default `debug` threshold), so there was no observable evidence the advert went out.

## Test plan

- [ ] Click \"Send Advert\" in the web UI → `journalctl` shows `mesh: sending self-advert flood=…`
- [ ] Outbound companion frames (SetAdvertLatlon, SendSelfAdvert, SendTxtMsg, etc.) appear in logs at debug level

🤖 Generated with [Claude Code](https://claude.com/claude-code)