### PR TITLE
feat(sysop): promote/demote user level via .AIDE/.SYSOP/.USER (#127)

### DIFF
--- a/crates/bbs-core/src/host.rs
+++ b/crates/bbs-core/src/host.rs
@@ -3992,6 +3992,18 @@ impl BbsHost {
             Some(u) => u,
         };
 
+        // Status and permission_level are orthogonal. Refuse to touch the level
+        // of a non-active (banned/deleted) account: the new level would be
+        // pushed into any live session below, re-empowering a user who is still
+        // flagged banned. Re-activate first. (#127)
+        if user.status != UserStatus::Active {
+            return Ok(Response::Error(format!(
+                "'{}' is {} — re-activate the account before changing its level.",
+                username.as_str(),
+                user.status
+            )));
+        }
+
         // Promotion to a role is for already-validated accounts; an unvalidated
         // account must be validated first (V) so it isn't silently activated here.
         if user.permission_level == PermissionLevel::Unvalidated {
@@ -4006,6 +4018,25 @@ impl BbsHost {
                 "'{}' is already {level}.",
                 username.as_str()
             )));
+        }
+
+        // Backstop against removing the last Sysop. The self-change guard above
+        // already prevents a lone sysop from demoting themselves over the mesh,
+        // but enforce the invariant locally so it holds regardless of how this
+        // handler is reached. (#127)
+        if user.permission_level == PermissionLevel::Sysop && level < PermissionLevel::Sysop {
+            let active = UserStore::list(&self.db, Some(UserStatus::Active), 500, 0)
+                .await
+                .map_err(|e| HostError::Storage(format!("{e}")))?;
+            let sysops = active
+                .iter()
+                .filter(|u| u.permission_level == PermissionLevel::Sysop)
+                .count();
+            if sysops <= 1 {
+                return Ok(Response::Error(
+                    "Can't demote the last Sysop — promote another Sysop first.".into(),
+                ));
+            }
         }
 
         UserStore::update(&self.db, user.id, None, None, Some(level), None)
@@ -5620,6 +5651,98 @@ mod tests {
         assert!(
             matches!(&r, Response::Error(e) if e.to_lowercase().contains("sysop")),
             "non-sysop should be refused, got: {r:?}"
+        );
+    }
+
+    /// #127: a sysop must not change the level of a banned/deleted account
+    /// (it would be re-empowered in any live session), and a legitimate
+    /// demotion must still succeed while another Sysop remains.
+    #[tokio::test]
+    async fn set_user_level_guards_banned_and_last_sysop() {
+        let (host, _db) = make_host().await;
+        let sysop = host.create_session("test").await.unwrap();
+        register_and_login(&host, sysop, &Username::new("alice").unwrap(), "pass1234").await;
+
+        // bob: validated (→ User), then banned.
+        let bob_sid = host.create_session("test").await.unwrap();
+        do_register(&host, bob_sid, "bob", "pass5678").await;
+        let bob = Username::new("bob").unwrap();
+        host.process_command(
+            sysop,
+            Command::ValidateUser {
+                username: bob.clone(),
+            },
+        )
+        .await
+        .unwrap();
+        let bob_id = UserStore::get_by_username(&host.db, &bob)
+            .await
+            .unwrap()
+            .unwrap()
+            .id;
+        UserStore::update(&host.db, bob_id, None, Some(UserStatus::Banned), None, None)
+            .await
+            .unwrap();
+
+        let r = host
+            .process_command(
+                sysop,
+                Command::SetUserLevel {
+                    username: bob.clone(),
+                    level: PermissionLevel::Aide,
+                },
+            )
+            .await
+            .unwrap();
+        assert!(
+            matches!(&r, Response::Error(e)
+                if e.to_lowercase().contains("re-activate") || e.to_lowercase().contains("banned")),
+            "level change on a banned account should be refused, got: {r:?}"
+        );
+        assert_eq!(
+            UserStore::get_by_username(&host.db, &bob)
+                .await
+                .unwrap()
+                .unwrap()
+                .permission_level,
+            PermissionLevel::User,
+            "banned user's level must be unchanged"
+        );
+
+        // carol promoted to Sysop, then demoted — alice remains, so it succeeds.
+        let carol_sid = host.create_session("test").await.unwrap();
+        do_register(&host, carol_sid, "carol", "pass9012").await;
+        let carol = Username::new("carol").unwrap();
+        host.process_command(
+            sysop,
+            Command::ValidateUser {
+                username: carol.clone(),
+            },
+        )
+        .await
+        .unwrap();
+        host.process_command(
+            sysop,
+            Command::SetUserLevel {
+                username: carol.clone(),
+                level: PermissionLevel::Sysop,
+            },
+        )
+        .await
+        .unwrap();
+        let r = host
+            .process_command(
+                sysop,
+                Command::SetUserLevel {
+                    username: carol.clone(),
+                    level: PermissionLevel::User,
+                },
+            )
+            .await
+            .unwrap();
+        assert!(
+            matches!(&r, Response::Text(t) if t.to_lowercase().contains("user")),
+            "demoting a sysop while another remains should succeed, got: {r:?}"
         );
     }
 

