### PR TITLE
fix(sysop): wire `.PW <user>` password reset on mesh (#125)

### DIFF
--- a/crates/bbs-mesh/src/command.rs
+++ b/crates/bbs-mesh/src/command.rs
@@ -253,6 +253,13 @@ pub fn parse_command(text: &str, prefix: Option<char>, awaiting_reply: bool) -> 
             }),
         },
 
+        ".pw" => match rest.and_then(|s| Username::new(s).ok()) {
+            Some(username) => Some(Command::SetUserPassword { username }),
+            None => Some(Command::Unknown {
+                raw: text.to_owned(),
+            }),
+        },
+
         _ => Some(Command::Unknown {
             raw: text.to_owned(),
         }),
@@ -413,6 +420,15 @@ mod tests {
     #[test]
     fn whoami_is_parsed_on_mesh() {
         assert!(matches!(cmd("whoami"), Some(Command::Whoami)));
+    }
+
+    #[test]
+    fn pw_reset_parsed_on_mesh() {
+        // `.PW <user>` (sysop password reset) is now recognised on mesh. (#125)
+        let username = Username::new("bob").unwrap();
+        assert_eq!(cmd(".pw bob"), Some(Command::SetUserPassword { username }));
+        // Missing username → unknown (no silent no-op).
+        assert!(matches!(cmd(".pw"), Some(Command::Unknown { .. })));
     }
 
     #[test]

--- a/crates/bbs-meshtastic/src/command.rs
+++ b/crates/bbs-meshtastic/src/command.rs
@@ -156,6 +156,12 @@ pub fn parse_command(text: &str, prefix: Option<char>, awaiting_reply: bool) -> 
                 raw: text.to_owned(),
             }),
         },
+        ".pw" => match rest.and_then(|s| Username::new(s).ok()) {
+            Some(username) => Some(Command::SetUserPassword { username }),
+            None => Some(Command::Unknown {
+                raw: text.to_owned(),
+            }),
+        },
         _ => Some(Command::Unknown {
             raw: text.to_owned(),
         }),


### PR DESCRIPTION
Closes #125.

## Problem
Over MeshCore, `.PW <user>` (the documented sysop password reset) returned `Unknown command`.

## Root cause
The feature is fully implemented host-side (`Command::SetUserPassword` → `handle_set_user_password`, sysop-gated two-step reset) and the canonical CLI parser already mapped `.pw` — but the **mesh and Meshtastic** parsers didn't, so the command never reached the host over radio.

## Fix
Map `.pw <user>` → `Command::SetUserPassword` in the mesh and Meshtastic parsers (missing username → unknown), matching the existing `.eu`/`.du` pattern.

## Tests
- New `pw_reset_parsed_on_mesh`.
- Full pre-commit checklist passed on Linux.

🤖 Generated with [Claude Code](https://claude.com/claude-code)