### PR TITLE
fix(mesh): registration & reply reliability over lossy links

### DIFF
--- a/crates/bbs-core/src/host.rs
+++ b/crates/bbs-core/src/host.rs
@@ -118,14 +118,46 @@ enum ForcePwdStage {
 
 #[derive(Clone, Debug)]
 enum RegisterStage {
-    DisplayName,
-    Password {
-        display_name: Option<String>,
-    },
-    Confirm {
-        display_name: Option<String>,
-        password: String,
-    },
+    /// Waiting for the password. (The display name is no longer collected during
+    /// registration — it defaults to the username and is set later via PROFILE.
+    /// Dropping the prompt removes a lossy round-trip on mesh and the failure
+    /// mode where a re-sent `REGISTER <x>` was captured as the display name.)
+    Password,
+    /// Password entered; waiting for confirmation.
+    Confirm { password: String },
+}
+
+/// A REGISTER/LOGIN command recognised inside an active pre-auth workflow, so
+/// it can restart that flow instead of being captured as a field value.
+#[derive(Debug, PartialEq, Eq)]
+enum AuthEscape {
+    Register(String),
+    Login(Username),
+}
+
+/// Detect a REGISTER/LOGIN command in raw workflow-reply text.
+///
+/// Only these two commands escape an active register/login workflow: a lost
+/// prompt on a lossy mesh link leads users to retype the command, and capturing
+/// that as a password (or, previously, a display name) silently corrupts the
+/// account. Other words are intentionally NOT treated as commands here, because
+/// they may be a legitimate password. A keyword with no argument is left to the
+/// workflow (e.g. a bare "register" is too short to be a password and simply
+/// re-prompts). Matching is case-insensitive.
+fn auth_escape(reply: &str) -> Option<AuthEscape> {
+    let trimmed = reply.trim();
+    let (word, rest) = match trimmed.split_once(char::is_whitespace) {
+        Some((w, r)) => (w, r.trim()),
+        None => (trimmed, ""),
+    };
+    if rest.is_empty() {
+        return None;
+    }
+    match word.to_ascii_lowercase().as_str() {
+        "register" => Some(AuthEscape::Register(rest.to_owned())),
+        "login" => Username::new(rest).ok().map(AuthEscape::Login),
+        _ => None,
+    }
 }
 
 #[allow(clippy::enum_variant_names)]
@@ -1591,18 +1623,19 @@ impl BbsHost {
             )));
         }
 
+        let prompt = format!("Registering '{username}'. Choose a password (min 8 characters):");
         {
             let mut sessions = self.sessions.write().await;
             if let Some(r) = sessions.get_mut(&session) {
                 r.workflow = Workflow::Register {
                     username,
-                    stage: RegisterStage::DisplayName,
+                    stage: RegisterStage::Password,
                 };
             }
         }
         Ok(Response::Prompt {
-            text: "Choose a display name (or send - to use your username):".into(),
-            hide_input: false,
+            text: prompt,
+            hide_input: true,
         })
     }
 
@@ -1666,6 +1699,7 @@ impl BbsHost {
             _ => return Ok(Response::Error("Login failed.".into())),
         }
 
+        let prompt = format!("Enter the password for '{username}':");
         {
             let mut sessions = self.sessions.write().await;
             match sessions.get_mut(&session) {
@@ -1682,9 +1716,18 @@ impl BbsHost {
             }
         }
         Ok(Response::Prompt {
-            text: "Enter your password:".into(),
+            text: prompt,
             hide_input: true,
         })
+    }
+
+    /// Clear any in-progress workflow for `session` (best-effort; a missing
+    /// session is a no-op). Used when a command escapes an active workflow.
+    async fn clear_workflow(&self, session: SessionId) {
+        let mut sessions = self.sessions.write().await;
+        if let Some(r) = sessions.get_mut(&session) {
+            r.workflow = Workflow::None;
+        }
     }
 
     async fn handle_workflow_reply(
@@ -1700,99 +1743,77 @@ impl BbsHost {
             }
         };
 
