### PR TITLE
fix(mesh): confirm password no longer dropped as a retransmission (#104)

### DIFF
--- a/crates/bbs-mesh/src/session.rs
+++ b/crates/bbs-mesh/src/session.rs
@@ -183,6 +183,22 @@ impl SessionState {
         self.by_prefix.get(prefix)?.full_pubkey
     }
 
+    /// Clear the message-dedup baseline for `prefix` so the next inbound
+    /// message is never treated as a retransmission, even if its text matches
+    /// the one just processed.  No-op if the prefix has no session.
+    ///
+    /// Called when the host issues a new `Response::Prompt`: a prompt starts a
+    /// fresh reply turn, so the user's next message is genuine new input — most
+    /// importantly when it legitimately repeats the previous reply (e.g. typing
+    /// the same password again at "Confirm your password:"). Without this, the
+    /// general dedup in [`Self::dedup_message`] would silently drop the matching
+    /// confirmation. See issue #104.
+    pub fn clear_last_message(&mut self, prefix: &[u8; 6]) {
+        if let Some(entry) = self.by_prefix.get_mut(prefix) {
+            entry.last_message = None;
+        }
+    }
+
     /// Return `true` if `text` matches the last processed message for `prefix`
     /// within the deduplication window.  If it does not match, record `text`
     /// as the new last message and return `false`.
@@ -198,5 +214,55 @@ impl SessionState {
             entry.last_message = Some((text.to_owned(), Instant::now()));
         }
         false
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bbs_plugin_api::SessionId;
+
+    const PREFIX: [u8; 6] = [1, 2, 3, 4, 5, 6];
+
+    fn state_with_session() -> SessionState {
+        let mut st = SessionState::default();
+        st.get_or_insert(PREFIX, SessionId::__internal_new(1));
+        st
+    }
+
+    #[test]
+    fn dedup_drops_immediate_retransmission() {
+        let mut st = state_with_session();
+        assert!(!st.dedup_message(&PREFIX, "pw"), "first copy is processed");
+        assert!(
+            st.dedup_message(&PREFIX, "pw"),
+            "an identical retransmission within the window is dropped"
+        );
+    }
+
+    /// Issue #104: the password and its confirmation are the same text. After
+    /// the host prompts "Confirm your password:" the transport clears the dedup
+    /// baseline, so the matching confirmation is processed rather than dropped
+    /// as a retransmission.
+    #[test]
+    fn clear_last_message_allows_identical_reply_after_prompt() {
+        let mut st = state_with_session();
+        assert!(
+            !st.dedup_message(&PREFIX, "pw"),
+            "password entry is processed"
+        );
+
+        // Host returned a Prompt → a fresh reply turn begins.
+        st.clear_last_message(&PREFIX);
+        assert!(
+            !st.dedup_message(&PREFIX, "pw"),
+            "the matching confirmation must NOT be dropped after a fresh prompt"
+        );
+
+        // A genuine retransmission of the confirmation is still dropped.
+        assert!(
+            st.dedup_message(&PREFIX, "pw"),
+            "a retransmission of the confirmation is still deduped"
+        );
     }
 }

