### PR TITLE
feat(sysop): .PW issues a single-use temp password with forced change (#134)

### DIFF
--- a/crates/bbs-core/migrations/0011_must_change_password.sql
+++ b/crates/bbs-core/migrations/0011_must_change_password.sql
@@ -1,0 +1,8 @@
+-- Add a "must change password at next login" flag to stored credentials.
+--
+-- Set when a sysop resets an account's password to a server-generated temporary
+-- value (`.PW`): the temp password is single-use and the user is forced to choose
+-- a new one before their login completes. See issue #134.
+--
+-- Append-only: never edit this file once applied (sqlx records its checksum).
+ALTER TABLE user_credentials ADD COLUMN must_change INTEGER NOT NULL DEFAULT 0;

--- a/crates/bbs-core/src/db/credential_store.rs
+++ b/crates/bbs-core/src/db/credential_store.rs
@@ -7,9 +7,29 @@
 use super::{error::StoreError, Database};
 use crate::{ids::UserId, timestamp::Timestamp};
 use argon2::{
-    password_hash::{rand_core::OsRng, PasswordHash, PasswordHasher, PasswordVerifier, SaltString},
+    password_hash::{
+        rand_core::{OsRng, RngCore},
+        PasswordHash, PasswordHasher, PasswordVerifier, SaltString,
+    },
     Argon2,
 };
+
+/// Alphabet for generated temporary passwords — ASCII letters and digits with
+/// visually ambiguous characters (`0`/`O`, `1`/`l`/`I`) removed so a sysop can
+/// read it aloud without confusion.
+const TEMP_PASSWORD_ALPHABET: &[u8] = b"ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnpqrstuvwxyz23456789";
+/// Length of a generated temporary password (~70 bits over the alphabet above).
+const TEMP_PASSWORD_LEN: usize = 12;
+
+/// Generate a random single-use temporary password from [`TEMP_PASSWORD_ALPHABET`].
+fn generate_temp_password() -> String {
+    let mut bytes = [0u8; TEMP_PASSWORD_LEN];
+    OsRng.fill_bytes(&mut bytes);
+    bytes
+        .iter()
+        .map(|b| TEMP_PASSWORD_ALPHABET[*b as usize % TEMP_PASSWORD_ALPHABET.len()] as char)
+        .collect()
+}
 
 /// Internal-only credential operations for `Database`.
 pub(crate) struct CredentialStore<'db> {
@@ -54,6 +74,67 @@ impl<'db> CredentialStore<'db> {
         .execute(&self.db.write_pool)
         .await?;
 
+        Ok(())
+    }
+
+    /// Reset `user_id` to a freshly generated single-use temporary password and
+    /// flag the account so the next login must change it. Returns the plaintext
+    /// temp password for the caller to convey to the user. Used by the sysop
+    /// `.PW` reset so a real password is never chosen over the air. (#134)
+    ///
+    /// Runtime query (not the `query!` macro) so the new `must_change` column
+    /// doesn't require regenerating the offline `.sqlx` cache.
+    pub(crate) async fn reset_to_temp_password(
+        &self,
+        user_id: UserId,
+        now: Timestamp,
+    ) -> Result<String, StoreError> {
+        let temp = generate_temp_password();
+        let salt = SaltString::generate(&mut OsRng);
+        let phc = Argon2::default()
+            .hash_password(temp.as_bytes(), &salt)
+            .map_err(|e| StoreError::Decode(format!("argon2 hash error: {e}")))?
+            .to_string();
+        let uid = user_id.as_i64();
+        let ts = now.to_rfc3339();
+
+        sqlx::query(
+            "INSERT INTO user_credentials (user_id, phc_hash, updated_at, must_change) \
+             VALUES (?, ?, ?, 1) \
+             ON CONFLICT(user_id) DO UPDATE \
+               SET phc_hash = excluded.phc_hash, \
+                   updated_at = excluded.updated_at, \
+                   must_change = 1",
+        )
+        .bind(uid)
+        .bind(phc)
+        .bind(ts)
+        .execute(&self.db.write_pool)
+        .await?;
+
+        Ok(temp)
+    }
+
+    /// Return `true` if `user_id` must change their password at next login
+    /// (a sysop reset them to a temporary password). (#134)
+    pub(crate) async fn must_change_password(&self, user_id: UserId) -> Result<bool, StoreError> {
+        let uid = user_id.as_i64();
+        let flag: Option<i64> =
+            sqlx::query_scalar("SELECT must_change FROM user_credentials WHERE user_id = ?")
+                .bind(uid)
+                .fetch_optional(&self.db.read_pool)
+                .await?;
+        Ok(flag.unwrap_or(0) != 0)
+    }
+
+    /// Clear the must-change flag — called once the user has chosen a new
+    /// password of their own. (#134)
+    pub(crate) async fn clear_must_change(&self, user_id: UserId) -> Result<(), StoreError> {
+        let uid = user_id.as_i64();
+        sqlx::query("UPDATE user_credentials SET must_change = 0 WHERE user_id = ?")
+            .bind(uid)
+            .execute(&self.db.write_pool)
+            .await?;
         Ok(())
     }
 

--- a/crates/bbs-core/src/host.rs
+++ b/crates/bbs-core/src/host.rs
@@ -74,10 +74,12 @@ enum Workflow {
     ChangePassword {
         stage: ChangePwdStage,
     },
-    /// Resetting another user's password (.PW command, Sysop+).
-    SetUserPassword {
-        target: Username,
-        stage: SetUserPwdStage,
+    /// Forcing a new password at login after a sysop `.PW` reset to a temporary
+    /// password. The login is held until the user chooses a new password. (#134)
+    ForceChangePassword {
+        username: Username,
+        user_id: UserId,
+        stage: ForcePwdStage,
     },
     /// Browsing messages one-at-a-time with F/R navigation.
     /// E replies to the current message; any other input exits.
@@ -107,7 +109,7 @@ enum ChangePwdStage {
 }
 
 #[derive(Clone, Debug)]
-enum SetUserPwdStage {
+enum ForcePwdStage {
     /// Waiting for the new password.
     EnterNew,
     /// New password entered; waiting for confirmation.
@@ -1562,6 +1564,35 @@ impl BbsHost {
         })
     }
 
+    /// Authenticate `session` as `user`: set the session identity/level/room,
+    /// fire `SessionAuthenticated`, and return the `LoggedIn` response. Shared by
+    /// the normal login path and the forced-password-change completion. (#134)
+    async fn finalize_login(&self, session: SessionId, user: &crate::user::User) -> Response {
+        // Unverified users land in the guest room (if configured).
+        let initial_room = if user.permission_level < PermissionLevel::User {
+            self.guest_room_id().unwrap_or(LOBBY_ROOM_ID)
+        } else {
+            LOBBY_ROOM_ID
+        };
+        {
+            let mut sessions = self.sessions.write().await;
+            if let Some(r) = sessions.get_mut(&session) {
+                r.username = Some(user.username.clone());
+                r.user_id = Some(user.id);
+                r.level = user.permission_level;
+                r.workflow = Workflow::None;
+                r.current_room = initial_room;
+            }
+        }
+        let _ = self.events_tx.send(DomainEvent::SessionAuthenticated {
+            session,
+            user: user.username.clone(),
+        });
+        Response::LoggedIn {
+            user: user.username.clone(),
+        }
+    }
+
     async fn handle_login(
         &self,
         session: SessionId,
@@ -1848,28 +1879,34 @@ impl BbsHost {
                     UserStore::update(&self.db, user.id, None, None, None, Some(Timestamp::now()))
                         .await
                         .map_err(|e| HostError::Storage(format!("update last_login: {e}")))?;
-                    {
-                        // Unverified users land in the guest room (if configured).
-                        let initial_room = if user.permission_level < PermissionLevel::User {
-                            self.guest_room_id().unwrap_or(LOBBY_ROOM_ID)
-                        } else {
-                            LOBBY_ROOM_ID
-                        };
+
+                    // If a sysop reset this account to a temporary password, hold
+                    // the login and require a new password before completing. (#134)
+                    let must_change = self
+                        .db
+                        .credentials()
+                        .must_change_password(user.id)
+                        .await
+                        .map_err(|e| HostError::Storage(format!("must_change lookup: {e}")))?;
+                    if must_change {
                         let mut sessions = self.sessions.write().await;
                         if let Some(r) = sessions.get_mut(&session) {
-                            r.username = Some(username.clone());
-                            r.user_id = Some(user.id);
-                            r.level = user.permission_level;
-                            r.workflow = Workflow::None;
-                            r.current_room = initial_room;
+                            r.workflow = Workflow::ForceChangePassword {
+                                username: username.clone(),
+                                user_id: user.id,
+                                stage: ForcePwdStage::EnterNew,
+                            };
                         }
+                        return Ok(Response::Prompt {
+                            text: "Your password was reset by an operator. \
+                                   Choose a new password (min 8 characters):"
+                                .into(),
+                            hide_input: true,
+                        });
                     }
-                    let _ = self.events_tx.send(DomainEvent::SessionAuthenticated {
-                        session,
-                        user: username.clone(),
-                    });
+
                     info!(%session, %username, "login successful");
-                    Ok(Response::LoggedIn { user: username })
+                    Ok(self.finalize_login(session, &user).await)
                 } else {
                     // Global per-username failure tracking — parallel sessions share this
                     // counter so they can't bypass the delay by opening fresh connections.
@@ -2270,22 +2307,24 @@ impl BbsHost {
                 Ok(Response::Text("Password changed successfully.".into()))
             }
 
-            // ── Set another user's password (Sysop+) ────────────────────────
-            Workflow::SetUserPassword {
-                target,
-                stage: SetUserPwdStage::EnterNew,
+            // ── Forced password change at login after a sysop reset (#134) ──────
+            Workflow::ForceChangePassword {
+                username,
+                user_id,
+                stage: ForcePwdStage::EnterNew,
             } => {
                 if reply.chars().count() < 8 {
                     return Ok(Response::Prompt {
-                        text: "Too short (min 8 characters). New password:".into(),
+                        text: "Too short (min 8 characters). Choose a new password:".into(),
                         hide_input: true,
                     });
                 }
                 let mut sessions = self.sessions.write().await;
                 if let Some(r) = sessions.get_mut(&session) {
-                    r.workflow = Workflow::SetUserPassword {
-                        target,
-                        stage: SetUserPwdStage::ConfirmNew {
+                    r.workflow = Workflow::ForceChangePassword {
+                        username,
+                        user_id,
+                        stage: ForcePwdStage::ConfirmNew {
                             new_password: reply,
                         },
                     };
@@ -2296,78 +2335,54 @@ impl BbsHost {
                 })
             }
 
-            Workflow::SetUserPassword {
-                target,
-                stage: SetUserPwdStage::ConfirmNew { new_password },
+            Workflow::ForceChangePassword {
+                username,
+                user_id,
+                stage: ForcePwdStage::ConfirmNew { new_password },
             } => {
                 if reply != new_password {
                     let mut sessions = self.sessions.write().await;
                     if let Some(r) = sessions.get_mut(&session) {
-                        r.workflow = Workflow::SetUserPassword {
-                            target,
-                            stage: SetUserPwdStage::EnterNew,
+                        r.workflow = Workflow::ForceChangePassword {
+                            username,
+                            user_id,
+                            stage: ForcePwdStage::EnterNew,
                         };
                     }
                     return Ok(Response::Prompt {
-                        text: "Passwords don't match. New password:".into(),
+                        text: "Passwords don't match. Choose a new password:".into(),
                         hide_input: true,
                     });
                 }
-                let (actor, _, level, _) = match self.session_auth_user(session).await {
-                    Ok(t) => t,
-                    Err(r) => return Ok(r),
-                };
-                if level < PermissionLevel::Sysop {
-                    let mut sessions = self.sessions.write().await;
-                    if let Some(r) = sessions.get_mut(&session) {
-                        r.workflow = Workflow::None;
-                    }
-                    return Ok(Response::Error("Sysop access required.".into()));
-                }
-                let user = UserStore::get_by_username(&self.db, &target)
+
+                // Set the user's own password and clear the must-change flag.
+                self.db
+                    .credentials()
+                    .set_password(user_id, &new_password, Timestamp::now())
                     .await
-                    .map_err(|e| HostError::Storage(format!("{e}")))?;
-                let user = match user {
+                    .map_err(|e| HostError::Storage(format!("set_password: {e}")))?;
+                self.db
+                    .credentials()
+                    .clear_must_change(user_id)
+                    .await
+                    .map_err(|e| HostError::Storage(format!("clear must_change: {e}")))?;
+
+                // Complete the login that was held pending the password change.
+                let user = match UserStore::get_by_username(&self.db, &username)
+                    .await
+                    .map_err(|e| HostError::Storage(format!("{e}")))?
+                {
                     Some(u) => u,
                     None => {
                         let mut sessions = self.sessions.write().await;
                         if let Some(r) = sessions.get_mut(&session) {
                             r.workflow = Workflow::None;
                         }
-                        return Ok(Response::Error(format!(
-                            "User '{}' not found.",
-                            target.as_str()
-                        )));
+                        return Ok(Response::Error("Account no longer exists.".into()));
                     }
                 };
-                self.db
-                    .credentials()
-                    .set_password(user.id, &new_password, Timestamp::now())
-                    .await
-                    .map_err(|e| HostError::Storage(format!("set_password: {e}")))?;
-                {
-                    let mut sessions = self.sessions.write().await;
-                    if let Some(r) = sessions.get_mut(&session) {
-                        r.workflow = Workflow::None;
-                    }
-                }
-                if let Err(e) = self
-                    .db
-                    .audit_write(
-                        actor.as_str(),
-                        "set_user_password",
-                        Some(target.as_str()),
-                        None,
-                    )
-                    .await
-                {
-                    tracing::warn!("audit write failed: {e}");
-                }
-                info!(%actor, %target, "sysop reset user password");
-                Ok(Response::Text(format!(
-                    "Password for '{}' updated.",
-                    target.as_str()
-                )))
+                info!(%username, "forced password change complete; login finalised");
+                Ok(self.finalize_login(session, &user).await)
             }
 
             // ── Message reading ──────────────────────────────────────────────
@@ -4465,45 +4480,55 @@ impl BbsHost {
         session: SessionId,
         target: Username,
     ) -> Result<Response, HostError> {
-        let (_, _, level, _) = match self.session_auth_user(session).await {
+        let (actor, _, level, _) = match self.session_auth_user(session).await {
             Ok(t) => t,
             Err(r) => return Ok(r),
         };
         if level < PermissionLevel::Sysop {
             return Ok(Response::Error("Sysop access required.".into()));
         }
-        let user = UserStore::get_by_username(&self.db, &target)
+        let user = match UserStore::get_by_username(&self.db, &target)
             .await
-            .map_err(|e| HostError::Storage(format!("{e}")))?;
-        if user.is_none() {
-            return Ok(Response::Error(format!(
-                "User '{}' not found.",
-                target.as_str()
-            )));
-        }
+            .map_err(|e| HostError::Storage(format!("{e}")))?
         {
-            let sessions = self.sessions.read().await;
-            if let Some(r) = sessions.get(&session) {
-                if !matches!(r.workflow, Workflow::None) {
-                    return Ok(Response::Error(
-                        "A workflow is already in progress. Type 'cancel' first.".into(),
-                    ));
-                }
+            Some(u) => u,
+            None => {
+                return Ok(Response::Error(format!(
+                    "User '{}' not found.",
+                    target.as_str()
+                )))
             }
-        }
+        };
+
+        // Generate a single-use temporary password server-side (never chosen
+        // over the air) and flag the account so the user must pick a new one at
+        // their next login. The temp value is returned to the sysop to convey
+        // out-of-band. (#134)
+        let temp = self
+            .db
+            .credentials()
+            .reset_to_temp_password(user.id, Timestamp::now())
+            .await
+            .map_err(|e| HostError::Storage(format!("reset password: {e}")))?;
+
+        if let Err(e) = self
+            .db
+            .audit_write(
+                actor.as_str(),
+                "set_user_password",
+                Some(target.as_str()),
+                None,
+            )
+            .await
         {
-            let mut sessions = self.sessions.write().await;
-            if let Some(r) = sessions.get_mut(&session) {
-                r.workflow = Workflow::SetUserPassword {
-                    target: target.clone(),
-                    stage: SetUserPwdStage::EnterNew,
-                };
-            }
+            tracing::warn!("audit write failed: {e}");
         }
-        Ok(Response::Prompt {
-            text: format!("New password for {}:", target.as_str()),
-            hide_input: true,
-        })
+        info!(%actor, %target, "sysop reset user to a temporary password");
+        Ok(Response::Text(format!(
+            "Temporary password for '{}': {temp}\n\
+             They must change it at next login. Share it securely — it is visible on-air.",
+            target.as_str()
+        )))
     }
 
     async fn handle_create_room(
@@ -4754,7 +4779,7 @@ fn help_for_command(cmd: &str, level: Option<PermissionLevel>) -> String {
         ".c" if is_sysop => ".C — create a new room\nEnters the room creation workflow.",
         ".dr" if is_sysop => ".DR <name> — delete a room",
         ".du" if is_sysop => ".DU <user> — soft-delete a user account\nSets status to deleted and ends active sessions.",
-        ".pw" if is_sysop => ".PW <user> — reset another user's password\nDoes not require knowing their current password.",
+        ".pw" if is_sysop => ".PW <user> — reset a user to a single-use temp password\nReturns a temp password to share; they must change it at next login.",
         "openaccess" if is_sysop => {
             "OPENACCESS — disable verification requirement (SHTF mode)\n\
              All registrations immediately receive User-level access.\n\
@@ -5481,6 +5506,110 @@ mod tests {
         assert_eq!(
             user.display_name, None,
             "`-` sentinel should leave the display name unset"
+        );
+    }
+
+    /// Issue #134: `.PW` generates a single-use temp password (returned to the
+    /// sysop, not chosen over-air); the user is forced to set a new password
+    /// before their next login completes, and the temp stops working afterwards.
+    #[tokio::test]
+    async fn sysop_temp_password_reset_and_forced_change() {
+        let (host, _db) = make_host().await;
+        let sysop = host.create_session("test").await.unwrap();
+        register_and_login(&host, sysop, &Username::new("alice").unwrap(), "pass1234").await;
+
+        // bob registers (auto-logged-in).
+        let bob_sid = host.create_session("test").await.unwrap();
+        do_register(&host, bob_sid, "bob", "oldpass1").await;
+        let bob = || Username::new("bob").unwrap();
+
+        // Sysop resets bob → a temporary password is returned (not entered over-air).
+        let resp = host
+            .process_command(sysop, Command::SetUserPassword { username: bob() })
+            .await
+            .unwrap();
+        let temp = match &resp {
+            Response::Text(t) => {
+                assert!(
+                    t.to_lowercase().contains("temporary password"),
+                    "reset should return a temp password, got: {t}"
+                );
+                t.lines()
+                    .next()
+                    .unwrap()
+                    .rsplit(": ")
+                    .next()
+                    .unwrap()
+                    .to_owned()
+            }
+            other => panic!("expected Text, got {other:?}"),
+        };
+        assert!(temp.len() >= 8, "temp password too short: {temp:?}");
+
+        // bob logs in with the temp → forced to choose a new password, NOT yet in.
+        let s = host.create_session("test").await.unwrap();
+        host.process_command(s, Command::Login { username: bob() })
+            .await
+            .unwrap();
+        let resp = host
+            .process_command(
+                s,
+                Command::WorkflowReply {
+                    reply: temp.clone(),
+                },
+            )
+            .await
+            .unwrap();
+        assert!(
+            matches!(&resp, Response::Prompt { text, .. } if text.to_lowercase().contains("new password")),
+            "temp login should force a password change, got: {resp:?}"
+        );
+        assert!(
+            host.permission_ctx(s).await.unwrap().username().is_none(),
+            "login must not complete until the password is changed"
+        );
+
+        // Choose + confirm a new password → login completes.
+        host.process_command(
+            s,
+            Command::WorkflowReply {
+                reply: "newpass1".into(),
+            },
+        )
+        .await
+        .unwrap();
+        let resp = host
+            .process_command(
+                s,
+                Command::WorkflowReply {
+                    reply: "newpass1".into(),
+                },
+            )
+            .await
+            .unwrap();
+        assert!(
+            matches!(&resp, Response::LoggedIn { .. }),
+            "login should complete after the forced change, got: {resp:?}"
+        );
+        assert!(host.permission_ctx(s).await.unwrap().username().is_some());
+
+        // The new password logs in directly (no forced change).
+        let s2 = host.create_session("test").await.unwrap();
+        host.process_command(s2, Command::Login { username: bob() })
+            .await
+            .unwrap();
+        let resp = host
+            .process_command(
+                s2,
+                Command::WorkflowReply {
+                    reply: "newpass1".into(),
+                },
+            )
+            .await
+            .unwrap();
+        assert!(
+            matches!(&resp, Response::LoggedIn { .. }),
+            "new password should log in directly, got: {resp:?}"
         );
     }
 

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -770,25 +770,23 @@ The five built-in rooms (Lobby, Mail, Aides, Sysop, System) cannot be deleted.
 .PW <username>
 ```
 
-Starts a two-step workflow to set a new password for any account without
-needing to know their current password:
+Generates a single-use **temporary password** for the account and returns it to
+you — you never type a real password over the air:
 
 ```
-New password for alice (min 8 chars):
-> ••••••••
-
-Confirm new password:
-> ••••••••
-
-Password updated for alice.
+Temporary password for 'alice': Kp7mQ2rtVx9d
+They must change it at next login. Share it securely — it is visible on-air.
 ```
 
-If the confirmation doesn't match you are asked to try again. Use `CANCEL`
-to abort without changing anything.
+Convey that temporary password to the user out-of-band. The next time they log
+in with it, the BBS forces them to choose a new password before the session
+completes; the temporary password then stops working.
 
-This is the quickest path for password resets — no CLI access to the server
-required. The equivalent CLI command (`supply-drop-bbs user set-password`) is
-also available and documented in section 15.
+> **On-air note.** The temporary password is shown in your session, which on a
+> radio link is itself visible over the air — it is *single-use* and must be
+> changed immediately, which limits exposure, but treat it as sensitive. The
+> equivalent CLI command (`supply-drop-bbs user set-password`, section 15) sets
+> a password directly without going over the air.
 
 ### Web admin panel
 
@@ -817,7 +815,7 @@ accounts waiting for approval.
 Tell the sysop your username. They can reset your password in three ways,
 from most to least convenient:
 
-1. **In-session** — while connected to the BBS, the sysop types `.PW <username>` and follows the two prompts. No server access needed.
+1. **In-session** — while connected to the BBS, the sysop types `.PW <username>`; the BBS returns a single-use temporary password for them to pass to you, and you set your own password at next login. No server access needed.
 2. **Web admin** — log into the **web admin panel** → Users → find your account → reset password.
 3. **CLI** — on the server, run:
    ```bash
@@ -925,7 +923,7 @@ account and you can re-register with the same username.
 | `UNBAN <user>` | Lift a ban |
 | `.C <name>` | Create a new room |
 | `.DR <name>` | Delete a room |
-| `.PW <user>` | Reset a user's password (two-step workflow) |
+| `.PW <user>` | Reset a user to a single-use temp password |
 
 ---
 


### PR DESCRIPTION
Closes #134 (the chosen approach: full temp-password feature).

## Problem
A sysop's `.PW` reset prompted the sysop to **type the new password over the air** (cleartext on a LoRa link; `hide_input` is a no-op there), and the user kept using it indefinitely.

## Fix
- `.PW <user>` now generates a **single-use temporary password** server-side (`reset_to_temp_password`) — a real password is never chosen over-air. It stores the temp, flags the account `must_change`, and returns the temp value to the sysop to convey out-of-band.
- At the user's **next login**, the password verifies but the session is held in a new `ForceChangePassword` workflow that requires choosing a new password before the login completes; the flag is then cleared and the temp stops working.

## Notes
- New **append-only migration 0011** adds `must_change` to `user_credentials`. The new column is read/written via **runtime sqlx queries**, so the offline `.sqlx` cache doesn't need regenerating (existing `query!` macros are untouched).
- Removed the old interactive `SetUserPassword`/`SetUserPwdStage` workflow (replaced by the one-shot reset).
- The temp value is still shown in the sysop's session (on-air) — it's single-use + forced-change, which limits exposure; the on-air caveat is documented (USER_GUIDE + in-app `.PW` help). True out-of-band delivery remains the sysop's manual step, per the chosen option.

## Tests
- `sysop_temp_password_reset_and_forced_change`: reset returns a temp; temp login forces a change (not authenticated until done); new password logs in directly afterward.
- Full pre-commit checklist passed on Linux.

🤖 Generated with [Claude Code](https://claude.com/claude-code)