### PR TITLE
fix(profile): mesh-friendly PROFILE prompt (#120)

### DIFF
--- a/crates/bbs-core/src/host.rs
+++ b/crates/bbs-core/src/host.rs
@@ -4426,7 +4426,7 @@ impl BbsHost {
             }
         }
         Ok(Response::Prompt {
-            text: "Enter your new display name (or '-' to clear, Enter to cancel):".into(),
+            text: "Enter your new display name (- to clear, CANCEL to abort):".into(),
             hide_input: false,
         })
     }
@@ -6670,5 +6670,41 @@ mod tests {
             matches!(&resp, Response::Text(t) if t.contains("Unknown command")),
             "after another command, bare `.` should be Unknown, got: {resp:?}"
         );
+    }
+
+    /// Issue #120: the PROFILE prompt must not tell mesh users to "Enter to
+    /// cancel" (an empty message can't be sent over a radio). It advertises
+    /// CANCEL instead, which aborts the workflow on every transport.
+    #[tokio::test]
+    async fn profile_prompt_is_mesh_friendly_and_cancel_aborts() {
+        let (host, _db) = make_host().await;
+        let sid = host.create_session("test").await.unwrap();
+        register_and_login(&host, sid, &Username::new("alice").unwrap(), "pass1234").await;
+
+        let resp = host
+            .process_command(sid, Command::EditProfile)
+            .await
+            .unwrap();
+        let prompt = match resp {
+            Response::Prompt { text, .. } => text,
+            other => panic!("PROFILE should prompt, got {other:?}"),
+        };
+        assert!(
+            !prompt.to_lowercase().contains("enter to cancel"),
+            "prompt must not instruct 'Enter to cancel', got: {prompt}"
+        );
+        assert!(
+            prompt.contains("CANCEL"),
+            "prompt should advertise CANCEL, got: {prompt}"
+        );
+
+        // CANCEL aborts and clears the workflow.
+        let resp = host.process_command(sid, Command::Cancel).await.unwrap();
+        assert!(
+            matches!(&resp, Response::Text(t) if t.to_lowercase().contains("cancel")),
+            "CANCEL should abort, got: {resp:?}"
+        );
+        let sessions = host.sessions.read().await;
+        assert!(matches!(sessions[&sid].workflow, Workflow::None));
     }
 }

--- a/crates/bbs-plugin-api/src/command.rs
+++ b/crates/bbs-plugin-api/src/command.rs
@@ -336,15 +336,26 @@ impl Command {
     ///
     /// When `awaiting_reply` is `true` (the previous [`Response`] was a
     /// [`Response::Prompt`]), the entire line becomes a [`Command::WorkflowReply`]
-    /// regardless of content — this lets the host handle password entry, message
-    /// bodies, and other free-form workflow steps without each transport
-    /// re-implementing that state machine.
+    /// (with the sole exception of `CANCEL`/`STOP`, see below) — this lets the
+    /// host handle password entry, message bodies, and other free-form workflow
+    /// steps without each transport re-implementing that state machine.
+    ///
+    /// `CANCEL`/`STOP` (case-insensitive) always abort the current workflow via
+    /// [`Command::Cancel`], on every transport and *before* the awaiting-reply
+    /// passthrough — otherwise the words would be captured as the literal reply
+    /// (e.g. become the new display name). Mirrors the MeshCore parser. (#120)
     ///
     /// This is the canonical parser shared by all transports that forward raw
     /// text lines (CLI, process plugins).  Transports with their own wire
     /// syntax (e.g. MeshCore frames) do their own mapping.
     pub fn parse(line: &str, awaiting_reply: bool) -> Self {
         let text = line.trim();
+
+        // CANCEL / STOP always break out of a workflow, before the awaiting-reply
+        // passthrough, so they can't be swallowed as a literal reply. (#120)
+        if matches!(text.to_ascii_lowercase().as_str(), "cancel" | "stop") {
+            return Command::Cancel;
+        }
 
         if awaiting_reply {
             return Command::WorkflowReply {
@@ -615,5 +626,29 @@ mod tests {
             let back: Response = serde_json::from_str(&json).unwrap();
             assert_eq!(r, back);
         }
+    }
+
+    #[test]
+    fn cancel_breaks_out_of_workflow_on_shared_parser() {
+        // CANCEL/STOP abort a workflow instead of being captured as the reply,
+        // matching the MeshCore parser, so the prompt's "CANCEL to abort" advice
+        // holds on the shared (CLI / process) parser too. (#120)
+        for kw in ["cancel", "CANCEL", "Stop", "stop"] {
+            assert_eq!(Command::parse(kw, true), Command::Cancel, "awaiting: {kw}");
+            assert_eq!(Command::parse(kw, false), Command::Cancel, "idle: {kw}");
+        }
+        // A reply that merely contains the word is still captured verbatim.
+        assert_eq!(
+            Command::parse("CancelTheOrder", true),
+            Command::WorkflowReply {
+                reply: "CancelTheOrder".to_owned()
+            }
+        );
+        assert_eq!(
+            Command::parse("Alice", true),
+            Command::WorkflowReply {
+                reply: "Alice".to_owned()
+            }
+        );
     }
 }

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -591,9 +591,13 @@ Your display name is shown next to your messages. It can be anything up to
 the system limit. To remove your display name and show only your username:
 
 ```
-Enter your new display name (or '-' to clear, Enter to cancel):
+Enter your new display name (- to clear, CANCEL to abort):
 > -
 ```
+
+Send `-` to clear your display name, type a new one to change it, or send
+`CANCEL` to leave it unchanged. (On the CLI/web an empty line also leaves it
+unchanged, but mesh radios can't send an empty message — use `CANCEL`.)
 
 ### Change your password
 


### PR DESCRIPTION
Closes #120.

## Problem
`PROFILE` prompted `Enter your new display name (or '-' to clear, Enter to cancel):`. Over a mesh radio you can't send an empty message, so "Enter to cancel" was unreachable (only `CANCEL` worked).

## Fix
Reworded to **`Enter your new display name (- to clear, CANCEL to abort):`**:
- `-` clears the display name
- a typed name changes it
- `CANCEL` / `STOP` aborts on every transport

Empty input still means "no change" on CLI/web — it's just no longer advertised as the cancel path. `USER_GUIDE.md` updated. (Same class as #105/#129.)

## Tests
- New `profile_prompt_is_mesh_friendly_and_cancel_aborts`.
- Full pre-commit checklist passed on Linux.

🤖 Generated with [Claude Code](https://claude.com/claude-code)