--- a/crates/bbs-mesh/src/transport.rs
+++ b/crates/bbs-mesh/src/transport.rs
@@ -1279,10 +1279,18 @@ async fn dispatch_message(
 
     // ── Update workflow-reply flag ────────────────────────────────────────────
     let is_prompt = matches!(response, Response::Prompt { .. });
-    state
-        .lock()
-        .expect("state mutex poisoned")
-        .set_awaiting_reply(&sender_prefix, is_prompt);
+    {
+        let mut state = state.lock().expect("state mutex poisoned");
+        state.set_awaiting_reply(&sender_prefix, is_prompt);
+        // A new prompt begins a fresh reply turn, so the user's next message is
+        // genuine input even if it repeats the previous reply verbatim. Clear
+        // the message-dedup baseline so the general retransmission dedup can't
+        // silently drop, for example, the matching password entered again at
+        // "Confirm your password:". (#104)
+        if is_prompt {
+            state.clear_last_message(&sender_prefix);
+        }
+    }
 
     // ── Collect frames to send back ───────────────────────────────────────────
     // MultiText delivers each element as a separate radio frame.

--- a/crates/bbs-mesh/tests/transport.rs
+++ b/crates/bbs-mesh/tests/transport.rs
@@ -282,6 +282,58 @@ async fn prompt_sets_workflow_state() {
     transport.stop().await.unwrap();
 }
 
+/// Issue #104: two identical workflow replies in a row (e.g. the password and
+/// its matching confirmation) must BOTH reach the host. The general
+/// retransmission dedup must not silently drop the second one just because its
+/// text equals the first — a new prompt between them starts a fresh reply turn.
+#[tokio::test]
+async fn identical_workflow_replies_after_prompt_both_reach_host() {
+    let host = Arc::new(MockHost::new());
+    // The initial command and every workflow reply return a Prompt, so the
+    // session stays in awaiting-reply mode across all three messages (mirrors
+    // "Choose a password:" → "Confirm your password:").
+    host.set_response_for(
+        |cmd| matches!(cmd, Command::Help { .. }),
+        Response::Prompt {
+            text: "Choose a password:".to_owned(),
+            hide_input: true,
+        },
+    );
+    host.set_response_for(
+        |cmd| matches!(cmd, Command::WorkflowReply { .. }),
+        Response::Prompt {
+            text: "Confirm your password:".to_owned(),
+            hide_input: true,
+        },
+    );
+
+    let (transport, mut bridge) = make_transport(Arc::clone(&host), None).await;
+    bridge.complete_handshake("Node").await;
+
+    let sender = [0x33u8; 6];
+    bridge.send(&contact_msg_frame(sender, "help")).await;
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    // Password, then the SAME text again as confirmation.
+    bridge.send(&contact_msg_frame(sender, "hunter2pw")).await;
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    bridge.send(&contact_msg_frame(sender, "hunter2pw")).await;
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    let received = host.commands_received();
+    let reply_count = received
+        .iter()
+        .filter(|(_, c)| matches!(c, Command::WorkflowReply { reply } if reply == "hunter2pw"))
+        .count();
+    assert_eq!(
+        reply_count,
+        2,
+        "both identical confirmations must reach the host, got commands: {:?}",
+        received.iter().map(|(_, c)| c).collect::<Vec<_>>()
+    );
+
+    transport.stop().await.unwrap();
+}
+
 /// With a prefix configured, messages without the prefix are silently ignored.
 #[tokio::test]
 async fn prefix_filters_non_prefixed_messages() {


### PR DESCRIPTION
Closes #104.

## Symptom
During MeshCore registration, the **first** "Confirm your password:" entry did nothing — the user had to type the matching password a **second** time before registration completed.

## Root cause
The host-side confirm logic is correct single-confirm. The bug is in the mesh transport's retransmission dedup: `dedup_message` (transport.rs) drops any inbound message whose text matches the previously processed message within the 10s window. The confirmation is, by definition, the **same text** as the password just entered, so it was silently dropped as if it were a radio retransmission. Only after the dedup window expired (≈ one mesh round-trip) did a repeat get through — hence "enter it twice". (This is why DMs/Meshtastic differed and why the host's `Confirm` stage was only reached on the second input.)

## Fix
A new `Response::Prompt` starts a fresh reply turn — the user's next message is genuine input even if it repeats the previous reply verbatim. Clear the message-dedup baseline (`SessionState::clear_last_message`) whenever the host returns a `Prompt`. Genuine retransmissions are still dropped: the baseline is re-armed by the confirmation itself, and the post-completion `is_recent_workflow_reply` guard is unchanged.

## Tests
- `identical_workflow_replies_after_prompt_both_reach_host` (integration, via `MockHost`): two identical workflow replies after a prompt **both** reach the host (would be 1 before the fix).
- `clear_last_message_allows_identical_reply_after_prompt` + `dedup_drops_immediate_retransmission` (session unit tests).
- Full pre-commit checklist passes on Linux.

🤖 Generated with [Claude Code](https://claude.com/claude-code)