--- a/crates/bbs-core/src/host.rs
+++ b/crates/bbs-core/src/host.rs
@@ -430,6 +430,9 @@ impl Host for BbsHost {
             Command::ValidateUser { username } => {
                 self.handle_validate_user(session, username).await
             }
+            Command::SetUserLevel { username, level } => {
+                self.handle_set_user_level(session, username, level).await
+            }
             Command::BlockUser { target, force } => {
                 self.handle_block_user(session, target, force).await
             }
@@ -3961,6 +3964,85 @@ impl BbsHost {
         )))
     }
 
+    /// Set a user's permission level (Sysop only). Backs `.AIDE`/`.SYSOP`/`.USER`
+    /// over mesh/CLI; the web admin uses `admin_update_user`. See issue #127.
+    async fn handle_set_user_level(
+        &self,
+        session: SessionId,
+        username: Username,
+        level: PermissionLevel,
+    ) -> Result<Response, HostError> {
+        let (actor, _, actor_level, _) = match self.session_auth_user(session).await {
+            Ok(t) => t,
+            Err(r) => return Ok(r),
+        };
+        if actor_level < PermissionLevel::Sysop {
+            return Ok(Response::Error("Sysop access required.".into()));
+        }
+        // Guard against self-lockout — a sysop can't change their own level.
+        if actor == username {
+            return Ok(Response::Error("You can't change your own level.".into()));
+        }
+
+        let user = match UserStore::get_by_username(&self.db, &username)
+            .await
+            .map_err(|e| HostError::Storage(format!("{e}")))?
+        {
+            None => return Ok(Response::Error("User not found.".into())),
+            Some(u) => u,
+        };
+
+        // Promotion to a role is for already-validated accounts; an unvalidated
+        // account must be validated first (V) so it isn't silently activated here.
+        if user.permission_level == PermissionLevel::Unvalidated {
+            return Ok(Response::Error(format!(
+                "'{}' isn't validated yet — use V {} first.",
+                username.as_str(),
+                username.as_str()
+            )));
+        }
+        if user.permission_level == level {
+            return Ok(Response::Error(format!(
+                "'{}' is already {level}.",
+                username.as_str()
+            )));
+        }
+
+        UserStore::update(&self.db, user.id, None, None, Some(level), None)
+            .await
+            .map_err(|e| HostError::Storage(format!("set level: {e}")))?;
+
+        // Apply the new level to any live sessions for this user immediately.
+        {
+            let mut sessions = self.sessions.write().await;
+            for r in sessions.values_mut() {
+                if r.username.as_ref() == Some(&username) {
+                    r.level = level;
+                }
+            }
+        }
+
+        let detail = format!("level -> {level}");
+        if let Err(e) = self
+            .db
+            .audit_write(
+                actor.as_str(),
+                "set_level",
+                Some(username.as_str()),
+                Some(&detail),
+            )
+            .await
+        {
+            tracing::warn!("audit write failed: {e}");
+        }
+
+        info!(%actor, %username, %level, "user level changed");
+        Ok(Response::Text(format!(
+            "'{}' is now {level}.",
+            username.as_str()
+        )))
+    }
+
     async fn handle_block_user(
         &self,
         session: SessionId,
@@ -4630,6 +4712,7 @@ fn cmd_label(cmd: &Command) -> &'static str {
         Command::WhoIsOnline => "WhoIsOnline",
         Command::ListPending => "ListPending",
         Command::ValidateUser { .. } => "ValidateUser",
+        Command::SetUserLevel { .. } => "SetUserLevel",
         Command::BlockUser { .. } => "BlockUser",
         Command::BanUser { .. } => "BanUser",
         Command::UnbanUser { .. } => "UnbanUser",
@@ -4751,6 +4834,11 @@ fn help_for_command(cmd: &str, level: Option<PermissionLevel>) -> String {
 
         // ── Sysop+ only ──────────────────────────────────────────────────
         "unban" if is_sysop => "UNBAN <user> — lift a ban",
+        ".aide" | ".sysop" | ".user" if is_sysop => {
+            ".AIDE/.SYSOP/.USER <user> — set a user's permission level\n\
+             Promote a validated user to Aide or Sysop, or demote to User.\n\
+             Validate pending users with V first."
+        }
         ".c" if is_sysop => ".C — create a new room\nEnters the room creation workflow.",
         ".dr" if is_sysop => ".DR <name> — delete a room",
         ".du" if is_sysop => ".DU <user> — soft-delete a user account\nSets status to deleted and ends active sessions.",
@@ -4875,9 +4963,10 @@ Users:\n\
 
 const HELP_SYSOP: &str = "\
 Sysop:\n\
+ .AIDE/.SYSOP/.USER <u>\n\
  .C .DR .DU .PW rooms/users\n\
- UNBAN <u>   lift a ban\n\
- OPENACCESS  skip verify\n\
+ UNBAN <u> lift a ban\n\
+ OPENACCESS skip verify\n\
  CLOSEACCESS require verify\n\
  GUESTROOM <name>|OFF";
 
@@ -5437,6 +5526,100 @@ mod tests {
             dm.content.to_lowercase().contains("verify")
                 || dm.content.to_lowercase().contains("v newuser"),
             "DM should hint at the verify command"
+        );
+    }
+
+    /// Issue #127: a sysop can promote/demote a validated user's level, with
+    /// guards (validated-first, no self-change, sysop-only).
+    #[tokio::test]
+    async fn set_user_level_promotes_and_guards() {
+        let (host, _db) = make_host().await;
+        let sysop = host.create_session("test").await.unwrap();
+        register_and_login(&host, sysop, &Username::new("alice").unwrap(), "pass1234").await;
+
+        // bob registers (auto-logged-in, Unvalidated).
+        let bob_sid = host.create_session("test").await.unwrap();
+        do_register(&host, bob_sid, "bob", "pass5678").await;
+        let bob = Username::new("bob").unwrap();
+
+        // Unvalidated target → directed to validate first.
+        let r = host
+            .process_command(
+                sysop,
+                Command::SetUserLevel {
+                    username: bob.clone(),
+                    level: PermissionLevel::Aide,
+                },
+            )
+            .await
+            .unwrap();
+        assert!(
+            matches!(&r, Response::Error(e) if e.to_lowercase().contains("validated")),
+            "unvalidated target should be rejected, got: {r:?}"
+        );
+
+        // Validate bob, then promote to Aide.
+        host.process_command(
+            sysop,
+            Command::ValidateUser {
+                username: bob.clone(),
+            },
+        )
+        .await
+        .unwrap();
+        let r = host
+            .process_command(
+                sysop,
+                Command::SetUserLevel {
+                    username: bob.clone(),
+                    level: PermissionLevel::Aide,
+                },
+            )
+            .await
+            .unwrap();
+        assert!(
+            matches!(&r, Response::Text(t) if t.to_lowercase().contains("aide")),
+            "promotion should confirm, got: {r:?}"
+        );
+        assert_eq!(
+            UserStore::get_by_username(&host.db, &bob)
+                .await
+                .unwrap()
+                .unwrap()
+                .permission_level,
+            PermissionLevel::Aide
+        );
+
+        // Self-change is refused.
+        let r = host
+            .process_command(
+                sysop,
+                Command::SetUserLevel {
+                    username: Username::new("alice").unwrap(),
+                    level: PermissionLevel::User,
+                },
+            )
+            .await
+            .unwrap();
+        assert!(
+            matches!(&r, Response::Error(e) if e.to_lowercase().contains("own level")),
+            "self-change should be refused, got: {r:?}"
+        );
+
+        // Non-sysop (bob, now Aide) cannot set levels.
+        let r = host
+            .process_command(
+                bob_sid,
+                Command::SetUserLevel {
+                    username: Username::new("alice").unwrap(),
+                    level: PermissionLevel::User,
+                },
+            )
+            .await
+            .unwrap();
+        assert!(
+            matches!(&r, Response::Error(e) if e.to_lowercase().contains("sysop")),
+            "non-sysop should be refused, got: {r:?}"
         );
     }
 

--- a/crates/bbs-mesh/src/command.rs
+++ b/crates/bbs-mesh/src/command.rs
@@ -253,9 +253,9 @@ pub fn parse_command(text: &str, prefix: Option<char>, awaiting_reply: bool) -> 
             }),
         },
 
