### PR TITLE
chore(release): bump version to 0.9.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -246,7 +246,7 @@ checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bbs-cli"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "async-trait",
  "bbs-plugin-api",
@@ -259,7 +259,7 @@ dependencies = [
 
 [[package]]
 name = "bbs-core"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "argon2",
  "async-trait",
@@ -278,7 +278,7 @@ dependencies = [
 
 [[package]]
 name = "bbs-hello-transport"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "async-trait",
  "bbs-plugin-api",
@@ -289,7 +289,7 @@ dependencies = [
 
 [[package]]
 name = "bbs-mesh"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "async-trait",
  "bbs-core",
@@ -303,7 +303,7 @@ dependencies = [
 
 [[package]]
 name = "bbs-meshtastic"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "async-trait",
  "bbs-plugin-api",
@@ -317,7 +317,7 @@ dependencies = [
 
 [[package]]
 name = "bbs-plugin-api"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "async-trait",
  "serde",
@@ -328,7 +328,7 @@ dependencies = [
 
 [[package]]
 name = "bbs-process-transport"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "async-trait",
  "bbs-plugin-api",
@@ -343,7 +343,7 @@ dependencies = [
 
 [[package]]
 name = "bbs-web"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "async-trait",
  "axum",
@@ -1434,7 +1434,7 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "meshcore-companion"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "proptest",
  "thiserror 1.0.69",
@@ -2528,7 +2528,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "supply-drop-bbs"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "bbs-cli",
  "bbs-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,7 +64,7 @@ resolver = "2"
 members  = ["crates/*"]
 
 [workspace.package]
-version = "0.9.4"
+version = "0.9.5"
 edition      = "2021"
 authors      = ["Mesh-America"]
 repository   = "https://github.com/Mesh-America/supply-drop-bbs"
@@ -73,14 +73,14 @@ rust-version = "1.88"
 # Shared dependencies. As we add real deps (sqlx, axum, etc.) they
 # go here so every workspace member uses the same version.
 [workspace.dependencies]
-bbs-core              = { path = "crates/bbs-core",              version = "0.9.4" }
-bbs-plugin-api        = { path = "crates/bbs-plugin-api",        version = "0.9.4" }
-bbs-cli               = { path = "crates/bbs-cli",               version = "0.9.4" }
-bbs-mesh              = { path = "crates/bbs-mesh",              version = "0.9.4" }
-bbs-meshtastic        = { path = "crates/bbs-meshtastic",        version = "0.9.4" }
-bbs-web               = { path = "crates/bbs-web",              version = "0.9.4" }
-bbs-process-transport = { path = "crates/bbs-process-transport", version = "0.9.4" }
-meshcore-companion    = { path = "crates/meshcore-companion",    version = "0.9.4" }
+bbs-core              = { path = "crates/bbs-core",              version = "0.9.5" }
+bbs-plugin-api        = { path = "crates/bbs-plugin-api",        version = "0.9.5" }
+bbs-cli               = { path = "crates/bbs-cli",               version = "0.9.5" }
+bbs-mesh              = { path = "crates/bbs-mesh",              version = "0.9.5" }
+bbs-meshtastic        = { path = "crates/bbs-meshtastic",        version = "0.9.5" }
+bbs-web               = { path = "crates/bbs-web",              version = "0.9.5" }
+bbs-process-transport = { path = "crates/bbs-process-transport", version = "0.9.5" }
+meshcore-companion    = { path = "crates/meshcore-companion",    version = "0.9.5" }
 
 # Third-party deps. We use loose version constraints (semver-major)
 # so cargo can pick patch updates; the lockfile pins the exact


### PR DESCRIPTION
Version bump 0.9.4 → 0.9.5.

Ships the QA-verified room-server / MeshCore UX fixes merged this round:
- #104 confirm password no longer dropped as a retransmission
- #105 `-` sentinel for display name on mesh
- #106 N no longer strands the "new messages" header on a lossy link
- #107 idempotent re-sent `.` after posting
- #108 commands sent during room selection now execute
- #109 H shows help in reading mode instead of exiting
- #110 in-app help reconciled with USER_GUIDE

Version-only change (Cargo.toml workspace.package + path-dep versions, Cargo.lock), mirroring #103. Tag `v0.9.5` will be pushed after merge to trigger the release build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)