### PR TITLE
fix(mesh): advertise BBS as Room Server (adv_type=3) not Chat Node

### DIFF
--- a/contrib/pymc-companion/pymc-companion.py
+++ b/contrib/pymc-companion/pymc-companion.py
@@ -129,6 +129,9 @@ async def run(config: dict) -> None:
     # ── CompanionRadio ─────────────────────────────────────────────────────────
 
     node_name = companion_cfg.get("node_name", "Supply Drop BBS")
+    # adv_type controls what node type is advertised on the mesh.
+    # 1=Chat, 2=Repeater, 3=Room (BBS), 4=Sensor. Default: 3 (Room/BBS).
+    adv_type_val = int(companion_cfg.get("adv_type", 3))
     radio_params = {
         "frequency":        radio_kwargs["frequency"],
         "bandwidth":        radio_kwargs["bandwidth"],
@@ -137,8 +140,11 @@ async def run(config: dict) -> None:
         "tx_power":         radio_kwargs["tx_power"],
     }
     companion = CompanionRadio(
-        radio, identity, node_name=node_name, radio_config=radio_params
+        radio, identity, node_name=node_name, adv_type=adv_type_val,
+        radio_config=radio_params
     )
+    _type_names = {1: "Chat", 2: "Repeater", 3: "Room", 4: "Sensor"}
+    log.info(f"Advertising as adv_type={adv_type_val} ({_type_names.get(adv_type_val, 'unknown')})")
 
     # Auto-add contacts so the BBS sees incoming users without manual approval.
     # 0x01 = overwrite oldest, 0x02 = chat, 0x04 = repeater, 0x08 = room

--- a/contrib/pymc-companion/pymc-companion.yaml.example
+++ b/contrib/pymc-companion/pymc-companion.yaml.example
@@ -14,6 +14,10 @@ companion:
   tcp_port: 5000
   bind_address: "127.0.0.1"
 
+  # Node type advertised on the mesh.
+  # 1=Chat, 2=Repeater, 3=Room (BBS), 4=Sensor. Default: 3 (Room/BBS).
+  adv_type: 3
+
   # Auto-add bitmask: 0x01=overwrite_oldest 0x02=chat 0x04=repeater 0x08=room
   # 0x0F adds all types and evicts the oldest when the contact list is full.
   autoadd_config: 0x0F

--- a/crates/bbs-mesh/src/transport.rs
+++ b/crates/bbs-mesh/src/transport.rs
@@ -538,6 +538,7 @@ async fn event_loop(
                             info!(
                                 node = %info.node_name,
                                 freq_khz = info.frequency_khz,
+                                adv_type = info.adv_type,
                                 "mesh: radio bridge connected — draining stale queue"
                             );
                             // Register the BBS node in the advert bus so it appears in

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -1727,6 +1727,11 @@ fn build_companion_yaml(p: &HatParams) -> String {
     writeln!(s, "  identity_path: {:?}", p.identity_path).unwrap();
     writeln!(s, "  tcp_port: 5000").unwrap();
     writeln!(s, "  bind_address: \"127.0.0.1\"").unwrap();
+    writeln!(
+        s,
+        "  adv_type: 3  # 1=Chat, 2=Repeater, 3=Room (BBS), 4=Sensor"
+    )
+    .unwrap();
     writeln!(s, "  autoadd_config: 0x0F").unwrap();
     writeln!(s).unwrap();
     writeln!(s, "radio:").unwrap();


### PR DESCRIPTION
## Summary

- `pymc-companion.py` was constructing `CompanionRadio` without an `adv_type` argument, which defaulted to `ADV_TYPE_CHAT` (1)
- Every Send Advert broadcast the BBS as a Chat Node, not a Room Server — companion apps filtered or mis-categorised it
- Fix reads `adv_type` from `pymc-companion.yaml` `companion.adv_type`, defaulting to **3 (Room)** when absent
- Existing deployments fix immediately on `pymc-companion.service` restart — no yaml edit needed
- Setup wizard and yaml example updated to write/document `adv_type: 3`
- BBS transport now logs `adv_type` at connect time so operators can verify

## Test plan

- [ ] Deploy updated `pymc-companion.py` to Pi, restart `pymc-companion.service`
- [ ] Check journal: `Advertising as adv_type=3 (Room)`
- [ ] Check BBS log at connect: `adv_type=3` in `mesh: radio bridge connected` line
- [ ] Click Send Advert in web UI — confirm BBS node appears as Room Server in companion app

🤖 Generated with [Claude Code](https://claude.com/claude-code)