-        ".aide" => Some(parse_set_level(rest, PermissionLevel::Aide, text)),
-        ".sysop" => Some(parse_set_level(rest, PermissionLevel::Sysop, text)),
-        ".user" => Some(parse_set_level(rest, PermissionLevel::User, text)),
+        ".aide" => Some(parse_set_level(rest, PermissionLevel::Aide)),
+        ".sysop" => Some(parse_set_level(rest, PermissionLevel::Sysop)),
+        ".user" => Some(parse_set_level(rest, PermissionLevel::User)),
 
         _ => Some(Command::Unknown {
             raw: text.to_owned(),
@@ -278,12 +278,21 @@ fn split_first_word(s: &str) -> (&str, Option<&str>) {
 }
 
 /// Parse a `.AIDE` / `.SYSOP` / `.USER <user>` set-level command. (#127)
-fn parse_set_level(rest: Option<&str>, level: PermissionLevel, raw: &str) -> Command {
+fn parse_set_level(rest: Option<&str>, level: PermissionLevel) -> Command {
     match rest.and_then(|s| Username::new(s).ok()) {
         Some(username) => Command::SetUserLevel { username, level },
-        None => Command::Unknown {
-            raw: raw.to_owned(),
-        },
+        // Missing/invalid username → show the command's usage rather than a
+        // generic "unknown command". (#127 follow-up)
+        None => {
+            let topic = match level {
+                PermissionLevel::Aide => ".aide",
+                PermissionLevel::Sysop => ".sysop",
+                _ => ".user",
+            };
+            Command::Help {
+                topic: Some(topic.to_owned()),
+            }
+        }
     }
 }
 
@@ -454,8 +463,13 @@ mod tests {
                 level: PermissionLevel::User
             })
         );
-        // Missing username → unknown.
-        assert!(matches!(cmd(".aide"), Some(Command::Unknown { .. })));
+        // Missing username → the command's usage help, not a generic unknown.
+        assert_eq!(
+            cmd(".aide"),
+            Some(Command::Help {
+                topic: Some(".aide".to_owned())
+            })
+        );
     }
 
     #[test]

