### PR TITLE
test(register): lock in the `-` display-name shortcut (#129)

### DIFF
--- a/crates/bbs-core/src/host.rs
+++ b/crates/bbs-core/src/host.rs
@@ -5440,6 +5440,37 @@ mod tests {
         );
     }
 
+    /// Issue #129: the `-` display-name shortcut must ADVANCE to the password
+    /// step (not exit registration). Regression guard for the #105 fix.
+    #[tokio::test]
+    async fn register_dash_advances_to_password() {
+        let (host, _db) = make_host().await;
+        let sid = host.create_session("test").await.unwrap();
+        host.process_command(
+            sid,
+            Command::Register {
+                username: Username::new("qatester1").unwrap(),
+            },
+        )
+        .await
+        .unwrap();
+
+        let resp = host
+            .process_command(sid, Command::WorkflowReply { reply: "-".into() })
+            .await
+            .unwrap();
+        assert!(
+            matches!(&resp, Response::Prompt { text, .. } if text.to_lowercase().contains("password")),
+            "`-` should advance to the password prompt, got: {resp:?}"
+        );
+        // Still mid-registration — not dropped back to the anonymous menu.
+        let sessions = host.sessions.read().await;
+        assert!(
+            matches!(sessions[&sid].workflow, Workflow::Register { .. }),
+            "session should still be in the registration workflow after `-`"
+        );
+    }
+
     /// Issue #105: on a mesh radio you can't send an empty message, so the
     /// `-` sentinel must mean "use my username" (display name left unset),
     /// matching the empty-input behaviour available on CLI/web.

--- a/crates/bbs-mesh/tests/transport.rs
+++ b/crates/bbs-mesh/tests/transport.rs
@@ -334,6 +334,52 @@ async fn identical_workflow_replies_after_prompt_both_reach_host() {
     transport.stop().await.unwrap();
 }
 
+/// Issue #129: after the registration prompt, the `-` display-name shortcut must
+/// reach the host as a `WorkflowReply` — it must NOT be parsed as a standalone
+/// command (which would drop the user out of registration). This is the mesh
+/// parse-layer half of the `-`-uses-username behaviour (the host half is covered
+/// by `register_display_name_dash_sentinel_uses_username` in bbs-core).
+#[tokio::test]
+async fn dash_shortcut_after_prompt_is_workflow_reply() {
+    let host = Arc::new(MockHost::new());
+    host.set_response_for(
+        |cmd| matches!(cmd, Command::Register { .. }),
+        Response::Prompt {
+            text: "Choose a display name (or send - to use your username):".to_owned(),
+            hide_input: false,
+        },
+    );
+    host.set_response_for(
+        |cmd| matches!(cmd, Command::WorkflowReply { .. }),
+        Response::Prompt {
+            text: "Choose a password (min 8 characters):".to_owned(),
+            hide_input: true,
+        },
+    );
+
+    let (transport, mut bridge) = make_transport(Arc::clone(&host), None).await;
+    bridge.complete_handshake("Node").await;
+
+    let sender = [0x44u8; 6];
+    bridge
+        .send(&contact_msg_frame(sender, "register qatester1"))
+        .await;
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    bridge.send(&contact_msg_frame(sender, "-")).await;
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    let received = host.commands_received();
+    assert!(
+        received
+            .iter()
+            .any(|(_, c)| matches!(c, Command::WorkflowReply { reply } if reply == "-")),
+        "`-` after the registration prompt must reach the host as a WorkflowReply, got: {:?}",
+        received.iter().map(|(_, c)| c).collect::<Vec<_>>()
+    );
+
+    transport.stop().await.unwrap();
+}
+
 /// With a prefix configured, messages without the prefix are silently ignored.
 #[tokio::test]
 async fn prefix_filters_non_prefixed_messages() {


### PR DESCRIPTION
Closes #129.

## Status
On current `main` (the #105 fix shipped in **v0.9.5**) the `-` display-name shortcut works correctly: it sets the display name to the username and advances to the password step. The live QA build that filed #129 **predated the fix** — I verified the current behaviour empirically with the tests below.

## Coverage added (both layers)
- **bbs-core** `register_dash_advances_to_password`: `REGISTER` then `-` returns the password prompt and the session stays in `Workflow::Register` (does not drop to the anonymous menu).
- **bbs-mesh** `dash_shortcut_after_prompt_is_workflow_reply`: after the registration prompt, `-` reaches the host as a `WorkflowReply` rather than being parsed as a standalone command — the suspected live failure point.

No behaviour change; regression coverage only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)