### PR TITLE
fix(reading): H shows help in reading mode instead of exiting (#109)

### DIFF
--- a/crates/bbs-core/src/host.rs
+++ b/crates/bbs-core/src/host.rs
@@ -2334,6 +2334,10 @@ impl BbsHost {
                     "F" => self.handle_read_forward(session, None).await,
                     "R" => self.handle_read_reverse(session).await,
                     "E" => self.handle_reply_from_reading(session).await,
+                    // H is the universal help key; in reading mode it shows
+                    // contextual help and stays in the reading sub-mode rather
+                    // than bouncing the user out (issue #109).
+                    "H" | "?" => Ok(Response::Text(HELP_READING_MODE.into())),
                     _ => {
                         // Any other input exits reading mode.
                         {
@@ -3334,7 +3338,7 @@ impl BbsHost {
 
             return Ok(Response::Prompt {
                 text: format!(
-                    "[{} — Reading]\n{} message(s)\nF - Forward  R - Backward  X - Exit",
+                    "[{} — Reading]\n{} message(s)\nF - Forward  R - Backward  H - Help  X - Exit",
                     room.name, count
                 ),
                 hide_input: false,
@@ -3351,7 +3355,10 @@ impl BbsHost {
         let msg = match msg {
             None => {
                 return Ok(Response::Prompt {
-                    text: format!("No more messages in {}.\nR - Backward  X - Exit", room.name),
+                    text: format!(
+                        "No more messages in {}.\nR - Backward  H - Help  X - Exit",
+                        room.name
+                    ),
                     hide_input: false,
                 })
             }
@@ -3437,7 +3444,7 @@ impl BbsHost {
 
             return Ok(Response::Prompt {
                 text: format!(
-                    "[{} — Reading]\n{} message(s)\nF - Forward  R - Backward  X - Exit",
+                    "[{} — Reading]\n{} message(s)\nF - Forward  R - Backward  H - Help  X - Exit",
                     room.name, count
                 ),
                 hide_input: false,
@@ -3455,7 +3462,7 @@ impl BbsHost {
             None => {
                 return Ok(Response::Prompt {
                     text: format!(
-                        "No previous messages in {}.\nF - Forward  X - Exit",
+                        "No previous messages in {}.\nF - Forward  H - Help  X - Exit",
                         room.name
                     ),
                     hide_input: false,
@@ -4800,6 +4807,16 @@ Reading:\n\
  S    scan message headers\n\
  .FF  fast-forward past unread";
 
+/// Contextual help shown when `H`/`?` is pressed inside the one-at-a-time
+/// reading sub-mode (`Workflow::Reading`). Lists only the keys valid there.
+const HELP_READING_MODE: &str = "\
+Reading mode:\n\
+ F  next message (forward)\n\
+ R  previous message (back)\n\
+ E  reply to this message\n\
+ H  this help\n\
+ X  exit reading";
+
 const HELP_POSTING: &str = "\
 Posting:\n\
  D <#>  delete\n\
@@ -4910,6 +4927,7 @@ mod tests {
             ("HELP_OVERVIEW", HELP_OVERVIEW),
             ("HELP_MAIL", HELP_MAIL),
             ("HELP_READING", HELP_READING),
+            ("HELP_READING_MODE", HELP_READING_MODE),
             ("HELP_POSTING", HELP_POSTING),
             ("HELP_NAVIGATION", HELP_NAVIGATION),
             ("HELP_ACCOUNT", HELP_ACCOUNT),
@@ -6092,6 +6110,69 @@ mod tests {
             after, 0,
             "unread_count must be 0 after the pointed-to message is deleted"
         );
+    }
+
+    /// Issue #109: `H` inside the one-at-a-time reading sub-mode shows
+    /// contextual reading help and stays in reading mode, rather than bouncing
+    /// the user out (which previously cost a second round-trip to get help).
+    #[tokio::test]
+    async fn reading_mode_h_shows_help_and_stays() {
+        let (host, _tmp) = make_host().await;
+        let sid = host.create_session("test").await.unwrap();
+        let uname = Username::new("alice").unwrap();
+        register_and_login(&host, sid, &uname, "pass1234").await;
+
+        // Post a message so the room has something to read.
+        host.process_command(
+            sid,
+            Command::EnterMessage {
+                body: Some("hello".into()),
+            },
+        )
+        .await
+        .unwrap();
+        host.process_command(sid, Command::WorkflowReply { reply: ".".into() })
+            .await
+            .unwrap();
+
+        // Enter reading mode with F.
+        host.process_command(sid, Command::ReadForward { after: None })
+            .await
+            .unwrap();
+        {
+            let sessions = host.sessions.read().await;
+            assert!(
+                matches!(sessions[&sid].workflow, Workflow::Reading),
+                "F should enter reading mode"
+            );
+        }
+
+        // H during reading → contextual help, NOT an exit.
+        let resp = host
+            .process_command(sid, Command::WorkflowReply { reply: "H".into() })
+            .await
+            .unwrap();
+        let text = match resp {
+            Response::Text(t) => t,
+            other => panic!("expected Text help, got {other:?}"),
+        };
+        assert!(
+            text.to_lowercase().contains("reading mode"),
+            "H should return reading-mode help, got: {text:?}"
+        );
+        assert!(
+            !text.to_lowercase().contains("exited"),
+            "H should not exit reading mode, got: {text:?}"
+        );
+
+        // Still in reading mode after H.
+        {
+            let sessions = host.sessions.read().await;
+            assert!(
+                matches!(sessions[&sid].workflow, Workflow::Reading),
+                "H should keep the user in reading mode"
+            );
+        }
     }
 
     /// After pointer reset, pressing N should return "No new messages" rather

--- a/docs/WORKFLOWS.md
+++ b/docs/WORKFLOWS.md
@@ -168,13 +168,14 @@ Up to 3 failed attempts on `VerifyOld` before the workflow is cancelled.
 **Trigger:** First `F` or `R` command in a room.  
 **Purpose:** Browse messages one-at-a-time without re-typing the command prefix.
 
-**Entry:** Shows `[Room — Reading] / N message(s) / F - Forward  R - Backward  X - Exit`.
+**Entry:** Shows `[Room — Reading] / N message(s) / F - Forward  R - Backward  H - Help  X - Exit`.
 
 | Reply | Action |
 |---|---|
 | `F` | Fetch next message, advance cursor, stay in workflow |
 | `R` | Fetch previous message, move cursor back, stay in workflow |
 | `E` | Start `Workflow::Compose` replying to current message sender (Mail) or posting to current room |
+| `H` / `?` | Show contextual reading-mode help, stay in workflow |
 | Anything else | Reset cursor and workflow, return to normal mode |
 
 Each message frame ends with a nav hint line:


### PR DESCRIPTION
Closes #109.

## Problem
In the one-at-a-time reading sub-mode (`Workflow::Reading`), only `F`/`R`/`E`/`X` were recognized; anything else — including the universal help key `H` — fell through to **`Exited reading mode. Type H for help.`** So pressing `H` for help bounced the user out of reading and required a second `H` to actually get help: two round-trips on a slow link, and the reading position was lost. The sub-mode prompt also advertised only `F/R/X`, so the instinct to press `H` wasn't supported.

## Fix
- Handle `H`/`?` in reading mode: return concise contextual help (`HELP_READING_MODE`, listing F/R/E/H/X) and **stay** in the sub-mode.
- Add `H - Help` to the reading prompt lines for discoverability.
- `docs/WORKFLOWS.md` updated.

## Tests
- New `reading_mode_h_shows_help_and_stays`: `H` returns reading-mode help and the workflow remains `Reading`.
- `HELP_READING_MODE` added to the existing one-frame (≤156 byte) size test.
- Full pre-commit checklist passes on Linux.

🤖 Generated with [Claude Code](https://claude.com/claude-code)