--- a/crates/bbs-mesh/src/command.rs
+++ b/crates/bbs-mesh/src/command.rs
@@ -29,7 +29,7 @@
 //! [`render_notification`] converts a [`Notification`] (a host-initiated push)
 //! into the text string delivered via `OutboundFrame::SendTxtMsg`.
 
-use bbs_plugin_api::{event::Notification, identity::Username, Command, Response};
+use bbs_plugin_api::{event::Notification, identity::Username, Command, PermissionLevel, Response};
 
 // ── Command parsing ───────────────────────────────────────────────────────────
 
@@ -253,6 +253,10 @@ pub fn parse_command(text: &str, prefix: Option<char>, awaiting_reply: bool) -> 
             }),
         },
 
+        ".aide" => Some(parse_set_level(rest, PermissionLevel::Aide, text)),
+        ".sysop" => Some(parse_set_level(rest, PermissionLevel::Sysop, text)),
+        ".user" => Some(parse_set_level(rest, PermissionLevel::User, text)),
+
         _ => Some(Command::Unknown {
             raw: text.to_owned(),
         }),
@@ -270,6 +274,16 @@ fn split_first_word(s: &str) -> (&str, Option<&str>) {
             let rest = s[i..].trim_start();
             (&s[..i], if rest.is_empty() { None } else { Some(rest) })
         }