+        // While registering or logging in, a re-sent REGISTER/LOGIN command must
+        // restart that flow rather than be captured as a field value (e.g. a
+        // password). On a lossy mesh link a prompt is easily lost, so a confused
+        // user retypes the command — and previously it was silently swallowed,
+        // corrupting the account (username vs display name, garbage password).
+        // Deliberately limited to REGISTER/LOGIN: other words may be a legitimate
+        // password and must not be reinterpreted. CANCEL/STOP already break out
+        // upstream in the transport parser.
+        if matches!(workflow, Workflow::Register { .. } | Workflow::Login { .. }) {
+            match auth_escape(&reply) {
+                Some(AuthEscape::Register(name)) => {
+                    self.clear_workflow(session).await;
+                    return self.handle_register(session, name).await;
+                }
+                Some(AuthEscape::Login(name)) => {
+                    self.clear_workflow(session).await;
+                    return self.handle_login(session, name).await;
+                }
+                None => {}
+            }
+        }
+
         match workflow {
             Workflow::None => Ok(Response::Error("No active workflow. Type 'H'.".into())),
 
             // ── Registration ─────────────────────────────────────────────────
             Workflow::Register {
                 username,
-                stage: RegisterStage::DisplayName,
-            } => {
-                let trimmed = reply.trim();
-                // Empty input or the `-` sentinel both mean "use my username".
-                // Mesh transports can't send an empty message, so `-` (the same
-                // sentinel the PROFILE flow uses to clear a display name) is the
-                // mesh-usable way to accept the default; empty stays valid for
-                // CLI/web. See issue #105.
-                let display_name = if trimmed.is_empty() || trimmed == "-" {
-                    None
-                } else {
-                    if let Err(e) = crate::user::User::validate_display_name(trimmed) {
-                        return Ok(Response::Prompt {
-                            text: format!("Invalid display name: {e}. Try again:"),
-                            hide_input: false,
-                        });
-                    }
-                    Some(trimmed.to_owned())
-                };
-                let mut sessions = self.sessions.write().await;
-                if let Some(r) = sessions.get_mut(&session) {
-                    r.workflow = Workflow::Register {
-                        username,
-                        stage: RegisterStage::Password { display_name },
-                    };
-                }
-                Ok(Response::Prompt {
-                    text: "Choose a password (min 8 characters):".into(),
-                    hide_input: true,
-                })
-            }
-
-            Workflow::Register {
-                username,
-                stage: RegisterStage::Password { display_name },
+                stage: RegisterStage::Password,
             } => {
                 if reply.chars().count() < 8 {
-                    let mut sessions = self.sessions.write().await;
-                    if let Some(r) = sessions.get_mut(&session) {
-                        r.workflow = Workflow::Register {
-                            username,
-                            stage: RegisterStage::Password { display_name },
-                        };
-                    }
                     return Ok(Response::Prompt {
-                        text: "Password must be at least 8 characters. Try again:".into(),
+                        text: format!(
+                            "Password for '{username}' must be at least 8 characters. Try again:"
+                        ),
                         hide_input: true,
                     });
                 }
+                let prompt = format!("Confirm the password for '{username}':");
                 let mut sessions = self.sessions.write().await;
                 if let Some(r) = sessions.get_mut(&session) {
                     r.workflow = Workflow::Register {
                         username,
-                        stage: RegisterStage::Confirm {
-                            display_name,
-                            password: reply,
-                        },
+                        stage: RegisterStage::Confirm { password: reply },
                     };
                 }
                 Ok(Response::Prompt {
-                    text: "Confirm your password:".into(),
+                    text: prompt,
                     hide_input: true,
                 })
             }
 
             Workflow::Register {
                 username,
-                stage:
-                    RegisterStage::Confirm {
-                        display_name,
-                        password,
-                    },
+                stage: RegisterStage::Confirm { password },
             } => {
                 if reply != password {
+                    let prompt =
+                        format!("Passwords didn't match. Choose a password for '{username}':");
                     let mut sessions = self.sessions.write().await;
                     if let Some(r) = sessions.get_mut(&session) {
                         r.workflow = Workflow::Register {
                             username,
-                            stage: RegisterStage::Password { display_name },
+                            stage: RegisterStage::Password,
                         };
                     }
                     return Ok(Response::Prompt {
-                        text: "Passwords don't match. Choose a password:".into(),
+                        text: prompt,
                         hide_input: true,
                     });
                 }
-
                 let now = Timestamp::now();
                 // Promote the very first registrant to Sysop so the system
                 // isn't stuck with no one able to validate new users.
@@ -1805,27 +1826,22 @@ impl BbsHost {
                 } else {
                     PermissionLevel::Unvalidated
                 };
-                let user_id = match UserStore::create(
-                    &self.db,
-                    &username,
-                    display_name.as_deref(),
-                    initial_level,
-                    now,
-                )
-                .await
-                {
-                    Ok(id) => id,
-                    Err(crate::db::StoreError::Conflict(_)) => {
-                        let mut sessions = self.sessions.write().await;
-                        if let Some(r) = sessions.get_mut(&session) {
-                            r.workflow = Workflow::None;
+                // Display name defaults to the username (stored as NULL); the user
+                // sets it later with PROFILE. See RegisterStage docs.
+                let user_id =
+                    match UserStore::create(&self.db, &username, None, initial_level, now).await {
+                        Ok(id) => id,
+                        Err(crate::db::StoreError::Conflict(_)) => {
+                            let mut sessions = self.sessions.write().await;
+                            if let Some(r) = sessions.get_mut(&session) {
+                                r.workflow = Workflow::None;
+                            }
+                            return Ok(Response::Error(format!(
+                                "'{username}' was just taken. Try: register <different_username>"
+                            )));
                         }
-                        return Ok(Response::Error(format!(
-                            "'{username}' was just taken. Try: register <different_username>"
-                        )));
-                    }
-                    Err(e) => return Err(HostError::Storage(format!("create user: {e}"))),
-                };
+                        Err(e) => return Err(HostError::Storage(format!("create user: {e}"))),
+                    };
                 self.db
                     .credentials()
                     .set_password(user_id, &password, now)
@@ -5380,16 +5396,14 @@ mod tests {
             )
             .await
             .unwrap();
-        assert!(matches!(r, Response::Prompt { .. }));
+        // Registration goes straight to a self-describing password prompt — no
+        // display-name step (it defaults to the username; set later via PROFILE).
+        assert!(
+            matches!(&r, Response::Prompt { text, .. }
+                if text.to_lowercase().contains("password") && text.contains("alice")),
+            "expected a self-describing password prompt, got: {r:?}"
+        );
 
-        host.process_command(
-            sid,
-            Command::WorkflowReply {
-                reply: "Alice".into(),
-            },
-        )
-        .await
-        .unwrap();
         host.process_command(
             sid,
             Command::WorkflowReply {
@@ -5448,14 +5462,6 @@ mod tests {
         host.process_command(
             sid,
             Command::WorkflowReply {
-                reply: String::new(),
-            },
-        )
-        .await
-        .unwrap();
-        host.process_command(
-            sid,
-            Command::WorkflowReply {
                 reply: "password1".into(),
             },
         )
@@ -5492,14 +5498,6 @@ mod tests {
             sid,
             Command::Register {
                 username: uname.as_str().to_owned(),
-            },
-        )
-        .await
-        .unwrap();
-        host.process_command(
-            sid,
-            Command::WorkflowReply {
-                reply: String::new(),
             },
         )
         .await
@@ -5611,14 +5609,6 @@ mod tests {
         host.process_command(
             sid,
             Command::WorkflowReply {
-                reply: String::new(),
-            },
-        )
-        .await
-        .unwrap();
-        host.process_command(
-            sid,
-            Command::WorkflowReply {
                 reply: "password1".into(),
             },
         )
@@ -5679,15 +5669,6 @@ mod tests {
             sid,
             Command::Register {
                 username: uname.as_str().to_owned(),
-            },
-        )
-        .await
-        .unwrap();
-        // display name (empty = skip)
-        host.process_command(
-            sid,
-            Command::WorkflowReply {
-                reply: String::new(),
             },
         )
         .await
@@ -5757,35 +5738,222 @@ mod tests {
         );
     }
 
-    /// Issue #129: the `-` display-name shortcut must ADVANCE to the password
-    /// step (not exit registration). Regression guard for the #105 fix.
+    /// Registration no longer has a display-name step: REGISTER advances straight
+    /// to a password prompt, and the account is created with no display name (it
+    /// shows the username until changed via PROFILE). This removes the lossy
+    /// round-trip and the failure mode where a re-sent command was captured as
+    /// the display name.
     #[tokio::test]
-    async fn register_dash_advances_to_password() {
+    async fn register_skips_display_name_step() {
         let (host, _db) = make_host().await;
         let sid = host.create_session("test").await.unwrap();
+
+        let resp = host
+            .process_command(
+                sid,
+                Command::Register {
+                    username: "qatester1".to_owned(),
+                },
+            )
+            .await
+            .unwrap();
+        // First prompt is the password (self-describing), not a display-name ask.
+        match &resp {
+            Response::Prompt { text, .. } => {
+                let t = text.to_lowercase();
+                assert!(t.contains("password"), "expected password prompt: {text}");
+                assert!(
+                    !t.contains("display name"),
+                    "registration must not ask for a display name: {text}"
+                );
+                assert!(
+                    text.contains("qatester1"),
+                    "prompt should name the user: {text}"
+                );
+            }
+            other => panic!("expected a prompt, got {other:?}"),
+        }
+        let stage_is_password = {
+            let sessions = host.sessions.read().await;
+            matches!(
+                sessions[&sid].workflow,
+                Workflow::Register {
+                    stage: RegisterStage::Password,
+                    ..
+                }
+            )
+        };
+        assert!(stage_is_password, "should be at the password stage");
+
+        // Complete registration; the account has no display name.
+        host.process_command(
+            sid,
+            Command::WorkflowReply {
+                reply: "hunter2!".into(),
+            },
+        )
+        .await
+        .unwrap();
+        let done = host
+            .process_command(
+                sid,
+                Command::WorkflowReply {
+                    reply: "hunter2!".into(),
+                },
+            )
+            .await
+            .unwrap();
+        assert!(matches!(done, Response::LoggedIn { .. }));
+        let user = host
+            .db
+            .get_by_username(&Username::new("qatester1").unwrap())
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            user.display_name, None,
+            "display name should default to None"
+        );
+    }
+
+    /// A re-sent REGISTER while mid-registration restarts registration with the
+    /// new username instead of being captured as a password — the core fix for
+    /// the lost-prompt corruption (a "Failed" REGISTER set the username, the next
+    /// REGISTER became the display name, and chat text became the password).
+    #[tokio::test]
+    async fn register_command_escapes_active_registration() {
+        let (host, _db) = make_host().await;
+        let sid = host.create_session("test").await.unwrap();
+
         host.process_command(
             sid,
             Command::Register {
-                username: "qatester1".to_owned(),
+                username: "tcf".to_owned(),
             },
         )
         .await
         .unwrap();
 
+        // User didn't see the prompt and retypes the command with a new name.
         let resp = host
-            .process_command(sid, Command::WorkflowReply { reply: "-".into() })
+            .process_command(
+                sid,
+                Command::WorkflowReply {
+                    reply: "REGISTER tcm1".into(),
+                },
+            )
+            .await
+            .unwrap();
+
+        // It restarts registration as 'tcm1' (a fresh password prompt for tcm1),
+        // NOT captured as tcf's password.
+        match &resp {
+            Response::Prompt { text, .. } => {
+                assert!(text.contains("tcm1"), "should restart as tcm1: {text}");
+                assert!(
+                    text.to_lowercase().contains("password"),
+                    "should prompt for password: {text}"
+                );
+            }
+            other => panic!("expected a prompt, got {other:?}"),
+        }
+        let registering_tcm1 = {
+            let sessions = host.sessions.read().await;
+            matches!(
+                &sessions[&sid].workflow,
+                Workflow::Register { username, .. } if username.as_str() == "tcm1"
+            )
+        };
+        assert!(registering_tcm1, "workflow should now be registering tcm1");
+    }
+
+    /// A LOGIN command escapes an active registration (switches flows), and a
+    /// REGISTER escapes an active login. Passwords are never reinterpreted.
+    #[tokio::test]
+    async fn login_register_escape_each_other() {
+        let (host, _db) = make_host().await;
+
+        // Seed an existing account to log into.
+        let setup = host.create_session("test").await.unwrap();
+        do_register(&host, setup, "alice", "s3cr3t!!").await;
+
+        // Mid-registration, LOGIN switches to the login flow.
+        let sid = host.create_session("test").await.unwrap();
+        host.process_command(
+            sid,
+            Command::Register {
+                username: "bob".to_owned(),
+            },
+        )
+        .await
+        .unwrap();
+        let resp = host
+            .process_command(
+                sid,
+                Command::WorkflowReply {
+                    reply: "login alice".into(),
+                },
+            )
             .await
             .unwrap();
         assert!(
-            matches!(&resp, Response::Prompt { text, .. } if text.to_lowercase().contains("password")),
-            "`-` should advance to the password prompt, got: {resp:?}"
+            matches!(&resp, Response::Prompt { text, .. } if text.to_lowercase().contains("password") && text.contains("alice")),
+            "LOGIN should switch to login for alice, got: {resp:?}"
         );
-        // Still mid-registration — not dropped back to the anonymous menu.
-        let sessions = host.sessions.read().await;
+        let logging_in = {
+            let sessions = host.sessions.read().await;
+            matches!(&sessions[&sid].workflow, Workflow::Login { username, .. } if username.as_str() == "alice")
+        };
+        assert!(logging_in, "should be in the login workflow for alice");
+
+        // A password that merely *looks* like normal text is NOT reinterpreted:
+        // an ordinary password is accepted as the password.
+        let s2 = host.create_session("test").await.unwrap();
+        host.process_command(
+            s2,
+            Command::Register {
+                username: "carol".to_owned(),
+            },
+        )
+        .await
+        .unwrap();
+        let resp = host
+            .process_command(
+                s2,
+                Command::WorkflowReply {
+                    reply: "hello world pw".into(),
+                },
+            )
+            .await
+            .unwrap();
+        // Advanced to confirm — the text was taken as the password, not a command.
         assert!(
-            matches!(sessions[&sid].workflow, Workflow::Register { .. }),
-            "session should still be in the registration workflow after `-`"
+            matches!(&resp, Response::Prompt { text, .. } if text.to_lowercase().contains("confirm")),
+            "ordinary text should be taken as the password, got: {resp:?}"
         );
+    }
+
+    #[test]
+    fn auth_escape_recognizes_register_and_login_only() {
+        assert_eq!(
+            auth_escape("REGISTER tcm1"),
+            Some(AuthEscape::Register("tcm1".into()))
+        );
+        assert_eq!(
+            auth_escape("  register   TCF  "),
+            Some(AuthEscape::Register("TCF".into()))
+        );
+        assert_eq!(
+            auth_escape("login alice"),
+            Some(AuthEscape::Login(Username::new("alice").unwrap()))
+        );
+        // No argument → not an escape (a bare keyword is left to the workflow).
+        assert_eq!(auth_escape("register"), None);
+        assert_eq!(auth_escape("login"), None);
+        // Other words are never escapes — they may be a legitimate password.
+        assert_eq!(auth_escape("hello there friend"), None);
+        assert_eq!(auth_escape("help"), None);
+        assert_eq!(auth_escape("s3cr3t!!"), None);
     }
 
     /// Issue #128: `REGISTER` validates the username up front and returns a
@@ -5838,7 +6006,7 @@ mod tests {
             "reserved username should be rejected specifically, got: {reserved:?}"
         );
 
-        // A valid username advances to the display-name prompt.
+        // A valid username advances straight to the password prompt.
         let ok = host
             .process_command(
                 sid,
@@ -5849,7 +6017,7 @@ mod tests {
             .await
             .unwrap();
         assert!(
-            matches!(&ok, Response::Prompt { text, .. } if text.to_lowercase().contains("display name")),
+            matches!(&ok, Response::Prompt { text, .. } if text.to_lowercase().contains("password")),
             "valid username should start registration, got: {ok:?}"
         );
     }
@@ -6124,50 +6292,6 @@ mod tests {
         assert!(
             matches!(&r, Response::Text(t) if t.to_lowercase().contains("user")),
             "demoting a sysop while another remains should succeed, got: {r:?}"
-        );
-    }
-
-    /// Issue #105: on a mesh radio you can't send an empty message, so the
-    /// `-` sentinel must mean "use my username" (display name left unset),
-    /// matching the empty-input behaviour available on CLI/web.
-    #[tokio::test]
-    async fn register_display_name_dash_sentinel_uses_username() {
-        let (host, _db) = make_host().await;
-        let sid = host.create_session("test").await.unwrap();
-        let uname = Username::new("dashuser").unwrap();
-
-        host.process_command(
-            sid,
-            Command::Register {
-                username: uname.as_str().to_owned(),
-            },
-        )
-        .await
-        .unwrap();
-        // Display name: `-` → use username (the empty-input default is
-        // unreachable over mesh).
-        host.process_command(sid, Command::WorkflowReply { reply: "-".into() })
-            .await
-            .unwrap();
-        // Password, then matching confirmation.
-        for _ in 0..2 {
-            host.process_command(
-                sid,
-                Command::WorkflowReply {
-                    reply: "abc12345".into(),
-                },
-            )
-            .await
-            .unwrap();
-        }
-
-        let user = UserStore::get_by_username(&host.db, &uname)
-            .await
-            .unwrap()
-            .expect("user should be created");
-        assert_eq!(
-            user.display_name, None,
-            "`-` sentinel should leave the display name unset"
         );
     }
 
@@ -6875,16 +6999,7 @@ mod tests {
         )
         .await
         .unwrap();
-        // Step 2: skip optional display name.
-        host.process_command(
-            sid,
-            Command::WorkflowReply {
-                reply: String::new(),
-            },
-        )
-        .await
-        .unwrap();
-        // Step 3: enter password.
+        // Step 2: enter password.
         host.process_command(
             sid,
             Command::WorkflowReply {
@@ -6893,7 +7008,7 @@ mod tests {
         )
         .await
         .unwrap();
-        // Step 4: confirm password — should log in.
+        // Step 3: confirm password — should log in.
         let resp = host
             .process_command(
                 sid,

--- a/crates/bbs-mesh/src/config.rs
+++ b/crates/bbs-mesh/src/config.rs
@@ -202,6 +202,20 @@ pub struct MeshConfig {
     #[serde(default = "default_flood_after_send")]
     pub flood_after_send: bool,
 
+    /// Total transmissions for an outbound reply, including the first.
+    ///
+    /// On a multi-hop mesh the return path is lossy, so a reply (or its
+    /// end-to-end ACK) is routinely dropped and the BBS appears unresponsive.
+    /// When this is greater than `1`, the transport tracks each reply's delivery
+    /// (via the device's `RESP_CODE_SENT` CRC and `PUSH_CODE_SEND_CONFIRMED`)
+    /// and retransmits if no confirmation arrives before the device's timeout
+    /// hint. `1` disables retransmission (record-and-forget). Defaults to `3`.
+    ///
+    /// Trade-off: delivery becomes at-least-once, so a confirmation lost on the
+    /// return path can produce a duplicate reply — preferable to silence.
+    #[serde(default = "default_reply_max_attempts")]
+    pub reply_max_attempts: u8,
+
     /// Radio parameter configuration.
     ///
     /// Stored here for reference and applied on demand via
@@ -244,6 +258,7 @@ impl Default for MeshConfig {
             reconnect_delay_max_ms: default_reconnect_max_ms(),
             node_credential_ttl_days: default_node_credential_ttl_days(),
             flood_after_send: default_flood_after_send(),
+            reply_max_attempts: default_reply_max_attempts(),
             radio: None,
         }
     }
@@ -281,6 +296,10 @@ fn default_node_credential_ttl_days() -> u32 {
 
 fn default_flood_after_send() -> bool {
     true
+}
+
+fn default_reply_max_attempts() -> u8 {
+    3
 }
 
 fn default_true() -> bool {

--- a/crates/bbs-mesh/src/lib.rs
+++ b/crates/bbs-mesh/src/lib.rs
@@ -49,6 +49,7 @@
 
 pub mod command;
 pub mod config;
+mod send_tracker;
 pub mod session;
 pub mod transport;
 

--- a/crates/bbs-mesh/src/send_tracker.rs
+++ b/crates/bbs-mesh/src/send_tracker.rs
@@ -1,0 +1,317 @@
+//! Delivery tracking and retransmission for outbound text replies.
+//!
+//! # Why
+//!
+//! The MeshCore companion link is fire-and-forget: the host writes a
+//! `CMD_SEND_TXT_MSG` and moves on. On a multi-hop mesh the *return* path is
+//! lossy, so a reply (or its end-to-end ACK) is routinely dropped — the user
+//! sends a command, the BBS processes it, but the answer never arrives and the
+//! BBS looks unresponsive.
+//!
+//! The firmware actually gives us enough to do better, we just weren't using it:
+//!
+//! - `RESP_CODE_SENT` (`InboundFrame::Sent`) is the device's immediate reply to
+//!   a send. It carries an `expected_ack` CRC identifying the message and a
+//!   `timeout_ms` hint for how long to wait for end-to-end delivery. A CRC of 0
+//!   means the device could not even queue it (no route / unknown contact).
+//! - `PUSH_CODE_SEND_CONFIRMED` (`InboundFrame::SendConfirmed`) arrives later
+//!   with the same CRC once the destination has acknowledged receipt.
+//!
+//! [`SendTracker`] turns those signals into at-least-once delivery: every text
+//! send is recorded; if no `SendConfirmed` arrives before the deadline, the
+//! message is retransmitted (up to a configured attempt cap). A delivered
+//! message that loses only its `SendConfirmed` may be retransmitted once more —
+//! a duplicate reply is far less harmful than silence, and inbound commands are
+//! already deduplicated elsewhere.
+//!
+//! # Correlation
+//!
+//! `RESP_CODE_SENT` is the device's synchronous response to `CMD_SEND_TXT_MSG`
+//! and is emitted in the same order the sends were written to the wire. So a
+//! FIFO of "sent, awaiting RESP_CODE_SENT" records correlates 1:1 with incoming
+//! `Sent` frames by order; once a CRC is known the record moves to a CRC-keyed
+//! map to await `SendConfirmed`. All text sends must be recorded here in send
+//! order for the correlation to hold (see `enqueue_text` in `transport.rs`).
+//!
+//! This module is pure state — no I/O, no clock of its own (the caller passes
+//! `Instant`s) — so the state machine is unit-tested directly.
+
+use std::collections::{HashMap, VecDeque};
+use std::time::{Duration, Instant};
+
+/// Tunables for reply retransmission.
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct RetryConfig {
+    /// Total transmissions per message, including the first. `1` disables
+    /// retransmission entirely (record-and-forget, only used for observability).
+    pub max_attempts: u8,
+    /// Floor for the per-attempt ACK wait, regardless of the device hint.
+    pub min_timeout: Duration,
+    /// Ceiling for the per-attempt ACK wait (guards against absurd hints).
+    pub max_timeout: Duration,
+}
+
+impl RetryConfig {
+    /// Clamp the device's `timeout_ms` hint into the configured window.
+    fn ack_wait(&self, timeout_ms: u32) -> Duration {
+        Duration::from_millis(u64::from(timeout_ms)).clamp(self.min_timeout, self.max_timeout)
+    }
+}
+
+/// A text send awaiting a delivery outcome.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct PendingSend {
+    pub prefix: [u8; 6],
+    pub text: String,
+    pub txt_type: u8,
+    /// 1-based count of transmissions made so far (1 = first send).
+    pub attempt: u8,
+    /// When the wait for this attempt's `SendConfirmed` expires. Only meaningful
+    /// once the record is in `awaiting_ack`; a placeholder while in
+    /// `awaiting_sent`.
+    pub deadline: Instant,
+}
+
+/// Outcome of an `on_sent` correlation.
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) enum SentOutcome {
+    /// Device accepted the message; now awaiting end-to-end confirmation.
+    Accepted,
+    /// Device reported `MSG_SEND_FAILED` (CRC 0). The record is returned so the
+    /// caller can retransmit immediately if attempts remain.
+    Failed(PendingSend),
+    /// A `Sent` frame arrived with no recorded send to correlate it to.
+    Spurious,
+}
+
+/// FIFO + CRC-keyed tracker of in-flight text sends. See module docs.
+pub(crate) struct SendTracker {
+    cfg: RetryConfig,
+    /// Sent, awaiting `RESP_CODE_SENT`, in send order.
+    awaiting_sent: VecDeque<PendingSend>,
+    /// CRC (`expected_ack`) → record awaiting `SendConfirmed` or timeout.
+    awaiting_ack: HashMap<u32, PendingSend>,
+}
+
+impl SendTracker {
+    pub fn new(cfg: RetryConfig) -> Self {
+        Self {
+            cfg,
+            awaiting_sent: VecDeque::new(),
+            awaiting_ack: HashMap::new(),
+        }
+    }
+
+    /// Whether retransmission is enabled at all.
+    pub fn retries_enabled(&self) -> bool {
+        self.cfg.max_attempts > 1
+    }
+
+    /// Record a text send that was just written to the wire. `attempt` is 1 for
+    /// a first send, or the previous attempt + 1 for a retransmission.
+    pub fn record(
+        &mut self,
+        prefix: [u8; 6],
+        text: String,
+        txt_type: u8,
+        attempt: u8,
+        now: Instant,
+    ) {
+        self.awaiting_sent.push_back(PendingSend {
+            prefix,
+            text,
+            txt_type,
+            attempt,
+            deadline: now, // replaced when the CRC + timeout arrive
+        });
+    }
+
+    /// Correlate a `RESP_CODE_SENT` (`expected_ack` CRC, `timeout_ms` hint) with
+    /// the oldest un-correlated send.
+    pub fn on_sent(&mut self, crc: u32, timeout_ms: u32, now: Instant) -> SentOutcome {
+        let Some(mut rec) = self.awaiting_sent.pop_front() else {
+            return SentOutcome::Spurious;
+        };
+        if crc == 0 {
+            return SentOutcome::Failed(rec);
+        }
+        rec.deadline = now + self.cfg.ack_wait(timeout_ms);
+        // A CRC collision (same message retransmitted) simply refreshes the entry.
+        self.awaiting_ack.insert(crc, rec);
+        SentOutcome::Accepted
+    }
+
+    /// Mark a message delivered (`SendConfirmed`). Returns true if it was being
+    /// tracked (false for an unknown/duplicate CRC).
+    pub fn on_confirmed(&mut self, crc: u32) -> bool {
+        self.awaiting_ack.remove(&crc).is_some()
+    }
+
+    /// Remove and return all entries whose ACK deadline has passed, split into
+    /// those that should be retransmitted (attempts remain) and those that have
+    /// exhausted their attempts (caller logs the give-up).
+    pub fn collect_due(&mut self, now: Instant) -> DueSends {
+        let due_crcs: Vec<u32> = self
+            .awaiting_ack
+            .iter()
+            .filter(|(_, r)| r.deadline <= now)
+            .map(|(crc, _)| *crc)
+            .collect();
+        let mut to_retry = Vec::new();
+        let mut gave_up = Vec::new();
+        for crc in due_crcs {
+            if let Some(rec) = self.awaiting_ack.remove(&crc) {
+                if rec.attempt < self.cfg.max_attempts {
+                    to_retry.push(rec);
+                } else {
+                    gave_up.push(rec);
+                }
+            }
+        }
+        DueSends { to_retry, gave_up }
+    }
+
+    #[cfg(test)]
+    fn in_flight(&self) -> usize {
+        self.awaiting_sent.len() + self.awaiting_ack.len()
+    }
+}
+
+/// Result of [`SendTracker::collect_due`].
+pub(crate) struct DueSends {
+    /// Records to retransmit (resend with `attempt + 1`).
+    pub to_retry: Vec<PendingSend>,
+    /// Records abandoned after exhausting their attempt budget.
+    pub gave_up: Vec<PendingSend>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn cfg(max_attempts: u8) -> RetryConfig {
+        RetryConfig {
+            max_attempts,
+            min_timeout: Duration::from_secs(3),
+            max_timeout: Duration::from_secs(30),
+        }
+    }
+
+    fn rec(t: &mut SendTracker, txt: &str, attempt: u8, now: Instant) {
+        t.record([1, 2, 3, 4, 5, 6], txt.to_owned(), 0, attempt, now);
+    }
+
+    #[test]
+    fn confirmed_before_deadline_is_not_retried() {
+        let now = Instant::now();
+        let mut t = SendTracker::new(cfg(3));
+        rec(&mut t, "hi", 1, now);
+        assert_eq!(t.on_sent(0xABCD, 5_000, now), SentOutcome::Accepted);
+        assert!(t.on_confirmed(0xABCD));
+        // Past the deadline, nothing is due — it was delivered.
+        let due = t.collect_due(now + Duration::from_secs(60));
+        assert!(due.to_retry.is_empty() && due.gave_up.is_empty());
+        assert_eq!(t.in_flight(), 0);
+    }
+
+    #[test]
+    fn missing_confirm_retransmits_until_cap() {
+        let now = Instant::now();
+        let mut t = SendTracker::new(cfg(3));
+        // Attempt 1.
+        rec(&mut t, "hi", 1, now);
+        t.on_sent(0x1, 5_000, now);
+        // Deadline ~5s later; before that, nothing due.
+        assert!(t
+            .collect_due(now + Duration::from_secs(4))
+            .to_retry
+            .is_empty());
+        let due = t.collect_due(now + Duration::from_secs(6));
+        assert_eq!(due.to_retry.len(), 1);
+        assert_eq!(
+            due.to_retry[0].attempt, 1,
+            "returns the prior attempt count"
+        );
+
+        // Caller retransmits as attempt 2.
+        let t2 = now + Duration::from_secs(6);
+        rec(&mut t, "hi", 2, t2);
+        t.on_sent(0x2, 5_000, t2);
+        let due = t.collect_due(t2 + Duration::from_secs(6));
+        assert_eq!(due.to_retry.len(), 1);
+
+        // Attempt 3 is the cap → next timeout gives up, no further retry.
+        let t3 = t2 + Duration::from_secs(6);
+        rec(&mut t, "hi", 3, t3);
+        t.on_sent(0x3, 5_000, t3);
+        let due = t.collect_due(t3 + Duration::from_secs(6));
+        assert!(due.to_retry.is_empty(), "attempt 3 hit the cap");
+        assert_eq!(due.gave_up.len(), 1);
+        assert_eq!(t.in_flight(), 0);
+    }
+
+    #[test]
+    fn send_failed_crc_zero_returns_record() {
+        let now = Instant::now();
+        let mut t = SendTracker::new(cfg(3));
+        rec(&mut t, "hi", 1, now);
+        match t.on_sent(0, 0, now) {
+            SentOutcome::Failed(r) => assert_eq!(r.attempt, 1),
+            other => panic!("expected Failed, got {other:?}"),
+        }
+        assert_eq!(t.in_flight(), 0, "failed send is not left dangling");
+    }
+
+    #[test]
+    fn fifo_correlation_matches_sends_in_order() {
+        let now = Instant::now();
+        let mut t = SendTracker::new(cfg(2));
+        rec(&mut t, "first", 1, now);
+        rec(&mut t, "second", 1, now);
+        // Sent frames arrive in send order.
+        t.on_sent(0xAA, 5_000, now);
+        t.on_sent(0xBB, 5_000, now);
+        // Confirm the second; the first is still in flight.
+        assert!(t.on_confirmed(0xBB));
+        let due = t.collect_due(now + Duration::from_secs(10));
+        assert_eq!(due.to_retry.len(), 1);
+        assert_eq!(due.to_retry[0].text, "first");
+    }
+
+    #[test]
+    fn spurious_sent_without_record_is_reported() {
+        let now = Instant::now();
+        let mut t = SendTracker::new(cfg(3));
+        assert_eq!(t.on_sent(0x1, 5_000, now), SentOutcome::Spurious);
+    }
+
+    #[test]
+    fn timeout_hint_is_clamped() {
+        let now = Instant::now();
+        let mut t = SendTracker::new(cfg(3));
+        // A tiny hint is floored to min_timeout (3s), so not due at 1s.
+        rec(&mut t, "hi", 1, now);
+        t.on_sent(0x1, 10, now);
+        assert!(t
+            .collect_due(now + Duration::from_secs(1))
+            .to_retry
+            .is_empty());
+        assert_eq!(
+            t.collect_due(now + Duration::from_secs(4)).to_retry.len(),
+            1
+        );
+
+        // A huge hint is capped to max_timeout (30s).
+        let mut t = SendTracker::new(cfg(3));
+        rec(&mut t, "hi", 1, now);
+        t.on_sent(0x2, 10_000_000, now);
+        assert!(t
+            .collect_due(now + Duration::from_secs(29))
+            .to_retry
+            .is_empty());
+        assert_eq!(
+            t.collect_due(now + Duration::from_secs(31)).to_retry.len(),
+            1
+        );
+    }
+}

--- a/crates/bbs-mesh/src/transport.rs
+++ b/crates/bbs-mesh/src/transport.rs
@@ -27,7 +27,7 @@
 
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use async_trait::async_trait;
 use bbs_plugin_api::{
@@ -59,8 +59,92 @@ use tracing::{debug, error, info, warn};
 use crate::{
     command::{format_response, parse_command, render_notification},
     config::{ConnectionType, MeshConfig},
+    send_tracker::{RetryConfig, SendTracker, SentOutcome},
     session::SessionState,
 };
+
+/// Floor for how long to wait for a reply's end-to-end ACK before retransmitting.
+const REPLY_ACK_MIN_WAIT: Duration = Duration::from_secs(4);
+/// Ceiling for the ACK wait (guards against an absurd device timeout hint).
+const REPLY_ACK_MAX_WAIT: Duration = Duration::from_secs(30);
+/// How often the event loop checks for replies that timed out awaiting an ACK.
+const RETRY_TICK: Duration = Duration::from_millis(500);
+
+/// Enqueue a plain-text reply to the companion client and, when retransmission
+/// is enabled, record it in `tracker` for delivery tracking.
+///
+/// Record + enqueue happen together under the tracker lock with a *non-blocking*
+/// `try_send`, so the tracker's send-order FIFO matches the wire order even when
+/// called from several tasks (the event loop, `notify`, domain-event pushes).
+/// No `.await` is held across the lock. A full command channel drops the reply
+/// (logged) rather than blocking the caller; depth is generous and this is rare.
+fn enqueue_text(
+    tracker: &Mutex<SendTracker>,
+    cmd_tx: &mpsc::Sender<OutboundFrame>,
+    prefix: [u8; 6],
+    text: String,
+    attempt: u8,
+) {
+    let frame = OutboundFrame::SendTxtMsg {
+        txt_type: TXT_TYPE_PLAIN,
+        // The wire `attempt` field is 0-based (0 = first send); the tracker
+        // counts transmissions 1-based.
+        attempt: attempt.saturating_sub(1),
+        timestamp: now_unix_secs(),
+        pubkey_prefix: prefix,
+        text: text.clone(),
+    };
+    let mut t = tracker.lock().expect("send tracker mutex poisoned");
+    match cmd_tx.try_send(frame) {
+        Ok(()) => {
+            if t.retries_enabled() {
+                t.record(prefix, text, TXT_TYPE_PLAIN, attempt, Instant::now());
+            }
+        }
+        Err(e) => warn!(error = %e, "mesh: command channel full/closed — reply dropped"),
+    }
+}
+
+/// Retransmit any replies whose end-to-end ACK deadline has passed, and log the
+/// ones that have exhausted their attempt budget. Called on the retry tick from
+/// the event loop. On retry the node's stored path is reset first (when flooding
+/// is enabled) so a stale direct route doesn't keep failing the same way.
+fn retransmit_due_replies(
+    cmd_tx: &mpsc::Sender<OutboundFrame>,
+    state: &Arc<Mutex<SessionState>>,
+    tracker: &Arc<Mutex<SendTracker>>,
+    flood_after_send: bool,
+) {
+    let due = {
+        let mut t = tracker.lock().expect("send tracker mutex poisoned");
+        if !t.retries_enabled() {
+            return;
+        }
+        t.collect_due(Instant::now())
+    };
+    for rec in due.gave_up {
+        warn!(
+            attempts = rec.attempt,
+            "mesh: reply undelivered after all retries — giving up"
+        );
+    }
+    for rec in due.to_retry {
+        if flood_after_send {
+            let pubkey = state
+                .lock()
+                .expect("state mutex poisoned")
+                .get_full_pubkey(&rec.prefix);
+            if let Some(pubkey) = pubkey {
+                let _ = cmd_tx.try_send(OutboundFrame::ResetPath { pubkey });
+            }
+        }
+        debug!(
+            next_attempt = rec.attempt + 1,
+            "mesh: retransmitting unacknowledged reply"
+        );
+        enqueue_text(tracker, cmd_tx, rec.prefix, rec.text, rec.attempt + 1);
+    }
+}
 
 /// Current Unix time in seconds, truncated to u32 (the wire format's field width).
 /// Returns 0 if the system clock is before the epoch, which should never happen
@@ -118,6 +202,10 @@ pub struct MeshTransport {
     /// a potentially-stale direct path.  Can be disabled in config to
     /// restore pre-v0.2.4 direct-path-only behaviour.
     flood_after_send: bool,
+    /// Tracks in-flight replies and drives retransmission on missing ACKs.
+    /// Shared with the event-loop task (which owns the retry timer and the
+    /// `Sent`/`SendConfirmed` correlation). See [`crate::send_tracker`].
+    send_tracker: Arc<Mutex<SendTracker>>,
 }
 
 #[async_trait]
@@ -190,6 +278,11 @@ impl Plugin for MeshTransport {
             node_credential_ttl_days: config.node_credential_ttl_days,
             draining: Arc::new(AtomicBool::new(false)),
             flood_after_send: config.flood_after_send,
+            send_tracker: Arc::new(Mutex::new(SendTracker::new(RetryConfig {
+                max_attempts: config.reply_max_attempts.max(1),
+                min_timeout: REPLY_ACK_MIN_WAIT,
+                max_timeout: REPLY_ACK_MAX_WAIT,
+            }))),
         })
     }
 
@@ -276,6 +369,7 @@ impl Plugin for MeshTransport {
         let notif_state = Arc::clone(&self.state);
         let notif_cmd_tx = self.cmd_tx.clone();
         let notif_host = Arc::clone(&self.host);
+        let notif_tracker = Arc::clone(&self.send_tracker);
         let mut notif_shutdown_rx = self.shutdown_tx.subscribe();
         tokio::spawn(async move {
             loop {
@@ -288,6 +382,7 @@ impl Plugin for MeshTransport {
                                     &notif_host,
                                     &notif_cmd_tx,
                                     &notif_state,
+                                    &notif_tracker,
                                     flood_after_send,
                                 )
                                 .await;
@@ -304,6 +399,7 @@ impl Plugin for MeshTransport {
         });
 
         let draining = Arc::clone(&self.draining);
+        let send_tracker = Arc::clone(&self.send_tracker);
         tokio::spawn(event_loop(
             client,
             host,
@@ -315,6 +411,7 @@ impl Plugin for MeshTransport {
             ttl_days,
             draining,
             flood_after_send,
+            send_tracker,
             key_rx,
         ));
 
@@ -365,16 +462,7 @@ impl TransportEngine for MeshTransport {
         };
 
         let text = render_notification(&payload);
-        self.cmd_tx
-            .send(OutboundFrame::SendTxtMsg {
-                txt_type: TXT_TYPE_PLAIN,
-                attempt: 0,
-                timestamp: now_unix_secs(),
-                pubkey_prefix,
-                text,
-            })
-            .await
-            .map_err(|_| TransportError::ConnectionLost("companion client closed".into()))?;
+        enqueue_text(&self.send_tracker, &self.cmd_tx, pubkey_prefix, text, 1);
 
         if self.flood_after_send {
             let full_pubkey = self
@@ -402,6 +490,7 @@ async fn push_domain_notification(
     host: &Arc<dyn Host>,
     cmd_tx: &mpsc::Sender<OutboundFrame>,
     state: &Arc<Mutex<SessionState>>,
+    send_tracker: &Arc<Mutex<SendTracker>>,
     flood_after_send: bool,
 ) {
     let sessions: Vec<SessionId> = state
@@ -428,17 +517,14 @@ async fn push_domain_notification(
                     .get(&sid)
                     .copied();
                 if let Some(prefix) = prefix {
-                    let _ = cmd_tx
-                        .send(OutboundFrame::SendTxtMsg {
-                            txt_type: TXT_TYPE_PLAIN,
-                            attempt: 0,
-                            timestamp: now_unix_secs(),
-                            pubkey_prefix: prefix,
-                            text: "Your account has been validated. \
-                                   You now have full access. Type 'H'."
-                                .to_owned(),
-                        })
-                        .await;
+                    enqueue_text(
+                        send_tracker,
+                        cmd_tx,
+                        prefix,
+                        "Your account has been validated. You now have full access. Type 'H'."
+                            .to_owned(),
+                        1,
+                    );
                     if flood_after_send {
                         let pubkey = state
                             .lock()
@@ -466,18 +552,16 @@ async fn push_domain_notification(
                     .get(&sid)
                     .copied();
                 if let Some(prefix) = prefix {
-                    let _ = cmd_tx
-                        .send(OutboundFrame::SendTxtMsg {
-                            txt_type: TXT_TYPE_PLAIN,
-                            attempt: 0,
-                            timestamp: now_unix_secs(),
-                            pubkey_prefix: prefix,
-                            text: format!(
-                                "New registration: {} — type PENDING to review.",
-                                user.as_str()
-                            ),
-                        })
-                        .await;
+                    enqueue_text(
+                        send_tracker,
+                        cmd_tx,
+                        prefix,
+                        format!(
+                            "New registration: {} — type PENDING to review.",
+                            user.as_str()
+                        ),
+                        1,
+                    );
                     if flood_after_send {
                         let pubkey = state
                             .lock()
@@ -526,10 +610,15 @@ async fn event_loop(
     node_credential_ttl_days: u32,
     draining: Arc<AtomicBool>,
     flood_after_send: bool,
+    send_tracker: Arc<Mutex<SendTracker>>,
     mut key_rx: tokio::sync::mpsc::Receiver<bbs_plugin_api::MeshKeyRequest>,
 ) {
     // Pending one-shot key operation. At most one at a time.
     let mut pending_key_op: Option<PendingKeyOp> = None;
+
+    // Periodically retransmit replies that timed out awaiting an end-to-end ACK.
+    let mut retry_tick = tokio::time::interval(RETRY_TICK);
+    retry_tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
 
     loop {
         tokio::select! {
@@ -706,10 +795,13 @@ async fn event_loop(
                             _ => false,
                         };
                         if !consumed {
-                            handle_frame(frame, &host, &cmd_tx, &state, command_prefix, &welcome_message, node_credential_ttl_days, &draining, flood_after_send).await;
+                            handle_frame(frame, &host, &cmd_tx, &state, command_prefix, &welcome_message, node_credential_ttl_days, &draining, flood_after_send, &send_tracker).await;
                         }
                     }
                 }
+            }
+            _ = retry_tick.tick() => {
+                retransmit_due_replies(&cmd_tx, &state, &send_tracker, flood_after_send);
             }
             Some(req) = key_rx.recv() => {
                 use bbs_plugin_api::MeshKeyRequest;
@@ -769,6 +861,7 @@ async fn handle_frame(
     node_credential_ttl_days: u32,
     draining: &Arc<AtomicBool>,
     flood_after_send: bool,
+    send_tracker: &Arc<Mutex<SendTracker>>,
 ) {
     use meshcore_companion::frame::InboundFrame;
 
@@ -819,6 +912,7 @@ async fn handle_frame(
                 welcome_message,
                 node_credential_ttl_days,
                 flood_after_send,
+                send_tracker,
             )
             .await;
         }
@@ -927,6 +1021,30 @@ async fn handle_frame(
                     timeout_ms = result.timeout_ms,
                     "mesh: message accepted by device"
                 );
+            }
+            // Correlate with the oldest tracked send (RESP_CODE_SENT is the
+            // in-order reply to each CMD_SEND_TXT_MSG). A CRC of 0 (send failed)
+            // pops the record without scheduling an ACK wait, so it isn't retried
+            // by the timeout path.
+            let outcome = send_tracker
+                .lock()
+                .expect("send tracker mutex poisoned")
+                .on_sent(result.expected_ack, result.timeout_ms, Instant::now());
+            if matches!(outcome, SentOutcome::Spurious) {
+                debug!("mesh: Sent frame with no tracked send (retries off or already resolved)");
+            }
+        }
+
+        // ── End-to-end delivery confirmation ──────────────────────────────────
+        // PUSH_CODE_SEND_CONFIRMED (0x82): the destination acknowledged receipt.
+        // Clear the pending retransmission for this message.
+        InboundFrame::SendConfirmed { crc } => {
+            if send_tracker
+                .lock()
+                .expect("send tracker mutex poisoned")
+                .on_confirmed(crc)
+            {
+                debug!(crc, "mesh: reply delivery confirmed");
             }
         }
 
@@ -1056,6 +1174,7 @@ async fn dispatch_message(
     welcome_message: &str,
     node_credential_ttl_days: u32,
     flood_after_send: bool,
+    send_tracker: &Arc<Mutex<SendTracker>>,
 ) {
     // ── Get or create a session for this node ─────────────────────────────────
     let Some((session, is_new)) = get_or_create_session(sender_prefix, host, state).await else {
@@ -1353,23 +1472,7 @@ async fn dispatch_message(
             "mesh: sending reply to node"
         );
 
-        let reply_sent = cmd_tx
-            .send(OutboundFrame::SendTxtMsg {
-                txt_type: TXT_TYPE_PLAIN,
-                attempt: 0,
-                timestamp: now_unix_secs(),
-                pubkey_prefix: sender_prefix,
-                text: reply_text,
-            })
-            .await
-            .is_ok();
-        if !reply_sent {
-            warn!(
-                ?session,
-                "mesh: could not enqueue reply — cmd channel closed"
-            );
-            break;
-        }
+        enqueue_text(send_tracker, cmd_tx, sender_prefix, reply_text, 1);
         // Reset path only after the last frame so intermediate frames travel
         // the same (possibly direct) route as the first.
         if is_last && flood_after_send {

--- a/crates/bbs-mesh/tests/transport.rs
+++ b/crates/bbs-mesh/tests/transport.rs
@@ -71,6 +71,23 @@ fn contact_msg_frame(sender_prefix: [u8; 6], text: &str) -> Vec<u8> {
     radio_frame(&payload)
 }
 
+/// RESP_CODE_SENT: the device's reply to a send. `send_type` 0=failed, 1=flood,
+/// 2=direct; `crc` is the expected-ack identifier; `timeout_ms` the delivery hint.
+fn sent_frame(send_type: u8, crc: u32, timeout_ms: u32) -> Vec<u8> {
+    let mut payload = vec![RESP_CODE_SENT, send_type];
+    payload.extend_from_slice(&crc.to_le_bytes());
+    payload.extend_from_slice(&timeout_ms.to_le_bytes());
+    radio_frame(&payload)
+}
+
+/// PUSH_CODE_SEND_CONFIRMED: destination acknowledged receipt of `crc`.
+fn send_confirmed_frame(crc: u32) -> Vec<u8> {
+    let mut payload = vec![PUSH_CODE_SEND_CONFIRMED];
+    payload.extend_from_slice(&crc.to_le_bytes());
+    payload.extend_from_slice(&0u32.to_le_bytes());
+    radio_frame(&payload)
+}
+
 // ── Test harness ──────────────────────────────────────────────────────────────
 
 struct Bridge {
@@ -167,6 +184,17 @@ impl Bridge {
         assert_eq!(header[0], FRAME_INBOUND_PREFIX);
         let len = u16::from_le_bytes([header[1], header[2]]) as usize;
         self.recv_n(len).await
+    }
+
+    /// Read outbound frames until a text send (`CMD_SEND_TXT_MSG`) appears,
+    /// skipping path resets and other bookkeeping frames. Returns its payload.
+    async fn read_text_send(&mut self) -> Vec<u8> {
+        loop {
+            let cmd = self.read_command().await;
+            if cmd[0] == CMD_SEND_TXT_MSG {
+                return cmd;
+            }
+        }
     }
 }
 
@@ -540,6 +568,75 @@ async fn unsupported_app_start_with_successful_drain_processes_messages() {
         .await
         .expect("timed out waiting for reply");
     assert_eq!(cmd_payload[0], CMD_SEND_TXT_MSG);
+
+    transport.stop().await.unwrap();
+}
+
+/// A reply that is accepted by the device (RESP_CODE_SENT with a CRC) but never
+/// confirmed (no PUSH_CODE_SEND_CONFIRMED) is retransmitted after the ack-wait
+/// floor — this is the core reply-reliability fix for the lossy return path.
+#[tokio::test]
+async fn unacked_reply_is_retransmitted() {
+    let host = Arc::new(MockHost::new());
+    host.set_default_response(Response::Text("hi there".to_owned()));
+
+    let (transport, mut bridge) = make_transport(Arc::clone(&host), None).await;
+    bridge.complete_handshake("Node").await;
+
+    let sender = [0x55u8; 6];
+    bridge.send(&contact_msg_frame(sender, "help")).await;
+
+    // First transmission of the reply (wire attempt 0).
+    let first = tokio::time::timeout(Duration::from_secs(2), bridge.read_text_send())
+        .await
+        .expect("first reply not sent");
+    assert_eq!(first[0], CMD_SEND_TXT_MSG);
+    assert_eq!(first[2], 0, "first send is attempt 0");
+    assert_eq!(std::str::from_utf8(&first[13..]).unwrap(), "hi there");
+
+    // Device accepts it (assigns CRC) but the destination never acknowledges.
+    bridge.send(&sent_frame(2, 0xDEAD_BEEF, 100)).await;
+
+    // After the ack-wait floor the BBS retransmits the same text (wire attempt 1).
+    let retry = tokio::time::timeout(Duration::from_secs(8), bridge.read_text_send())
+        .await
+        .expect("reply was not retransmitted");
+    assert_eq!(retry[0], CMD_SEND_TXT_MSG);
+    assert_eq!(std::str::from_utf8(&retry[13..]).unwrap(), "hi there");
+    assert_eq!(retry[2], 1, "retransmission is attempt 1 (0-based wire)");
+
+    transport.stop().await.unwrap();
+}
+
+/// A reply that is confirmed delivered (PUSH_CODE_SEND_CONFIRMED) is NOT
+/// retransmitted — delivery is at-least-once, not blindly duplicated.
+#[tokio::test]
+async fn confirmed_reply_is_not_retransmitted() {
+    let host = Arc::new(MockHost::new());
+    host.set_default_response(Response::Text("hi there".to_owned()));
+
+    let (transport, mut bridge) = make_transport(Arc::clone(&host), None).await;
+    bridge.complete_handshake("Node").await;
+
+    let sender = [0x56u8; 6];
+    bridge.send(&contact_msg_frame(sender, "help")).await;
+
+    let first = tokio::time::timeout(Duration::from_secs(2), bridge.read_text_send())
+        .await
+        .expect("first reply not sent");
+    assert_eq!(first[0], CMD_SEND_TXT_MSG);
+
+    // Device accepts AND the destination confirms delivery.
+    let crc = 0xAABB_CCDD;
+    bridge.send(&sent_frame(2, crc, 100)).await;
+    bridge.send(&send_confirmed_frame(crc)).await;
+
+    // Past the ack-wait floor there must be no second text send.
+    let retry = tokio::time::timeout(Duration::from_secs(6), bridge.read_text_send()).await;
+    assert!(
+        retry.is_err(),
+        "confirmed reply must not be retransmitted (got a duplicate send)"
+    );
 
     transport.stop().await.unwrap();
 }

--- a/crates/bbs-mesh/tests/transport.rs
+++ b/crates/bbs-mesh/tests/transport.rs
@@ -334,25 +334,25 @@ async fn identical_workflow_replies_after_prompt_both_reach_host() {
     transport.stop().await.unwrap();
 }
 
-/// Issue #129: after the registration prompt, the `-` display-name shortcut must
-/// reach the host as a `WorkflowReply` — it must NOT be parsed as a standalone
-/// command (which would drop the user out of registration). This is the mesh
-/// parse-layer half of the `-`-uses-username behaviour (the host half is covered
-/// by `register_display_name_dash_sentinel_uses_username` in bbs-core).
+/// After a prompt, the next message must reach the host as a `WorkflowReply` —
+/// it must NOT be re-parsed as a standalone command at the transport layer. The
+/// host owns the decision of how to interpret a reply (including whether a
+/// REGISTER/LOGIN reply should escape the workflow); the transport must deliver
+/// the text verbatim so that decision is possible.
 #[tokio::test]
-async fn dash_shortcut_after_prompt_is_workflow_reply() {
+async fn reply_after_prompt_reaches_host_as_workflow_reply() {
     let host = Arc::new(MockHost::new());
     host.set_response_for(
         |cmd| matches!(cmd, Command::Register { .. }),
         Response::Prompt {
-            text: "Choose a display name (or send - to use your username):".to_owned(),
-            hide_input: false,
+            text: "Registering 'qatester1'. Choose a password (min 8 characters):".to_owned(),
+            hide_input: true,
         },
     );
     host.set_response_for(
         |cmd| matches!(cmd, Command::WorkflowReply { .. }),
         Response::Prompt {
-            text: "Choose a password (min 8 characters):".to_owned(),
+            text: "Confirm the password for 'qatester1':".to_owned(),
             hide_input: true,
         },
     );
@@ -365,15 +365,19 @@ async fn dash_shortcut_after_prompt_is_workflow_reply() {
         .send(&contact_msg_frame(sender, "register qatester1"))
         .await;
     tokio::time::sleep(Duration::from_millis(50)).await;
-    bridge.send(&contact_msg_frame(sender, "-")).await;
+    // A reply that happens to look like a command keyword must still be delivered
+    // as a WorkflowReply (the host decides whether it escapes the workflow).
+    bridge
+        .send(&contact_msg_frame(sender, "register qatester2"))
+        .await;
     tokio::time::sleep(Duration::from_millis(50)).await;
 
     let received = host.commands_received();
     assert!(
-        received
-            .iter()
-            .any(|(_, c)| matches!(c, Command::WorkflowReply { reply } if reply == "-")),
-        "`-` after the registration prompt must reach the host as a WorkflowReply, got: {:?}",
+        received.iter().any(
+            |(_, c)| matches!(c, Command::WorkflowReply { reply } if reply == "register qatester2")
+        ),
+        "input after a prompt must reach the host as a WorkflowReply, got: {:?}",
         received.iter().map(|(_, c)| c).collect::<Vec<_>>()
     );
 

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -259,6 +259,23 @@ no-silent-overrides rule.
 | `connection_type`  | enum   | `"serial"` | no       | How to reach the radio: `"serial"`, `"tcp"`, or `"hat"`. See [ADR-0013](adr/0013-native-serial-transport-for-usb-devices.md). |
 | `command_prefix`   | string | `""`       | no       | Optional single-character prefix for BBS commands (e.g., `"!"`). Empty string means no prefix - every message is treated as a command. |
 
+### Reply delivery
+
+On a multi-hop mesh the return path is lossy, so a reply can be dropped even
+though the BBS processed the command. These keys make replies more likely to
+arrive.
+
+| Key                 | Type    | Default | Required | Description                                     |
+|---------------------|---------|---------|----------|-------------------------------------------------|
+| `flood_after_send`  | bool    | `true`  | no       | Reset the node's stored path after each send so the next message floods (hop-by-hop) rather than using a possibly-stale direct route. |
+| `reply_max_attempts`| integer | `3`     | no       | Total transmissions per reply, including the first. When > 1, the transport tracks each reply's delivery via the device's send-result CRC and delivery confirmation and retransmits if no confirmation arrives in time. `1` disables retransmission. |
+
+> **At-least-once delivery.** With `reply_max_attempts > 1`, a delivery
+> confirmation lost on the return path can cause the BBS to retransmit a reply
+> the user already received — a duplicate message is preferable to silence, and
+> inbound commands are deduplicated separately. The per-attempt wait is the
+> device's own timeout hint, clamped to the 4–30 s range.
+
 ### Serial mode (`connection_type = "serial"`)
 
 Used for USB-native MeshCore devices (Heltec V3, T-Beam, etc.) that

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -78,26 +78,29 @@ REGISTER alice
 - Case-insensitive at login (stored exactly as typed)
 - The names `bbs` and `system` are reserved and cannot be registered
 
-The BBS will walk you through three prompts:
+The BBS then prompts for a password and a confirmation — two short steps,
+each naming the account so you always know where you are:
 
 ```
-Choose a display name (or send - to use your username):
-> Alice Wonderland
-
-Choose a password (min 8 characters):
+Registering 'alice'. Choose a password (min 8 characters):
 > ••••••••
 
-Confirm your password:
+Confirm the password for 'alice':
 > ••••••••
 ```
 
-**Display name** is optional. It is the name shown alongside your messages.
-Send `-` to use your username as-is (on a mesh radio you can't send an empty
-message; on the CLI/web you can also just press Enter). You can change it later
-with `PROFILE`.
+**Display name.** New accounts use your username as the display name. Set a
+separate display name at any time with `PROFILE` (see [section 12](#12-your-profile)).
+Registration deliberately has no display-name step: on a mesh radio a lost
+prompt could otherwise capture the wrong message as your name (or password).
 
 **Password** must be at least 8 characters. It is stored as a hashed value —
 the BBS never stores your password in plain text.
+
+> **Retyping a command mid-registration is safe.** If a prompt is lost over the
+> air and you resend `REGISTER <name>` (or `LOGIN <name>`), the BBS restarts that
+> flow instead of treating your command as a password. To abort entirely, send
+> `CANCEL`.
 
 After confirmation you are immediately logged in:
 
@@ -125,7 +128,7 @@ LOGIN alice
 You'll be prompted for your password (input is hidden on supporting clients):
 
 ```
-Enter your password:
+Enter the password for 'alice':
 > ••••••••
 ```
 


### PR DESCRIPTION
Fixes the two failure modes behind the confused MeshCore registration report: an account created with the wrong details (`username=tcf`, `display name="REGISTER TCM1"`), and replies that never arrived.

**Do not merge yet** — this is up for code review + QA. A standalone QA test plan / reviewer validation guide accompanies this PR (see the "Validation" section below for where it lives).

## Root causes

1. **Workflow swallowed everything.** Mid-workflow, the transport collapses any message to `WorkflowReply`; the host then took it literally. A lost prompt → the user retyped `REGISTER …` → it became the *display name*, and subsequent chat became *password* attempts.
2. **Replies were fire-and-forget.** The host wrote `CMD_SEND_TXT_MSG` and ignored the device's delivery signals, so a reply (or its ACK) dropped on the lossy return path was simply lost — the BBS looked dead even though it processed the command.

## Changes (three reviewable commits)

**1. `fix(host)` — registration robustness**
- A re-sent `REGISTER`/`LOGIN` mid-flow now *restarts* that flow instead of being captured as a field value. Scoped to those two commands so a real password is never reinterpreted; `CANCEL`/`STOP` still abort.
- Registration drops the display-name prompt entirely (defaults to username, set later via `PROFILE`) — removes a lossy round-trip and the exact step that captured `REGISTER TCM1`.
- Prompts are self-describing (`Registering 'tcf'. Choose a password…`, `Enter the password for 'tcf':`).

**2. `fix(mesh)` — reply retransmission**
- New `send_tracker` module: a pure, unit-tested state machine that correlates each send to the device's `RESP_CODE_SENT` CRC (FIFO, in send order), awaits `PUSH_CODE_SEND_CONFIRMED`, and retransmits on timeout up to a cap.
- All four text-send sites funnel through one `enqueue_text` helper (atomic record + `try_send`, no lock held across `await`) so the FIFO matches wire order across tasks.
- Event-loop retry tick resends due replies (resetting the path first) and gives up after the cap; `Sent`/`SendConfirmed` are now handled.
- New `mesh.reply_max_attempts` (default 3; `1` disables). Ack-wait = device hint clamped to [4s, 30s].

**3. `docs`** — USER_GUIDE (new registration/login flow) + CONFIG (reply-delivery knobs).

## Behaviour changes to review
- **No display-name step at registration on any transport** (CLI/web included). Deliberate and isolated in commit 1 — easy to make mesh-only or revert if the team prefers. This supersedes the registration half of #105/#129 (the `-` display-name sentinel); `PROFILE`'s `-`-to-clear is unchanged.
- **At-least-once replies**: a lost delivery-confirmation can yield a duplicate reply (preferred over silence; inbound commands are deduplicated separately).

## Tests
`cargo fmt`/`clippy -D warnings`/`test --workspace` all green on WSL (Linux, cargo 1.96). New: `send_tracker` unit tests (correlation, timeout, cap, give-up, clamp, spurious), host tests (`register_skips_display_name_step`, `register_command_escapes_active_registration`, `login_register_escape_each_other`, `auth_escape`), and two transport integration tests (unacked reply retransmitted; confirmed reply not retransmitted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)