### PR TITLE
docs(help): reconcile in-app help with USER_GUIDE (#110)

### DIFF
--- a/crates/bbs-core/src/host.rs
+++ b/crates/bbs-core/src/host.rs
@@ -4670,7 +4670,7 @@ fn help_for_command(cmd: &str, level: Option<PermissionLevel>) -> String {
         "h" | "help" | "?" => {
             if logged_in {
                 "H — show this help\n\
-                 H reading / posting / navigation / account\n\
+                 H M/R/P/U/N/A for topics (mail, reading, posting, users, nav, account)\n\
                  H <cmd> for detail on one command (eg. H N)"
             } else {
                 "H — show this help."
@@ -4698,7 +4698,7 @@ fn help_for_command(cmd: &str, level: Option<PermissionLevel>) -> String {
         "g" if logged_in => "G — go to next room with unread messages",
         "c" if logged_in => "C <name> — change room by name or number",
         "k" if logged_in => "K — list known rooms",
-        "i" if logged_in => "I — ignore this room (toggle)\nIgnored rooms are skipped during navigation.",
+        "i" if logged_in => "I — ignore this room (not yet available)",
         "m" if logged_in => {
             "M — go to Mail (private messages)\n\
              In Mail: E to write, N to read new,\n\
@@ -4782,7 +4782,7 @@ const HELP_QUICK_LOGGED_IN: &str = "\
  M  go to Mail\n\
  W  who's online\n\
  Q  log out\n\
-H all - show all";
+H all - help topics";
 
 const HELP_OVERVIEW: &str = "\
 H M — Mail\n\
@@ -4811,7 +4811,6 @@ const HELP_NAVIGATION: &str = "\
 Navigation:\n\
  C    change room\n\
  G    next unread room\n\
- I    ignore this room\n\
  K    list known rooms\n\
  M    go to Mail";
 

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -213,14 +213,18 @@ Shows the quick command list for your current access level.
 
 ### Help topics
 
+`H all` lists the help topics. Each topic has a single-letter shortcut and a
+full-word form — both work (e.g. `H M` is the same as `H mail`):
+
 ```
-H mail       — private messaging
-H reading    — reading messages in a room
-H posting    — writing and deleting messages
-H nav        — navigating between rooms
-H acct       — your profile and password
-H aide       — moderation commands (Aide+)
-H sysop      — administration commands (Sysop+)
+H M  mail      — private messaging
+H R  reading   — reading messages in a room (incl. .FF fast-forward)
+H P  posting   — writing and deleting messages
+H U  users     — finding and listing user accounts
+H N  nav       — navigating between rooms
+H A  acct      — your profile and password
+H aide         — moderation commands (Aide+)
+H sysop        — administration commands (Sysop+)
 ```
 
 ### Help on a specific command
@@ -896,11 +900,13 @@ account and you can re-register with the same username.
 | Command | Shows |
 |---|---|
 | `H` | Quick command list |
-| `H mail` | Mail / private message commands |
-| `H reading` | All reading commands |
-| `H posting` | Writing and deleting |
-| `H nav` | Room navigation |
-| `H acct` | Profile and password |
+| `H all` | List of help topics |
+| `H M` / `H mail` | Mail / private message commands |
+| `H R` / `H reading` | All reading commands (incl. `.FF`) |
+| `H P` / `H posting` | Writing and deleting |
+| `H U` / `H users` | Finding and listing user accounts |
+| `H N` / `H nav` | Room navigation |
+| `H A` / `H acct` | Profile and password |
 | `H <cmd>` | Detail on one command (e.g. `H N`) |
 
 ### Aide commands


### PR DESCRIPTION
Closes #110.

Live in-app help and the published USER_GUIDE disagreed on the command set. This reconciles both (help text + docs only — no behavioural change).

| Finding | Resolution |
|---|---|
| `H N` listed `I  ignore this room`, undocumented | `I` is a stub ("not yet implemented"), so removed from Navigation help; `H I` now honestly says "not yet available". USER_GUIDE never listed it → now they agree. |
| `.FF` absent from live nav help | `.FF` exists and is a reading/unread command; it already lives under `H reading`. Documented as such in USER_GUIDE (incl. `.FF`). |
| `H all - show all` misleading | Relabelled to **`H all - help topics`** (it returns the topic index, not all commands). |
| Help-topic letters/names diverged | Quick `H` hint and USER_GUIDE now both present the topic set as **M/R/P/U/N/A** (mail, reading, posting, users, nav, account), note the single-letter and full-word forms are equivalent, and include the previously-undocumented **Users** topic. |

## Tests
- The existing one-frame (≤156 byte) size test covers the edited strings.
- Full pre-commit checklist passes on Linux.

🤖 Generated with [Claude Code](https://claude.com/claude-code)