+    }
+}
+
+/// Parse a `.AIDE` / `.SYSOP` / `.USER <user>` set-level command. (#127)
+fn parse_set_level(rest: Option<&str>, level: PermissionLevel, raw: &str) -> Command {
+    match rest.and_then(|s| Username::new(s).ok()) {
+        Some(username) => Command::SetUserLevel { username, level },
+        None => Command::Unknown {
+            raw: raw.to_owned(),
+        },
     }
 }
 
@@ -413,6 +427,35 @@ mod tests {
     #[test]
     fn whoami_is_parsed_on_mesh() {
         assert!(matches!(cmd("whoami"), Some(Command::Whoami)));
+    }
+
+    #[test]
+    fn set_level_commands_parsed_on_mesh() {
+        // `.AIDE`/`.SYSOP`/`.USER <user>` promote/demote (sysop-gated by host). (#127)
+        let u = Username::new("bob").unwrap();
+        assert_eq!(
+            cmd(".aide bob"),
+            Some(Command::SetUserLevel {
+                username: u.clone(),
+                level: PermissionLevel::Aide
+            })
+        );
+        assert_eq!(
+            cmd(".sysop bob"),
+            Some(Command::SetUserLevel {
+                username: u.clone(),
+                level: PermissionLevel::Sysop
+            })
+        );
+        assert_eq!(
+            cmd(".user bob"),
+            Some(Command::SetUserLevel {
+                username: u,
+                level: PermissionLevel::User
+            })
+        );
+        // Missing username → unknown.
+        assert!(matches!(cmd(".aide"), Some(Command::Unknown { .. })));
     }
 
     #[test]

--- a/crates/bbs-meshtastic/src/command.rs
+++ b/crates/bbs-meshtastic/src/command.rs
@@ -156,9 +156,9 @@ pub fn parse_command(text: &str, prefix: Option<char>, awaiting_reply: bool) -> 
                 raw: text.to_owned(),
             }),
         },
-        ".aide" => Some(parse_set_level(rest, PermissionLevel::Aide, text)),
-        ".sysop" => Some(parse_set_level(rest, PermissionLevel::Sysop, text)),
-        ".user" => Some(parse_set_level(rest, PermissionLevel::User, text)),
+        ".aide" => Some(parse_set_level(rest, PermissionLevel::Aide)),
+        ".sysop" => Some(parse_set_level(rest, PermissionLevel::Sysop)),
+        ".user" => Some(parse_set_level(rest, PermissionLevel::User)),
         _ => Some(Command::Unknown {
             raw: text.to_owned(),
         }),
@@ -176,12 +176,21 @@ fn split_first_word(s: &str) -> (&str, Option<&str>) {
 }
 
 /// Parse a `.AIDE` / `.SYSOP` / `.USER <user>` set-level command. (#127)
