### PR TITLE
fix(session): accept LOGOUT/QUIT/EXIT/BYE as aliases for Q (#124)

### DIFF
--- a/crates/bbs-mesh/src/command.rs
+++ b/crates/bbs-mesh/src/command.rs
@@ -154,7 +154,9 @@ pub fn parse_command(text: &str, prefix: Option<char>, awaiting_reply: bool) -> 
         },
 
         // ── Session control ──────────────────────────────────────────────────
-        "q" => Some(Command::Quit),
+        // Accept the obvious words for "log out" too — a real user reached for
+        // `logout` and got "Unknown command." (#124)
+        "q" | "logout" | "quit" | "exit" | "bye" => Some(Command::Quit),
 
         "cancel" | "stop" => Some(Command::Cancel),
 
@@ -406,8 +408,13 @@ mod tests {
     }
 
     #[test]
-    fn logout_is_unknown_on_mesh() {
-        assert!(matches!(cmd("logout"), Some(Command::Unknown { .. })));
+    fn logout_aliases_quit_on_mesh() {
+        // `logout` (and exit/bye/quit) now log out like `Q`. (#124)
+        assert_eq!(cmd("logout"), Some(Command::Quit));
+        assert_eq!(cmd("LOGOUT"), Some(Command::Quit));
+        assert_eq!(cmd("quit"), Some(Command::Quit));
+        assert_eq!(cmd("exit"), Some(Command::Quit));
+        assert_eq!(cmd("bye"), Some(Command::Quit));
     }
 
     #[test]

--- a/crates/bbs-meshtastic/src/command.rs
+++ b/crates/bbs-meshtastic/src/command.rs
@@ -48,7 +48,6 @@ pub fn parse_command(text: &str, prefix: Option<char>, awaiting_reply: bool) -> 
                 topic: Some("login".to_owned()),
             }),
         },
-        "logout" => Some(Command::Logout),
         "whoami" => Some(Command::Whoami),
         "k" => Some(Command::ListRooms),
         "g" => Some(Command::GoNextUnread),
@@ -78,7 +77,9 @@ pub fn parse_command(text: &str, prefix: Option<char>, awaiting_reply: bool) -> 
                 raw: text.to_owned(),
             }),
         },
-        "q" | "quit" | "exit" | "bye" => Some(Command::Quit),
+        // All quit aliases map to one intent (Quit), parallel with the mesh and
+        // canonical parsers. (#124 follow-up)
+        "q" | "quit" | "exit" | "bye" | "logout" => Some(Command::Quit),
         "cancel" | "stop" => Some(Command::Cancel),
         "w" => Some(Command::WhoIsOnline),
         "pending" => Some(Command::ListPending),

--- a/crates/bbs-meshtastic/src/command.rs
+++ b/crates/bbs-meshtastic/src/command.rs
@@ -78,7 +78,7 @@ pub fn parse_command(text: &str, prefix: Option<char>, awaiting_reply: bool) -> 
                 raw: text.to_owned(),
             }),
         },
-        "q" => Some(Command::Quit),
+        "q" | "quit" | "exit" | "bye" => Some(Command::Quit),
         "cancel" | "stop" => Some(Command::Cancel),
         "w" => Some(Command::WhoIsOnline),
         "pending" => Some(Command::ListPending),

--- a/crates/bbs-plugin-api/src/command.rs
+++ b/crates/bbs-plugin-api/src/command.rs
@@ -376,7 +376,7 @@ impl Command {
                     topic: Some("login".to_owned()),
                 },
             },
-            "logout" | "q" | "quit" => Command::Quit,
+            "logout" | "q" | "quit" | "exit" | "bye" => Command::Quit,
 
             // ── Room navigation ───────────────────────────────────────────────
             "k" => Command::ListRooms,


### PR DESCRIPTION
Closes #124.

## Problem
A real user "couldn't log out": over MeshCore, `logout` returned `Unknown command. Type H for help.` — only `Q` ended the session, despite the USER_GUIDE documenting logout as "LOGOUT or Q". The mesh parser only mapped `q`.

## Fix
Map `logout` / `quit` / `exit` / `bye` (case-insensitive) to `Quit` in the mesh parser, and add `exit`/`bye` to the canonical (CLI) and Meshtastic parsers for parity (they already accepted `logout`/`quit`). All resolve to the same end-session path.

## Tests
- Mesh parser test updated (was asserting `logout` is unknown) → now asserts logout/quit/exit/bye → `Quit`.
- Full pre-commit checklist passed on Linux.

🤖 Generated with [Claude Code](https://claude.com/claude-code)