### PR TITLE
docs: fix WORKFLOWS registration flow + example mesh reply knobs

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -201,6 +201,14 @@
 # every direct message is treated as a command.
 # command_prefix = "!"
 
+# Reply delivery on lossy multi-hop paths. See docs/CONFIG.md §[plugins.mesh].
+# Reset the node's path after each send so the next message floods (more
+# reliable than a possibly-stale direct route).
+# flood_after_send = true
+# Total transmissions per reply, including the first. >1 retransmits a reply
+# the destination never confirms; 1 disables retransmission.
+# reply_max_attempts = 3
+
 
 # ─── Plugin: Meshtastic transport ─────────────────────────────────
 #

--- a/docs/WORKFLOWS.md
+++ b/docs/WORKFLOWS.md
@@ -102,11 +102,20 @@ workflow state from carrying across rooms.
 
 | Stage | Prompt shown | Expected reply |
 |---|---|---|
-| `DisplayName` | "Enter your display name (or . to skip):" | Any text or `.` |
-| `Password { display_name }` | "Choose a password (min 8 chars):" | Password text |
-| `Confirm { display_name, password }` | "Confirm password:" | Same password again |
+| `Password` | "Registering '\<user>'. Choose a password (min 8 characters):" | Password text |
+| `Confirm { password }` | "Confirm the password for '\<user>':" | Same password again |
+
+There is **no display-name step**: a new account defaults its display name to the
+username (the user sets one later via `PROFILE`). Dropping the prompt removes a
+lossy round-trip on mesh and the failure mode where a re-sent command was
+captured as the display name.
 
 On success: account created, user is logged in, workflow set to `None`.
+
+**Command escape:** while this workflow (or [`Workflow::Login`](#workflowlogin))
+is active, a re-sent `REGISTER <name>` / `LOGIN <name>` *restarts* that flow
+instead of being captured as a field value (e.g. a password). Limited to those
+two commands so a real password is never reinterpreted; `CANCEL` / `STOP` abort.
 
 ---
 
@@ -117,7 +126,7 @@ On success: account created, user is logged in, workflow set to `None`.
 
 | Stage | Prompt shown | Expected reply |
 |---|---|---|
-| *(single stage)* | "Password:" | Password text |
+| *(single stage)* | "Enter the password for '\<user>':" | Password text |
 
 Up to 3 failed attempts; after the third the workflow exits with an error.
 


### PR DESCRIPTION
Follow-up to [#145](https://github.com/Mesh-America/supply-drop-bbs/pull/145) — that PR updated USER_GUIDE and CONFIG but left two spots stale.

- **`docs/WORKFLOWS.md`** still described the **removed** `DisplayName` registration stage (and `display_name` fields on `Password`/`Confirm`), plus the old `"Password:"` login prompt. Now reflects the two-stage Password → Confirm flow, the self-describing prompts, and the new REGISTER/LOGIN command-escape.
- **`config.example.toml`** `[plugins.mesh]` now lists the reply-delivery knobs (`flood_after_send`, `reply_max_attempts`).

Docs-only; VitePress site builds clean (no dead links). Left unmerged for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)