-fn parse_set_level(rest: Option<&str>, level: PermissionLevel, raw: &str) -> Command {
+fn parse_set_level(rest: Option<&str>, level: PermissionLevel) -> Command {
     match rest.and_then(|s| Username::new(s).ok()) {
         Some(username) => Command::SetUserLevel { username, level },
-        None => Command::Unknown {
-            raw: raw.to_owned(),
-        },
+        // Missing/invalid username → show the command's usage rather than a
+        // generic "unknown command". (#127 follow-up)
+        None => {
+            let topic = match level {
+                PermissionLevel::Aide => ".aide",
+                PermissionLevel::Sysop => ".sysop",
+                _ => ".user",
+            };
+            Command::Help {
+                topic: Some(topic.to_owned()),
+            }
+        }
     }
 }
 

--- a/crates/bbs-meshtastic/src/command.rs
+++ b/crates/bbs-meshtastic/src/command.rs
@@ -1,6 +1,6 @@
 //! Command parsing and response rendering for the Meshtastic transport.
 
-use bbs_plugin_api::{event::Notification, identity::Username, Command, Response};
+use bbs_plugin_api::{event::Notification, identity::Username, Command, PermissionLevel, Response};
 
 pub fn parse_command(text: &str, prefix: Option<char>, awaiting_reply: bool) -> Option<Command> {
     let text = text.trim();
@@ -156,6 +156,9 @@ pub fn parse_command(text: &str, prefix: Option<char>, awaiting_reply: bool) -> 
                 raw: text.to_owned(),
             }),
         },
+        ".aide" => Some(parse_set_level(rest, PermissionLevel::Aide, text)),
+        ".sysop" => Some(parse_set_level(rest, PermissionLevel::Sysop, text)),
+        ".user" => Some(parse_set_level(rest, PermissionLevel::User, text)),
         _ => Some(Command::Unknown {
             raw: text.to_owned(),
         }),
@@ -169,6 +172,16 @@ fn split_first_word(s: &str) -> (&str, Option<&str>) {
             let rest = s[i..].trim_start();
             (&s[..i], if rest.is_empty() { None } else { Some(rest) })
         }
+    }
+}
+
+/// Parse a `.AIDE` / `.SYSOP` / `.USER <user>` set-level command. (#127)
+fn parse_set_level(rest: Option<&str>, level: PermissionLevel, raw: &str) -> Command {
+    match rest.and_then(|s| Username::new(s).ok()) {
+        Some(username) => Command::SetUserLevel { username, level },
+        None => Command::Unknown {
+            raw: raw.to_owned(),
+        },
     }
 }
 

--- a/crates/bbs-plugin-api/src/command.rs
+++ b/crates/bbs-plugin-api/src/command.rs
@@ -24,6 +24,7 @@
 //! API — leaner dependency graph, clearer boundaries.
 
 use crate::identity::Username;
+use crate::permissions::PermissionLevel;
 use serde::{Deserialize, Serialize};
 
 // ── Parsing helpers (private) ─────────────────────────────────────────────────
@@ -168,6 +169,14 @@ pub enum Command {
     ValidateUser {
         /// The username of the account to validate.
         username: Username,
+    },
+
+    /// Set a user's permission level (Sysop only). (.AIDE / .SYSOP / .USER)
+    SetUserLevel {
+        /// The username whose level is being changed.
+        username: Username,
+        /// The new permission level.
+        level: PermissionLevel,
     },
 
     /// Block or unblock another user — hides their messages from the caller. (B)
@@ -488,6 +497,34 @@ impl Command {
             },
             ".du" => match rest.and_then(|s| Username::new(s).ok()) {
                 Some(username) => Command::DeleteUser { username },
+                None => Command::Unknown {
+                    raw: text.to_owned(),
+                },
+            },
+
+            ".aide" => match rest.and_then(|s| Username::new(s).ok()) {
+                Some(username) => Command::SetUserLevel {
+                    username,
+                    level: PermissionLevel::Aide,
+                },
+                None => Command::Unknown {
+                    raw: text.to_owned(),
+                },
+            },
+            ".sysop" => match rest.and_then(|s| Username::new(s).ok()) {
+                Some(username) => Command::SetUserLevel {
+                    username,
+                    level: PermissionLevel::Sysop,
+                },
+                None => Command::Unknown {
+                    raw: text.to_owned(),
+                },
+            },
+            ".user" => match rest.and_then(|s| Username::new(s).ok()) {
+                Some(username) => Command::SetUserLevel {
+                    username,
+                    level: PermissionLevel::User,
+                },
                 None => Command::Unknown {
                     raw: text.to_owned(),
                 },

--- a/crates/bbs-plugin-api/src/command.rs
+++ b/crates/bbs-plugin-api/src/command.rs
@@ -502,13 +502,15 @@ impl Command {
                 },
             },
 
+            // Missing/invalid username → show the command's usage rather than a
+            // generic "unknown command". (#127 follow-up)
             ".aide" => match rest.and_then(|s| Username::new(s).ok()) {
                 Some(username) => Command::SetUserLevel {
                     username,
                     level: PermissionLevel::Aide,
                 },
-                None => Command::Unknown {
-                    raw: text.to_owned(),
+                None => Command::Help {
+                    topic: Some(".aide".to_owned()),
                 },
             },
             ".sysop" => match rest.and_then(|s| Username::new(s).ok()) {
@@ -516,8 +518,8 @@ impl Command {
                     username,
                     level: PermissionLevel::Sysop,
                 },
-                None => Command::Unknown {
-                    raw: text.to_owned(),
+                None => Command::Help {
+                    topic: Some(".sysop".to_owned()),
                 },
             },
             ".user" => match rest.and_then(|s| Username::new(s).ok()) {
@@ -525,8 +527,8 @@ impl Command {
                     username,
                     level: PermissionLevel::User,
                 },
-                None => Command::Unknown {
-                    raw: text.to_owned(),
+                None => Command::Help {
+                    topic: Some(".user".to_owned()),
                 },
             },
 

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -741,6 +741,24 @@ UNBAN <username>
 
 Restores the account to **Active** status. The user can log in again.
 
+### Setting a user's permission level (Sysop only)
+
+Promote a **validated** user to Aide or Sysop, or demote back to User:
+
+```
+.AIDE <username>     make them an Aide (moderator)
+.SYSOP <username>    make them a Sysop (administrator)
+.USER <username>     demote back to plain User
+```
+
+Notes:
+
+- The account must already be validated (use `V <username>` first).
+- You can't change your own level (prevents accidental self-lockout).
+- The change applies immediately, including to any active session, and is
+  logged in the audit trail.
+- The same control is available in the web admin (Users → permission level).
+
 ### Creating a room (Sysop only)
 
 From within a session:
@@ -923,6 +941,9 @@ account and you can re-register with the same username.
 | Command | Action |
 |---|---|
 | `UNBAN <user>` | Lift a ban |
+| `.AIDE <user>` | Promote a validated user to Aide |
+| `.SYSOP <user>` | Promote a validated user to Sysop |
+| `.USER <user>` | Demote a user back to plain User |
 | `.C <name>` | Create a new room |
 | `.DR <name>` | Delete a room |
 | `.PW <user>` | Reset a user's password (two-step workflow) |


### PR DESCRIPTION
Closes #127.

## Problem
There was no way to make a user an **Aide** (or Sysop). Only the first account (auto-Sysop) and validation (→ User) reached levels, so the entire Aide moderation tier was unreachable and a single sysop couldn't delegate.

## Fix — all three surfaces
- **Mesh / Meshtastic / CLI**: new `.AIDE`/`.SYSOP`/`.USER <user>` commands via `Command::SetUserLevel { username, level }`, handled by `handle_set_user_level`:
  - sysop-only
  - target must already be validated (use `V` first)
  - can't change your own level (avoids self-lockout)
  - applies to the DB **and any live session** immediately
  - writes an audit entry (`set_level`)
- **Web admin**: already supported via `admin_update_user` (Users → permission level) — no change needed; this closes the gap across radio/CLI/web.
- Discoverability/docs: `H SYSOP` now lists the commands, `H .aide` gives detail, and USER_GUIDE (admin section + quick-ref) documents them.

## Tests
- `set_user_level_promotes_and_guards`: promote to Aide + validated-first / self-change / non-sysop guards, and DB level verified.
- `set_level_commands_parsed_on_mesh`: `.aide`/`.sysop`/`.user` parse to `SetUserLevel`.
- Full pre-commit checklist passed on Linux.

🤖 Generated with [Claude Code](https://claude.com/claude-code)