### PR TITLE
feat(auth): one-shot REGISTER/LOGIN <user> <password> (prototype)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -296,6 +296,7 @@ dependencies = [
  "bbs-plugin-api",
  "meshcore-companion",
  "serde",
+ "tempfile",
  "thiserror 1.0.69",
  "tokio",
  "tracing",

--- a/crates/bbs-core/src/host.rs
+++ b/crates/bbs-core/src/host.rs
@@ -30,7 +30,7 @@ use bbs_plugin_api::host::Host;
 use bbs_plugin_api::{
     AdminAccessPolicy, AdminBackupRecord, AdminMessageRecord, AdminRoomSummary, AdminSessionInfo,
     AdminStats, AdminUserInfo, Command, DomainEvent, HostError, MessageRecipient, PermissionCtx,
-    PermissionLevel, Response, SessionId, Username,
+    PermissionLevel, Response, Secret, SessionId, Username,
 };
 use tokio::sync::{broadcast, RwLock};
 use tracing::{debug, info, warn};
@@ -1704,11 +1704,24 @@ impl BbsHost {
         }
     }
 
-    /// Record a failed login for `username` and return the backoff delay (secs)
-    /// the caller should sleep before responding. The counter is global per
-    /// username so parallel sessions can't bypass the delay; entries reset after
-    /// 10 minutes idle and the map is hard-capped. Shared by the interactive
-    /// login workflow and the one-shot login path.
+    /// If `username` is within its login-backoff window, return the seconds
+    /// remaining; otherwise `None`. Lets callers reject immediately instead of
+    /// sleeping on the hot path (see `handle_login_oneshot`). Reads the same
+    /// counter `record_login_failure` writes.
+    async fn check_login_throttle(&self, username: &str) -> Option<u64> {
+        let map = self.login_failures.lock().await;
+        let (count, last) = map.get(username)?;
+        // Same backoff curve as record_login_failure: 2,4,8,16,30 s (capped).
+        let backoff = u64::min(2u64.saturating_pow(*count), 30);
+        let elapsed = last.elapsed().as_secs();
+        (elapsed < backoff).then_some(backoff - elapsed)
+    }
+
+    /// Record a failed login for `username` and return the resulting backoff
+    /// window (secs). The counter is global per username so parallel sessions
+    /// can't bypass it; entries reset after 10 minutes idle and the map is
+    /// hard-capped. Shared by the interactive login workflow and the one-shot
+    /// login path (see `check_login_throttle`).
     async fn record_login_failure(&self, username: &str) -> u64 {
         let mut map = self.login_failures.lock().await;
         // Evict stale entries before inserting to bound map size — keeps memory
@@ -1762,6 +1775,8 @@ impl BbsHost {
         let user_id = match UserStore::create(&self.db, username, None, initial_level, now).await {
             Ok(id) => id,
             Err(crate::db::StoreError::Conflict(_)) => {
+                // Clears the Register workflow on the interactive Confirm path;
+                // a no-op on the one-shot path (no workflow is active there).
                 self.clear_workflow(session).await;
                 return Ok(Response::Error(format!(
                     "'{username}' was just taken. Try: register <different_username>"
@@ -1842,7 +1857,7 @@ impl BbsHost {
         &self,
         session: SessionId,
         raw_username: String,
-        password: String,
+        password: Secret,
     ) -> Result<Response, HostError> {
         {
             let sessions = self.sessions.read().await;
@@ -1867,7 +1882,7 @@ impl BbsHost {
         // Password rule mirrors the interactive flow (min 8). No confirmation
         // step: the single message can't be typo-confirmed, and re-prompting
         // would reintroduce the round-trip this path exists to avoid.
-        if password.chars().count() < 8 {
+        if password.expose().chars().count() < 8 {
             return Ok(Response::Error(
                 "Password must be at least 8 characters. Not registered.".into(),
             ));
@@ -1883,7 +1898,7 @@ impl BbsHost {
             )));
         }
 
-        self.create_user_and_login(session, &username, &password)
+        self.create_user_and_login(session, &username, password.expose())
             .await
     }
 
@@ -1895,7 +1910,7 @@ impl BbsHost {
         &self,
         session: SessionId,
         username: Username,
-        password: String,
+        password: Secret,
     ) -> Result<Response, HostError> {
         {
             let sessions = self.sessions.read().await;
@@ -1913,6 +1928,17 @@ impl BbsHost {
             }
         }
 
+        // Throttle BEFORE verifying, and reject *immediately* rather than sleeping
+        // on the hot path: the mesh event loop awaits process_command serially, so
+        // a blocking sleep here would stall all traffic on the node — and one-shot
+        // login is a single stateless message, trivially scripted. The backoff
+        // window is shared with the interactive flow via `record_login_failure`.
+        if let Some(wait) = self.check_login_throttle(username.as_str()).await {
+            return Ok(Response::Error(format!(
+                "Too many login attempts. Try again in {wait}s."
+            )));
+        }
+
         let user = self
             .db
             .get_by_username(&username)
@@ -1927,14 +1953,13 @@ impl BbsHost {
         let ok = self
             .db
             .credentials()
-            .verify_password(user.id, &password, Timestamp::now())
+            .verify_password(user.id, password.expose(), Timestamp::now())
             .await
             .map_err(|e| HostError::Storage(format!("verify password: {e}")))?;
 
         if !ok {
-            let delay_secs = self.record_login_failure(username.as_str()).await;
-            warn!(%session, %username, delay_secs, "one-shot login failed: wrong password");
-            tokio::time::sleep(std::time::Duration::from_secs(delay_secs)).await;
+            let backoff = self.record_login_failure(username.as_str()).await;
+            warn!(%session, %username, backoff, "one-shot login failed: wrong password");
             return Ok(Response::Error("Login failed.".into()));
         }
 
@@ -2072,14 +2097,20 @@ impl BbsHost {
                 Some(AuthEscape::Register { username, password }) => {
                     self.clear_workflow(session).await;
                     return match password {
-                        Some(pw) => self.handle_register_oneshot(session, username, pw).await,
+                        Some(pw) => {
+                            self.handle_register_oneshot(session, username, pw.into())
+                                .await
+                        }
                         None => self.handle_register(session, username).await,
                     };
                 }
                 Some(AuthEscape::Login { username, password }) => {
                     self.clear_workflow(session).await;
                     return match password {
-                        Some(pw) => self.handle_login_oneshot(session, username, pw).await,
+                        Some(pw) => {
+                            self.handle_login_oneshot(session, username, pw.into())
+                                .await
+                        }
                         None => self.handle_login(session, username).await,
                     };
                 }
@@ -6276,6 +6307,35 @@ mod tests {
             ctx.username(),
             None,
             "must not be authenticated after a bad password"
+        );
+    }
+
+    /// A failed one-shot login must NOT sleep on the event loop; instead the next
+    /// rapid attempt is rejected immediately by the shared backoff throttle. This
+    /// is what stops one-shot login from being a scriptable event-loop-stall DoS.
+    #[tokio::test]
+    async fn login_oneshot_throttles_rapid_failures() {
+        let (host, _db) = make_host().await;
+        let s0 = host.create_session("test").await.unwrap();
+        do_register(&host, s0, "alice", "s3cr3t!!").await;
+
+        let sid = host.create_session("test").await.unwrap();
+        let bad = |pw: &str| Command::LoginOneShot {
+            username: Username::new("alice").unwrap(),
+            password: pw.into(),
+        };
+
+        // First wrong attempt: generic failure, records a backoff window.
+        let r1 = host.process_command(sid, bad("wrongone")).await.unwrap();
+        assert!(
+            matches!(&r1, Response::Error(e) if e.contains("Login failed")),
+            "first failure should be a generic Login failed, got: {r1:?}"
+        );
+        // Immediate second attempt is throttled (rejected fast, not slept on).
+        let r2 = host.process_command(sid, bad("wrongtwo")).await.unwrap();
+        assert!(
+            matches!(&r2, Response::Error(e) if e.to_lowercase().contains("too many")),
+            "rapid second attempt should be throttled, got: {r2:?}"
         );
     }
 

--- a/crates/bbs-core/src/host.rs
+++ b/crates/bbs-core/src/host.rs
@@ -131,8 +131,15 @@ enum RegisterStage {
 /// it can restart that flow instead of being captured as a field value.
 #[derive(Debug, PartialEq, Eq)]
 enum AuthEscape {
-    Register(String),
-    Login(Username),
+    Register {
+        username: String,
+        /// One-shot password if the user typed `REGISTER <user> <password>`.
+        password: Option<String>,
+    },
+    Login {
+        username: Username,
+        password: Option<String>,
+    },
 }
 
 /// Detect a REGISTER/LOGIN command in raw workflow-reply text.
@@ -143,7 +150,8 @@ enum AuthEscape {
 /// account. Other words are intentionally NOT treated as commands here, because
 /// they may be a legitimate password. A keyword with no argument is left to the
 /// workflow (e.g. a bare "register" is too short to be a password and simply
-/// re-prompts). Matching is case-insensitive.
+/// re-prompts). A trailing word after the username is taken as a one-shot
+/// password. Matching is case-insensitive.
 fn auth_escape(reply: &str) -> Option<AuthEscape> {
     let trimmed = reply.trim();
     let (word, rest) = match trimmed.split_once(char::is_whitespace) {
@@ -153,9 +161,23 @@ fn auth_escape(reply: &str) -> Option<AuthEscape> {
     if rest.is_empty() {
         return None;
     }
+    // Split the remainder into the username and an optional one-shot password.
+    let (name, password) = match rest.split_once(char::is_whitespace) {
+        Some((n, p)) => {
+            let p = p.trim();
+            (n, (!p.is_empty()).then(|| p.to_owned()))
+        }
+        None => (rest, None),
+    };
     match word.to_ascii_lowercase().as_str() {
-        "register" => Some(AuthEscape::Register(rest.to_owned())),
-        "login" => Username::new(rest).ok().map(AuthEscape::Login),
+        "register" => Some(AuthEscape::Register {
+            username: name.to_owned(),
+            password,
+        }),
+        "login" => Username::new(name).ok().map(|u| AuthEscape::Login {
+            username: u,
+            password,
+        }),
         _ => None,
     }
 }
@@ -437,6 +459,13 @@ impl Host for BbsHost {
 
             Command::Register { username } => self.handle_register(session, username).await,
             Command::Login { username } => self.handle_login(session, username).await,
+            Command::RegisterOneShot { username, password } => {
+                self.handle_register_oneshot(session, username, password)
+                    .await
+            }
+            Command::LoginOneShot { username, password } => {
+                self.handle_login_oneshot(session, username, password).await
+            }
             Command::WorkflowReply { reply } => self.handle_workflow_reply(session, reply).await,
             Command::Cancel => self.handle_cancel(session).await,
 
@@ -1668,6 +1697,275 @@ impl BbsHost {
         }
     }
 
+    /// Record a failed login for `username` and return the backoff delay (secs)
+    /// the caller should sleep before responding. The counter is global per
+    /// username so parallel sessions can't bypass the delay; entries reset after
+    /// 10 minutes idle and the map is hard-capped. Shared by the interactive
+    /// login workflow and the one-shot login path.
+    async fn record_login_failure(&self, username: &str) -> u64 {
+        let mut map = self.login_failures.lock().await;
+        // Evict stale entries before inserting to bound map size — keeps memory
+        // O(active_usernames). Hard cap prevents unbounded growth even if
+        // eviction somehow misses entries.
+        const MAX_FAILURE_ENTRIES: usize = 1_000;
+        if map.len() >= MAX_FAILURE_ENTRIES {
+            map.retain(|_, (_, t)| t.elapsed().as_secs() <= 600);
+            if map.len() >= MAX_FAILURE_ENTRIES {
+                map.clear();
+            }
+        }
+        let entry = map
+            .entry(username.to_owned())
+            .or_insert((0, Instant::now()));
+        // Stale entries (>10 min) reset the counter.
+        if entry.1.elapsed().as_secs() > 600 {
+            *entry = (0, Instant::now());
+        }
+        entry.0 += 1;
+        entry.1 = Instant::now();
+        let failures = entry.0;
+        // Exponential backoff: 2, 4, 8, 16, 30 s (capped).
+        u64::min(2u64.saturating_pow(failures), 30)
+    }
+
+    /// Create `username` with `password`, attach the new account to `session`,
+    /// log them in, and fire the registration side-effects (first-user → Sysop,
+    /// sysop notification DMs). Shared by the interactive Confirm step and the
+    /// one-shot `REGISTER <user> <password>` path. The caller must have already
+    /// validated the username and confirmed it is currently free.
+    async fn create_user_and_login(
+        &self,
+        session: SessionId,
+        username: &Username,
+        password: &str,
+    ) -> Result<Response, HostError> {
+        let now = Timestamp::now();
+        // Promote the very first registrant to Sysop so the system isn't stuck
+        // with no one able to validate new users.
+        let is_first = UserStore::list(&self.db, None, 1, 0)
+            .await
+            .map_err(|e| HostError::Storage(format!("list users: {e}")))?
+            .is_empty();
+        let initial_level = if is_first {
+            PermissionLevel::Sysop
+        } else {
+            PermissionLevel::Unvalidated
+        };
+        // Display name defaults to the username (stored as NULL); set via PROFILE.
+        let user_id = match UserStore::create(&self.db, username, None, initial_level, now).await {
+            Ok(id) => id,
+            Err(crate::db::StoreError::Conflict(_)) => {
+                self.clear_workflow(session).await;
+                return Ok(Response::Error(format!(
+                    "'{username}' was just taken. Try: register <different_username>"
+                )));
+            }
+            Err(e) => return Err(HostError::Storage(format!("create user: {e}"))),
+        };
+        self.db
+            .credentials()
+            .set_password(user_id, password, now)
+            .await
+            .map_err(|e| HostError::Storage(format!("set password: {e}")))?;
+
+        {
+            // Unvalidated users land in the guest room (if configured); sysop /
+            // first-user lands in Lobby as usual.
+            let initial_room = if initial_level < PermissionLevel::User {
+                self.guest_room_id().unwrap_or(LOBBY_ROOM_ID)
+            } else {
+                LOBBY_ROOM_ID
+            };
+            let mut sessions = self.sessions.write().await;
+            if let Some(r) = sessions.get_mut(&session) {
+                r.username = Some(username.clone());
+                r.user_id = Some(user_id);
+                r.level = initial_level;
+                r.workflow = Workflow::None;
+                r.current_room = initial_room;
+            }
+        }
+        let _ = self.events_tx.send(DomainEvent::UserCreated {
+            user: username.clone(),
+        });
+        if is_first {
+            info!(%session, %username, "first registration — promoted to Sysop");
+        } else {
+            info!(%session, %username, "registration complete — awaiting validation");
+
+            // DM every active sysop so they know there's a new user waiting to
+            // be validated (or banned).
+            let sysops: Vec<crate::user::User> = UserStore::list(&self.db, None, 200, 0)
+                .await
+                .unwrap_or_default()
+                .into_iter()
+                .filter(|u| {
+                    u.permission_level == PermissionLevel::Sysop
+                        && u.status == crate::user::UserStatus::Active
+                })
+                .collect();
+
+            if !sysops.is_empty() {
+                let dm_ts = Timestamp::now();
+                let dm_body = format!(
+                    "New user registered: {username}\nV {username} to verify, B {username} to ban."
+                );
+                let bbs_sender = Username::__internal_system("bbs");
+                for sysop in sysops {
+                    let _ = MessageStore::post_direct(
+                        &self.db,
+                        &bbs_sender,
+                        &sysop.username,
+                        &dm_body,
+                        dm_ts,
+                    )
+                    .await;
+                }
+            }
+        }
+        Ok(Response::LoggedIn {
+            user: username.clone(),
+        })
+    }
+
+    /// One-shot registration: validate, create, and log in from a single
+    /// `REGISTER <user> <password>` message — no password prompt/confirmation.
+    /// Fewer round-trips dramatically improves success on lossy multi-hop links.
+    async fn handle_register_oneshot(
+        &self,
+        session: SessionId,
+        raw_username: String,
+        password: String,
+    ) -> Result<Response, HostError> {
+        {
+            let sessions = self.sessions.read().await;
+            if let Some(r) = sessions.get(&session) {
+                if r.username.is_some() {
+                    return Ok(Response::Error(
+                        "Already logged in. Use 'logout' first.".into(),
+                    ));
+                }
+                if !matches!(r.workflow, Workflow::None) {
+                    return Ok(Response::Error(
+                        "A workflow is already in progress. Type 'cancel' first.".into(),
+                    ));
+                }
+            }
+        }
+
+        let username = match validate_new_username(&raw_username) {
+            Ok(u) => u,
+            Err(msg) => return Ok(Response::Error(msg)),
+        };
+        // Password rule mirrors the interactive flow (min 8). No confirmation
+        // step: the single message can't be typo-confirmed, and re-prompting
+        // would reintroduce the round-trip this path exists to avoid.
+        if password.chars().count() < 8 {
+            return Ok(Response::Error(
+                "Password must be at least 8 characters. Not registered.".into(),
+            ));
+        }
+        let existing = self
+            .db
+            .get_by_username(&username)
+            .await
+            .map_err(|e| HostError::Storage(format!("{e}")))?;
+        if existing.is_some() {
+            return Ok(Response::Error(format!(
+                "'{username}' is taken. Try: login {username} <password>"
+            )));
+        }
+
+        self.create_user_and_login(session, &username, &password)
+            .await
+    }
+
+    /// One-shot login: authenticate and log in from a single
+    /// `LOGIN <user> <password>` message — no password prompt. A temp-password
+    /// account (sysop `.PW` reset) still drops into the forced change-password
+    /// prompt, which can't be collapsed into one message.
+    async fn handle_login_oneshot(
+        &self,
+        session: SessionId,
+        username: Username,
+        password: String,
+    ) -> Result<Response, HostError> {
+        {
+            let sessions = self.sessions.read().await;
+            if let Some(r) = sessions.get(&session) {
+                if r.username.is_some() {
+                    return Ok(Response::Error(
+                        "Already logged in. Use 'logout' first.".into(),
+                    ));
+                }
+                if !matches!(r.workflow, Workflow::None) {
+                    return Ok(Response::Error(
+                        "A workflow is already in progress. Type 'cancel' first.".into(),
+                    ));
+                }
+            }
+        }
+
+        let user = self
+            .db
+            .get_by_username(&username)
+            .await
+            .map_err(|e| HostError::Storage(format!("{e}")))?;
+        let user = match user {
+            Some(u) if u.status == UserStatus::Active => u,
+            // Don't reveal whether the account exists; same generic failure.
+            _ => return Ok(Response::Error("Login failed.".into())),
+        };
+
+        let ok = self
+            .db
+            .credentials()
+            .verify_password(user.id, &password, Timestamp::now())
+            .await
+            .map_err(|e| HostError::Storage(format!("verify password: {e}")))?;
+
+        if !ok {
+            let delay_secs = self.record_login_failure(username.as_str()).await;
+            warn!(%session, %username, delay_secs, "one-shot login failed: wrong password");
+            tokio::time::sleep(std::time::Duration::from_secs(delay_secs)).await;
+            return Ok(Response::Error("Login failed.".into()));
+        }
+
+        // Success: clear failures, stamp last_login.
+        self.login_failures.lock().await.remove(username.as_str());
+        UserStore::update(&self.db, user.id, None, None, None, Some(Timestamp::now()))
+            .await
+            .map_err(|e| HostError::Storage(format!("update last_login: {e}")))?;
+
+        // Temp-password accounts must choose a new password before completing —
+        // that step is inherently interactive, so drop into the prompt. (#134)
+        let must_change = self
+            .db
+            .credentials()
+            .must_change_password(user.id)
+            .await
+            .map_err(|e| HostError::Storage(format!("must_change lookup: {e}")))?;
+        if must_change {
+            let mut sessions = self.sessions.write().await;
+            if let Some(r) = sessions.get_mut(&session) {
+                r.workflow = Workflow::ForceChangePassword {
+                    username: username.clone(),
+                    user_id: user.id,
+                    stage: ForcePwdStage::EnterNew,
+                };
+            }
+            return Ok(Response::Prompt {
+                text: "Your password was reset by an operator. \
+                       Choose a new password (min 8 characters):"
+                    .into(),
+                hide_input: true,
+            });
+        }
+
+        info!(%session, %username, "one-shot login successful");
+        Ok(self.finalize_login(session, &user).await)
+    }
+
     async fn handle_login(
         &self,
         session: SessionId,
@@ -1753,13 +2051,19 @@ impl BbsHost {
         // upstream in the transport parser.
         if matches!(workflow, Workflow::Register { .. } | Workflow::Login { .. }) {
             match auth_escape(&reply) {
-                Some(AuthEscape::Register(name)) => {
+                Some(AuthEscape::Register { username, password }) => {
                     self.clear_workflow(session).await;
-                    return self.handle_register(session, name).await;
+                    return match password {
+                        Some(pw) => self.handle_register_oneshot(session, username, pw).await,
+                        None => self.handle_register(session, username).await,
+                    };
                 }
-                Some(AuthEscape::Login(name)) => {
+                Some(AuthEscape::Login { username, password }) => {
                     self.clear_workflow(session).await;
-                    return self.handle_login(session, name).await;
+                    return match password {
+                        Some(pw) => self.handle_login_oneshot(session, username, pw).await,
+                        None => self.handle_login(session, username).await,
+                    };
                 }
                 None => {}
             }
@@ -1814,96 +2118,8 @@ impl BbsHost {
                         hide_input: true,
                     });
                 }
-                let now = Timestamp::now();
-                // Promote the very first registrant to Sysop so the system
-                // isn't stuck with no one able to validate new users.
-                let is_first = UserStore::list(&self.db, None, 1, 0)
+                self.create_user_and_login(session, &username, &password)
                     .await
-                    .map_err(|e| HostError::Storage(format!("list users: {e}")))?
-                    .is_empty();
-                let initial_level = if is_first {
-                    PermissionLevel::Sysop
-                } else {
-                    PermissionLevel::Unvalidated
-                };
-                // Display name defaults to the username (stored as NULL); the user
-                // sets it later with PROFILE. See RegisterStage docs.
-                let user_id =
-                    match UserStore::create(&self.db, &username, None, initial_level, now).await {
-                        Ok(id) => id,
-                        Err(crate::db::StoreError::Conflict(_)) => {
-                            let mut sessions = self.sessions.write().await;
-                            if let Some(r) = sessions.get_mut(&session) {
-                                r.workflow = Workflow::None;
-                            }
-                            return Ok(Response::Error(format!(
-                                "'{username}' was just taken. Try: register <different_username>"
-                            )));
-                        }
-                        Err(e) => return Err(HostError::Storage(format!("create user: {e}"))),
-                    };
-                self.db
-                    .credentials()
-                    .set_password(user_id, &password, now)
-                    .await
-                    .map_err(|e| HostError::Storage(format!("set password: {e}")))?;
-
-                {
-                    // Unvalidated users land in the guest room (if configured);
-                    // sysop / first-user lands in Lobby as usual.
-                    let initial_room = if initial_level < PermissionLevel::User {
-                        self.guest_room_id().unwrap_or(LOBBY_ROOM_ID)
-                    } else {
-                        LOBBY_ROOM_ID
-                    };
-                    let mut sessions = self.sessions.write().await;
-                    if let Some(r) = sessions.get_mut(&session) {
-                        r.username = Some(username.clone());
-                        r.user_id = Some(user_id);
-                        r.level = initial_level;
-                        r.workflow = Workflow::None;
-                        r.current_room = initial_room;
-                    }
-                }
-                let _ = self.events_tx.send(DomainEvent::UserCreated {
-                    user: username.clone(),
-                });
-                if is_first {
-                    info!(%session, %username, "first registration — promoted to Sysop");
-                } else {
-                    info!(%session, %username, "registration complete — awaiting validation");
-
-                    // DM every active sysop so they know there's a new
-                    // user waiting to be validated (or banned).
-                    let sysops: Vec<crate::user::User> = UserStore::list(&self.db, None, 200, 0)
-                        .await
-                        .unwrap_or_default()
-                        .into_iter()
-                        .filter(|u| {
-                            u.permission_level == PermissionLevel::Sysop
-                                && u.status == crate::user::UserStatus::Active
-                        })
-                        .collect();
-
-                    if !sysops.is_empty() {
-                        let dm_ts = Timestamp::now();
-                        let dm_body = format!(
-                            "New user registered: {username}\nV {username} to verify, B {username} to ban."
-                        );
-                        let bbs_sender = Username::__internal_system("bbs");
-                        for sysop in sysops {
-                            let _ = MessageStore::post_direct(
-                                &self.db,
-                                &bbs_sender,
-                                &sysop.username,
-                                &dm_body,
-                                dm_ts,
-                            )
-                            .await;
-                        }
-                    }
-                }
-                Ok(Response::LoggedIn { user: username })
             }
 
             // ── Login ────────────────────────────────────────────────────────
@@ -1966,37 +2182,7 @@ impl BbsHost {
                     info!(%session, %username, "login successful");
                     Ok(self.finalize_login(session, &user).await)
                 } else {
-                    // Global per-username failure tracking — parallel sessions share this
-                    // counter so they can't bypass the delay by opening fresh connections.
-                    let delay_secs = {
-                        let mut map = self.login_failures.lock().await;
-                        // Evict stale entries before inserting to bound map size.
-                        // On a busy node this keeps memory O(active_usernames) rather
-                        // than O(all_usernames_ever). Hard cap prevents unbounded growth
-                        // even if eviction somehow misses entries.
-                        const MAX_FAILURE_ENTRIES: usize = 1_000;
-                        if map.len() >= MAX_FAILURE_ENTRIES {
-                            map.retain(|_, (_, t)| t.elapsed().as_secs() <= 600);
-                            // If still over cap after eviction, clear entirely — this
-                            // should never happen in practice (1 000 simultaneous unique
-                            // attackers is not a realistic mesh scenario).
-                            if map.len() >= MAX_FAILURE_ENTRIES {
-                                map.clear();
-                            }
-                        }
-                        let entry = map
-                            .entry(username.as_str().to_owned())
-                            .or_insert((0, Instant::now()));
-                        // Stale entries (>10 min) reset the counter.
-                        if entry.1.elapsed().as_secs() > 600 {
-                            *entry = (0, Instant::now());
-                        }
-                        entry.0 += 1;
-                        entry.1 = Instant::now();
-                        let failures = entry.0;
-                        // Exponential backoff: 2, 4, 8, 16, 30 s (capped).
-                        u64::min(2u64.saturating_pow(failures), 30)
-                    };
+                    let delay_secs = self.record_login_failure(username.as_str()).await;
                     warn!(%session, %username, delay_secs, "login failed: wrong password");
                     tokio::time::sleep(std::time::Duration::from_secs(delay_secs)).await;
 
@@ -4839,6 +5025,8 @@ fn cmd_label(cmd: &Command) -> &'static str {
         Command::Help { .. } => "Help",
         Command::Login { .. } => "Login",
         Command::Register { .. } => "Register",
+        Command::RegisterOneShot { .. } => "RegisterOneShot",
+        Command::LoginOneShot { .. } => "LoginOneShot",
         Command::WorkflowReply { .. } => "WorkflowReply",
         Command::Cancel => "Cancel",
         Command::Logout | Command::Quit => "Logout",
@@ -4981,8 +5169,14 @@ fn help_for_command(cmd: &str, level: Option<PermissionLevel>) -> String {
                 "Q — quit"
             }
         }
-        "register" => "REGISTER <user> — create an account",
-        "login" => "LOGIN <user> — log in to your account",
+        "register" => {
+            "REGISTER <user> <password> — create an account and log in.\n\
+             One message, no prompts. Omit the password to be prompted instead."
+        }
+        "login" => {
+            "LOGIN <user> <password> — log in.\n\
+             One message, no prompts. Omit the password to be prompted instead."
+        }
         "cancel" => "CANCEL — cancel the current workflow",
 
         // ── Logged-in only ───────────────────────────────────────────────
@@ -5071,8 +5265,9 @@ fn help_for_command(cmd: &str, level: Option<PermissionLevel>) -> String {
 }
 
 const HELP_QUICK_ANON: &str = "\
-REGISTER <user>  create an account\n\
-LOGIN <user>     log in to your account";
+REGISTER <user> <password>\n\
+LOGIN <user> <password>\n\
+(omit password to be prompted)";
 
 // 156 bytes — must stay ≤ MAX_REPLY_BYTES (MAX_FRAME_SIZE(172) - 16 bytes overhead).
 const HELP_QUICK_LOGGED_IN: &str = "\
@@ -5933,19 +6128,215 @@ mod tests {
         );
     }
 
+    // ── One-shot auth (REGISTER/LOGIN <user> <password>) ──────────────────────
+
+    /// `REGISTER <user> <password>` creates the account and logs in from a single
+    /// message — no prompts. Far fewer round-trips on lossy multi-hop links.
+    #[tokio::test]
+    async fn register_oneshot_creates_and_logs_in() {
+        let (host, _db) = make_host().await;
+        let sid = host.create_session("test").await.unwrap();
+
+        let resp = host
+            .process_command(
+                sid,
+                Command::RegisterOneShot {
+                    username: "alice".into(),
+                    password: "hunter2!".into(),
+                },
+            )
+            .await
+            .unwrap();
+        assert!(
+            matches!(resp, Response::LoggedIn { .. }),
+            "one-shot register should log in immediately, got: {resp:?}"
+        );
+
+        let user = host
+            .db
+            .get_by_username(&Username::new("alice").unwrap())
+            .await
+            .unwrap()
+            .expect("account created");
+        assert_eq!(user.display_name, None, "display name defaults to username");
+        let ctx = host.permission_ctx(sid).await.unwrap();
+        assert_eq!(ctx.username(), Some(&Username::new("alice").unwrap()));
+        assert_eq!(
+            ctx.level(),
+            PermissionLevel::Sysop,
+            "first registrant is promoted to Sysop"
+        );
+    }
+
+    #[tokio::test]
+    async fn register_oneshot_rejects_short_password() {
+        let (host, _db) = make_host().await;
+        let sid = host.create_session("test").await.unwrap();
+
+        let resp = host
+            .process_command(
+                sid,
+                Command::RegisterOneShot {
+                    username: "alice".into(),
+                    password: "short".into(),
+                },
+            )
+            .await
+            .unwrap();
+        assert!(
+            matches!(&resp, Response::Error(e) if e.to_lowercase().contains("8 characters")),
+            "short password should be rejected, got: {resp:?}"
+        );
+        assert!(
+            host.db
+                .get_by_username(&Username::new("alice").unwrap())
+                .await
+                .unwrap()
+                .is_none(),
+            "no account should be created on a rejected one-shot register"
+        );
+    }
+
+    #[tokio::test]
+    async fn login_oneshot_succeeds_with_correct_password() {
+        let (host, _db) = make_host().await;
+        let s0 = host.create_session("test").await.unwrap();
+        do_register(&host, s0, "alice", "s3cr3t!!").await;
+
+        let sid = host.create_session("test").await.unwrap();
+        let resp = host
+            .process_command(
+                sid,
+                Command::LoginOneShot {
+                    username: Username::new("alice").unwrap(),
+                    password: "s3cr3t!!".into(),
+                },
+            )
+            .await
+            .unwrap();
+        assert!(
+            matches!(resp, Response::LoggedIn { .. }),
+            "one-shot login should authenticate, got: {resp:?}"
+        );
+        let ctx = host.permission_ctx(sid).await.unwrap();
+        assert_eq!(ctx.username(), Some(&Username::new("alice").unwrap()));
+    }
+
+    #[tokio::test]
+    async fn login_oneshot_wrong_password_fails() {
+        let (host, _db) = make_host().await;
+        let s0 = host.create_session("test").await.unwrap();
+        do_register(&host, s0, "alice", "s3cr3t!!").await;
+
+        let sid = host.create_session("test").await.unwrap();
+        let resp = host
+            .process_command(
+                sid,
+                Command::LoginOneShot {
+                    username: Username::new("alice").unwrap(),
+                    password: "wrongpass".into(),
+                },
+            )
+            .await
+            .unwrap();
+        assert!(
+            matches!(&resp, Response::Error(e) if e.contains("Login failed")),
+            "wrong one-shot password should fail, got: {resp:?}"
+        );
+        let ctx = host.permission_ctx(sid).await.unwrap();
+        assert_eq!(
+            ctx.username(),
+            None,
+            "must not be authenticated after a bad password"
+        );
+    }
+
+    /// A re-sent `REGISTER <user> <password>` mid-registration escapes the
+    /// interactive flow and completes one-shot — the lost-prompt recovery path,
+    /// now collapsed to a single message.
+    #[tokio::test]
+    async fn workflow_reply_register_with_password_escapes_to_one_shot() {
+        let (host, _db) = make_host().await;
+        let sid = host.create_session("test").await.unwrap();
+
+        host.process_command(
+            sid,
+            Command::Register {
+                username: "aaa".into(),
+            },
+        )
+        .await
+        .unwrap();
+        let resp = host
+            .process_command(
+                sid,
+                Command::WorkflowReply {
+                    reply: "register bob hunter2!".into(),
+                },
+            )
+            .await
+            .unwrap();
+        assert!(
+            matches!(resp, Response::LoggedIn { .. }),
+            "one-shot escape should create + log in 'bob', got: {resp:?}"
+        );
+        assert!(
+            host.db
+                .get_by_username(&Username::new("bob").unwrap())
+                .await
+                .unwrap()
+                .is_some(),
+            "'bob' should have been created"
+        );
+        assert!(
+            host.db
+                .get_by_username(&Username::new("aaa").unwrap())
+                .await
+                .unwrap()
+                .is_none(),
+            "the abandoned 'aaa' registration must not have created an account"
+        );
+        let ctx = host.permission_ctx(sid).await.unwrap();
+        assert_eq!(ctx.username(), Some(&Username::new("bob").unwrap()));
+    }
+
     #[test]
     fn auth_escape_recognizes_register_and_login_only() {
         assert_eq!(
             auth_escape("REGISTER tcm1"),
-            Some(AuthEscape::Register("tcm1".into()))
+            Some(AuthEscape::Register {
+                username: "tcm1".into(),
+                password: None
+            })
         );
         assert_eq!(
             auth_escape("  register   TCF  "),
-            Some(AuthEscape::Register("TCF".into()))
+            Some(AuthEscape::Register {
+                username: "TCF".into(),
+                password: None
+            })
         );
         assert_eq!(
             auth_escape("login alice"),
-            Some(AuthEscape::Login(Username::new("alice").unwrap()))
+            Some(AuthEscape::Login {
+                username: Username::new("alice").unwrap(),
+                password: None
+            })
+        );
+        // A trailing word is taken as a one-shot password.
+        assert_eq!(
+            auth_escape("register bob hunter2!"),
+            Some(AuthEscape::Register {
+                username: "bob".into(),
+                password: Some("hunter2!".into())
+            })
+        );
+        assert_eq!(
+            auth_escape("login alice s3cr3tpw"),
+            Some(AuthEscape::Login {
+                username: Username::new("alice").unwrap(),
+                password: Some("s3cr3tpw".into())
+            })
         );
         // No argument → not an escape (a bare keyword is left to the workflow).
         assert_eq!(auth_escape("register"), None);

--- a/crates/bbs-core/src/host.rs
+++ b/crates/bbs-core/src/host.rs
@@ -1662,11 +1662,21 @@ impl BbsHost {
         let prompt = format!("Registering '{username}'. Choose a password (min 8 characters):");
         {
             let mut sessions = self.sessions.write().await;
-            if let Some(r) = sessions.get_mut(&session) {
-                r.workflow = Workflow::Register {
-                    username,
-                    stage: RegisterStage::Password,
-                };
+            match sessions.get_mut(&session) {
+                Some(r) => {
+                    r.workflow = Workflow::Register {
+                        username,
+                        stage: RegisterStage::Password,
+                    };
+                }
+                // Session unknown — likely a stale ID held by the transport after
+                // a logout or server restart. Surface the error so the transport
+                // can mint a fresh session and replay REGISTER. Mirrors
+                // handle_login. Without this the prompt was returned while the
+                // workflow write silently no-opped, so the user's first password
+                // reply landed on a dead session and fell through to the
+                // anonymous banner (the logout-then-register QA bug).
+                None => return Err(HostError::UnknownSession(session)),
             }
         }
         Ok(Response::Prompt {
@@ -5624,6 +5634,79 @@ mod tests {
         let resp = host.process_command(sid, Command::Logout).await.unwrap();
         assert_eq!(resp, Response::LoggedOut);
         assert_eq!(host.sessions.read().await.len(), 0);
+    }
+
+    /// Regression: REGISTER against a session the host no longer has must surface
+    /// `UnknownSession` — so the mesh transport refreshes and replays it — rather
+    /// than fabricate a "choose a password" prompt while silently dropping the
+    /// workflow write. `handle_login` already did this; `handle_register` did
+    /// not, which is why a logout-then-register dropped the first password reply
+    /// to the anonymous banner (the over-the-air QA bug).
+    #[tokio::test]
+    async fn register_on_ended_session_errors() {
+        let (host, _db) = make_host().await;
+        let sid = host.create_session("meshcore").await.unwrap();
+        host.end_session(sid).await.unwrap();
+        let resp = host
+            .process_command(
+                sid,
+                Command::Register {
+                    username: "ghost".into(),
+                },
+            )
+            .await;
+        assert!(
+            matches!(resp, Err(HostError::UnknownSession(_))),
+            "REGISTER on an ended session must surface UnknownSession, got: {resp:?}"
+        );
+    }
+
+    /// `handle_login` has surfaced `UnknownSession` on a missing session all
+    /// along — this pins that parity so the two auth entry points can't drift.
+    #[tokio::test]
+    async fn login_on_ended_session_errors() {
+        let (host, _db) = make_host().await;
+        let uname = Username::new("ghostl").unwrap();
+
+        // Register + validate a real user so LOGIN gets past the username lookup
+        // and reaches the session write (where the missing-session check lives).
+        let sid = host.create_session("meshcore").await.unwrap();
+        host.process_command(
+            sid,
+            Command::Register {
+                username: uname.as_str().to_owned(),
+            },
+        )
+        .await
+        .unwrap();
+        host.process_command(
+            sid,
+            Command::WorkflowReply {
+                reply: "password1".into(),
+            },
+        )
+        .await
+        .unwrap();
+        host.process_command(
+            sid,
+            Command::WorkflowReply {
+                reply: "password1".into(),
+            },
+        )
+        .await
+        .unwrap();
+        force_validate(&host, &uname).await;
+
+        // Now LOGIN on a session the host has ended.
+        let sid2 = host.create_session("meshcore").await.unwrap();
+        host.end_session(sid2).await.unwrap();
+        let resp = host
+            .process_command(sid2, Command::Login { username: uname })
+            .await;
+        assert!(
+            matches!(resp, Err(HostError::UnknownSession(_))),
+            "LOGIN on an ended session must surface UnknownSession, got: {resp:?}"
+        );
     }
 
     #[tokio::test]

--- a/crates/bbs-core/src/host.rs
+++ b/crates/bbs-core/src/host.rs
@@ -1688,7 +1688,11 @@ impl BbsHost {
     /// Authenticate `session` as `user`: set the session identity/level/room,
     /// fire `SessionAuthenticated`, and return the `LoggedIn` response. Shared by
     /// the normal login path and the forced-password-change completion. (#134)
-    async fn finalize_login(&self, session: SessionId, user: &crate::user::User) -> Response {
+    async fn finalize_login(
+        &self,
+        session: SessionId,
+        user: &crate::user::User,
+    ) -> Result<Response, HostError> {
         // Unverified users land in the guest room (if configured).
         let initial_room = if user.permission_level < PermissionLevel::User {
             self.guest_room_id().unwrap_or(LOBBY_ROOM_ID)
@@ -1697,21 +1701,32 @@ impl BbsHost {
         };
         {
             let mut sessions = self.sessions.write().await;
-            if let Some(r) = sessions.get_mut(&session) {
-                r.username = Some(user.username.clone());
-                r.user_id = Some(user.id);
-                r.level = user.permission_level;
-                r.workflow = Workflow::None;
-                r.current_room = initial_room;
+            match sessions.get_mut(&session) {
+                Some(r) => {
+                    r.username = Some(user.username.clone());
+                    r.user_id = Some(user.id);
+                    r.level = user.permission_level;
+                    r.workflow = Workflow::None;
+                    r.current_room = initial_room;
+                }
+                // Session unknown — almost always a stale ID the transport kept
+                // after a logout or server restart. Surface the error instead of
+                // silently writing nothing and still reporting LoggedIn: that
+                // left the transport's prefix mapping pinned to a dead session,
+                // so every command after a one-shot LOGIN failed with "Unknown
+                // session". Returning the error lets the transport mint a fresh
+                // session and replay the command. Mirrors handle_login /
+                // handle_workflow_reply (and the handle_register fix, 50966ab).
+                None => return Err(HostError::UnknownSession(session)),
             }
         }
         let _ = self.events_tx.send(DomainEvent::SessionAuthenticated {
             session,
             user: user.username.clone(),
         });
-        Response::LoggedIn {
+        Ok(Response::LoggedIn {
             user: user.username.clone(),
-        }
+        })
     }
 
     /// If `username` is within its login-backoff window, return the seconds
@@ -1809,12 +1824,20 @@ impl BbsHost {
                 LOBBY_ROOM_ID
             };
             let mut sessions = self.sessions.write().await;
-            if let Some(r) = sessions.get_mut(&session) {
-                r.username = Some(username.clone());
-                r.user_id = Some(user_id);
-                r.level = initial_level;
-                r.workflow = Workflow::None;
-                r.current_room = initial_room;
+            match sessions.get_mut(&session) {
+                Some(r) => {
+                    r.username = Some(username.clone());
+                    r.user_id = Some(user_id);
+                    r.level = initial_level;
+                    r.workflow = Workflow::None;
+                    r.current_room = initial_room;
+                }
+                // Session vanished (stale ID after logout/restart). The account
+                // is already persisted; surface the error so the transport
+                // refreshes the session and replays, rather than reporting
+                // LoggedIn on a dead session. See finalize_login for the full
+                // rationale (the one-shot session-squash bug).
+                None => return Err(HostError::UnknownSession(session)),
             }
         }
         let _ = self.events_tx.send(DomainEvent::UserCreated {
@@ -1871,17 +1894,24 @@ impl BbsHost {
     ) -> Result<Response, HostError> {
         {
             let sessions = self.sessions.read().await;
-            if let Some(r) = sessions.get(&session) {
-                if r.username.is_some() {
-                    return Ok(Response::Error(
-                        "Already logged in. Use 'logout' first.".into(),
-                    ));
+            match sessions.get(&session) {
+                Some(r) => {
+                    if r.username.is_some() {
+                        return Ok(Response::Error(
+                            "Already logged in. Use 'logout' first.".into(),
+                        ));
+                    }
+                    if !matches!(r.workflow, Workflow::None) {
+                        return Ok(Response::Error(
+                            "A workflow is already in progress. Type 'cancel' first.".into(),
+                        ));
+                    }
                 }
-                if !matches!(r.workflow, Workflow::None) {
-                    return Ok(Response::Error(
-                        "A workflow is already in progress. Type 'cancel' first.".into(),
-                    ));
-                }
+                // Stale session — reject before creating the account, so the
+                // transport refreshes and replays on a fresh session. Surfacing
+                // this only after create_user_and_login would persist the
+                // account, then the replay would bounce off "username taken".
+                None => return Err(HostError::UnknownSession(session)),
             }
         }
 
@@ -1924,17 +1954,25 @@ impl BbsHost {
     ) -> Result<Response, HostError> {
         {
             let sessions = self.sessions.read().await;
-            if let Some(r) = sessions.get(&session) {
-                if r.username.is_some() {
-                    return Ok(Response::Error(
-                        "Already logged in. Use 'logout' first.".into(),
-                    ));
+            match sessions.get(&session) {
+                Some(r) => {
+                    if r.username.is_some() {
+                        return Ok(Response::Error(
+                            "Already logged in. Use 'logout' first.".into(),
+                        ));
+                    }
+                    if !matches!(r.workflow, Workflow::None) {
+                        return Ok(Response::Error(
+                            "A workflow is already in progress. Type 'cancel' first.".into(),
+                        ));
+                    }
                 }
-                if !matches!(r.workflow, Workflow::None) {
-                    return Ok(Response::Error(
-                        "A workflow is already in progress. Type 'cancel' first.".into(),
-                    ));
-                }
+                // Stale session (e.g. the transport kept the prefix mapping
+                // after a logout). Surface the error so the transport mints a
+                // fresh session and replays, instead of authenticating against
+                // a dead session and reporting LoggedIn while writing nothing —
+                // the one-shot session-squash bug.
+                None => return Err(HostError::UnknownSession(session)),
             }
         }
 
@@ -1989,12 +2027,18 @@ impl BbsHost {
             .map_err(|e| HostError::Storage(format!("must_change lookup: {e}")))?;
         if must_change {
             let mut sessions = self.sessions.write().await;
-            if let Some(r) = sessions.get_mut(&session) {
-                r.workflow = Workflow::ForceChangePassword {
-                    username: username.clone(),
-                    user_id: user.id,
-                    stage: ForcePwdStage::EnterNew,
-                };
+            match sessions.get_mut(&session) {
+                Some(r) => {
+                    r.workflow = Workflow::ForceChangePassword {
+                        username: username.clone(),
+                        user_id: user.id,
+                        stage: ForcePwdStage::EnterNew,
+                    };
+                }
+                // Stale session — don't return a prompt the transport would
+                // arm against a dead session. Surface the error so it refreshes
+                // and replays. See finalize_login for the full rationale.
+                None => return Err(HostError::UnknownSession(session)),
             }
             return Ok(Response::Prompt {
                 text: "Your password was reset by an operator. \
@@ -2005,7 +2049,7 @@ impl BbsHost {
         }
 
         info!(%session, %username, "one-shot login successful");
-        Ok(self.finalize_login(session, &user).await)
+        self.finalize_login(session, &user).await
     }
 
     async fn handle_login(
@@ -2239,7 +2283,7 @@ impl BbsHost {
                     }
 
                     info!(%session, %username, "login successful");
-                    Ok(self.finalize_login(session, &user).await)
+                    self.finalize_login(session, &user).await
                 } else {
                     let delay_secs = self.record_login_failure(username.as_str()).await;
                     warn!(%session, %username, delay_secs, "login failed: wrong password");
@@ -2696,7 +2740,7 @@ impl BbsHost {
                     }
                 };
                 info!(%username, "forced password change complete; login finalised");
-                Ok(self.finalize_login(session, &user).await)
+                self.finalize_login(session, &user).await
             }
 
             // ── Message reading ──────────────────────────────────────────────
@@ -5706,6 +5750,82 @@ mod tests {
         assert!(
             matches!(resp, Err(HostError::UnknownSession(_))),
             "LOGIN on an ended session must surface UnknownSession, got: {resp:?}"
+        );
+    }
+
+    /// Regression for the one-shot session-squash bug: a `LOGIN <user> <pw>`
+    /// against a session the host no longer has must surface `UnknownSession`,
+    /// NOT report `LoggedIn` while writing nothing. The latter pinned the mesh
+    /// transport's prefix mapping to a dead session, so every command after a
+    /// one-shot login failed with "Unknown session" / the anonymous banner.
+    #[tokio::test]
+    async fn login_oneshot_on_ended_session_errors() {
+        let (host, _db) = make_host().await;
+        let uname = Username::new("ghosto").unwrap();
+
+        // Register + validate a real user so the one-shot login passes the
+        // username/password checks and reaches finalize_login.
+        let sid = host.create_session("meshcore").await.unwrap();
+        host.process_command(
+            sid,
+            Command::RegisterOneShot {
+                username: uname.as_str().to_owned(),
+                password: "password1".into(),
+            },
+        )
+        .await
+        .unwrap();
+        force_validate(&host, &uname).await;
+
+        // One-shot login on a session the host has ended.
+        let sid2 = host.create_session("meshcore").await.unwrap();
+        host.end_session(sid2).await.unwrap();
+        let resp = host
+            .process_command(
+                sid2,
+                Command::LoginOneShot {
+                    username: uname,
+                    password: "password1".into(),
+                },
+            )
+            .await;
+        assert!(
+            matches!(resp, Err(HostError::UnknownSession(_))),
+            "one-shot LOGIN on an ended session must surface UnknownSession, got: {resp:?}"
+        );
+    }
+
+    /// One-shot REGISTER on a dead session must surface `UnknownSession` BEFORE
+    /// persisting the account — otherwise the transport's replay on a fresh
+    /// session would bounce off "username taken", and the original session
+    /// stays squashed.
+    #[tokio::test]
+    async fn register_oneshot_on_ended_session_errors() {
+        let (host, _db) = make_host().await;
+        let sid = host.create_session("meshcore").await.unwrap();
+        host.end_session(sid).await.unwrap();
+        let resp = host
+            .process_command(
+                sid,
+                Command::RegisterOneShot {
+                    username: "ghostr".into(),
+                    password: "password1".into(),
+                },
+            )
+            .await;
+        assert!(
+            matches!(resp, Err(HostError::UnknownSession(_))),
+            "one-shot REGISTER on an ended session must surface UnknownSession, got: {resp:?}"
+        );
+        // The account must NOT have been created (no orphaned half-registration).
+        let exists = host
+            .db
+            .get_by_username(&Username::new("ghostr").unwrap())
+            .await
+            .unwrap();
+        assert!(
+            exists.is_none(),
+            "one-shot REGISTER on a dead session must not persist the account"
         );
     }
 

--- a/crates/bbs-core/src/host.rs
+++ b/crates/bbs-core/src/host.rs
@@ -448,7 +448,12 @@ impl Host for BbsHost {
                 // level = None: unknown session; Some(None): not logged in;
                 // Some(Some(lvl)): logged in at lvl.
                 let auth_level = level.flatten();
-                Ok(Response::Text(help_text(topic.as_deref(), auth_level)))
+                let on_radio = self.session_on_radio(session).await;
+                Ok(Response::Text(help_text(
+                    topic.as_deref(),
+                    auth_level,
+                    on_radio,
+                )))
             }
 
             Command::Whoami => self.handle_whoami(session).await,
@@ -555,6 +560,8 @@ impl Host for BbsHost {
                 };
                 if is_authed {
                     Ok(Response::Text("Unknown command. Type H for help.".into()))
+                } else if self.session_on_radio(session).await {
+                    Ok(Response::Text(HELP_QUICK_ANON_RADIO.into()))
                 } else {
                     Ok(Response::Text(HELP_QUICK_ANON.into()))
                 }
@@ -2017,6 +2024,17 @@ impl BbsHost {
             text: prompt,
             hide_input: true,
         })
+    }
+
+    /// Whether `session` is on a radio transport (MeshCore / Meshtastic). One-shot
+    /// auth and its help are offered only on radio, where avoiding a prompt
+    /// round-trip matters; the CLI keeps the interactive (hidden-input) flow.
+    async fn session_on_radio(&self, session: SessionId) -> bool {
+        let sessions = self.sessions.read().await;
+        sessions
+            .get(&session)
+            .map(|r| matches!(r.transport.as_str(), "meshcore" | "meshtastic"))
+            .unwrap_or(false)
     }
 
     /// Clear any in-progress workflow for `session` (best-effort; a missing
@@ -5107,7 +5125,7 @@ fn validate_new_username(raw: &str) -> Result<Username, String> {
 
 // ── Help text ─────────────────────────────────────────────────────────────────
 
-fn help_text(topic: Option<&str>, level: Option<PermissionLevel>) -> String {
+fn help_text(topic: Option<&str>, level: Option<PermissionLevel>, on_radio: bool) -> String {
     let logged_in = level.is_some();
     let is_aide = level >= Some(PermissionLevel::Aide);
     let is_sysop = level >= Some(PermissionLevel::Sysop);
@@ -5116,6 +5134,9 @@ fn help_text(topic: Option<&str>, level: Option<PermissionLevel>) -> String {
         None => {
             if logged_in {
                 HELP_QUICK_LOGGED_IN.to_owned()
+            } else if on_radio {
+                // Radio transports advertise one-shot auth (fewer round-trips).
+                HELP_QUICK_ANON_RADIO.to_owned()
             } else {
                 HELP_QUICK_ANON.to_owned()
             }
@@ -5170,12 +5191,12 @@ fn help_for_command(cmd: &str, level: Option<PermissionLevel>) -> String {
             }
         }
         "register" => {
-            "REGISTER <user> <password> — create an account and log in.\n\
-             One message, no prompts. Omit the password to be prompted instead."
+            "REGISTER <user> — create an account (you'll be prompted for a password).\n\
+             On a radio you can also do it in one message: REGISTER <user> <password>."
         }
         "login" => {
-            "LOGIN <user> <password> — log in.\n\
-             One message, no prompts. Omit the password to be prompted instead."
+            "LOGIN <user> — log in (you'll be prompted for a password).\n\
+             On a radio, one message works too: LOGIN <user> <password>."
         }
         "cancel" => "CANCEL — cancel the current workflow",
 
@@ -5265,6 +5286,12 @@ fn help_for_command(cmd: &str, level: Option<PermissionLevel>) -> String {
 }
 
 const HELP_QUICK_ANON: &str = "\
+REGISTER <user>  create an account\n\
+LOGIN <user>     log in to your account";
+
+/// Anonymous help shown on radio transports, where one-shot auth
+/// (`REGISTER/LOGIN <user> <password>`) avoids a lossy prompt round-trip.
+const HELP_QUICK_ANON_RADIO: &str = "\
 REGISTER <user> <password>\n\
 LOGIN <user> <password>\n\
 (omit password to be prompted)";
@@ -5413,6 +5440,7 @@ mod tests {
         const MESH_MAX: usize = 156;
         let cases = [
             ("HELP_QUICK_ANON", HELP_QUICK_ANON),
+            ("HELP_QUICK_ANON_RADIO", HELP_QUICK_ANON_RADIO),
             ("HELP_QUICK_LOGGED_IN", HELP_QUICK_LOGGED_IN),
             ("HELP_OVERVIEW", HELP_OVERVIEW),
             ("HELP_MAIL", HELP_MAIL),
@@ -5438,13 +5466,13 @@ mod tests {
     /// those levels so operators can discover their admin toolset in-app.
     #[test]
     fn help_all_lists_admin_topics_by_level() {
-        let user = help_text(Some("all"), Some(PermissionLevel::User));
+        let user = help_text(Some("all"), Some(PermissionLevel::User), false);
         assert!(
             !user.contains("AIDE") && !user.contains("SYSOP"),
             "a plain User should not see admin topics: {user}"
         );
 
-        let aide = help_text(Some("all"), Some(PermissionLevel::Aide));
+        let aide = help_text(Some("all"), Some(PermissionLevel::Aide), false);
         assert!(
             aide.contains("H AIDE"),
             "aide should see the AIDE topic: {aide}"
@@ -5454,7 +5482,7 @@ mod tests {
             "an aide should not see the SYSOP topic: {aide}"
         );
 
-        let sysop = help_text(Some("all"), Some(PermissionLevel::Sysop));
+        let sysop = help_text(Some("all"), Some(PermissionLevel::Sysop), false);
         assert!(
             sysop.contains("H AIDE") && sysop.contains("H SYSOP"),
             "sysop should see both admin topics: {sysop}"

--- a/crates/bbs-mesh/Cargo.toml
+++ b/crates/bbs-mesh/Cargo.toml
@@ -20,5 +20,10 @@ tracing.workspace     = true
 # sync (Mutex, watch) + rt (spawn) are the only extras we need on top of workspace defaults.
 tokio = { workspace = true, features = ["sync", "rt"] }
 
+[dev-dependencies]
+# Drive a real BbsHost through the bridge in integration tests (reproduce
+# transport↔host session/workflow interactions that MockHost can't model).
+tempfile.workspace = true
+
 [lints]
 workspace = true

--- a/crates/bbs-mesh/src/command.rs
+++ b/crates/bbs-mesh/src/command.rs
@@ -109,7 +109,7 @@ pub fn parse_command(text: &str, prefix: Option<char>, awaiting_reply: bool) -> 
                 } else if let Some(password) = password {
                     Some(Command::RegisterOneShot {
                         username: name.to_owned(),
-                        password: password.to_owned(),
+                        password: password.into(),
                     })
                 } else {
                     Some(Command::Register {
@@ -129,7 +129,7 @@ pub fn parse_command(text: &str, prefix: Option<char>, awaiting_reply: bool) -> 
                 match (Username::new(name).ok(), password) {
                     (Some(username), Some(password)) => Some(Command::LoginOneShot {
                         username,
-                        password: password.to_owned(),
+                        password: password.into(),
                     }),
                     (Some(username), None) => Some(Command::Login { username }),
                     (None, _) => Some(Command::Help {
@@ -467,7 +467,7 @@ mod tests {
             cmd("register alice hunter2!"),
             Some(Command::RegisterOneShot {
                 username: "alice".to_owned(),
-                password: "hunter2!".to_owned(),
+                password: "hunter2!".into(),
             })
         );
         // Password may contain spaces (passphrase-friendly).
@@ -475,7 +475,7 @@ mod tests {
             cmd("register alice my pass phrase"),
             Some(Command::RegisterOneShot {
                 username: "alice".to_owned(),
-                password: "my pass phrase".to_owned(),
+                password: "my pass phrase".into(),
             })
         );
     }
@@ -486,7 +486,7 @@ mod tests {
             cmd("login bob s3cr3tpw"),
             Some(Command::LoginOneShot {
                 username: Username::new("bob").unwrap(),
-                password: "s3cr3tpw".to_owned(),
+                password: "s3cr3tpw".into(),
             })
         );
         // Bare login still starts the interactive flow.

--- a/crates/bbs-mesh/src/command.rs
+++ b/crates/bbs-mesh/src/command.rs
@@ -95,19 +95,48 @@ pub fn parse_command(text: &str, prefix: Option<char>, awaiting_reply: bool) -> 
             topic: rest.map(str::to_owned),
         }),
 
+        // `register <user>` → interactive flow; `register <user> <password>` →
+        // one-shot (account created + logged in from one message — fewer
+        // round-trips on lossy multi-hop links). Host validates the username
+        // (#128) and password.
         "register" => match rest {
-            // Pass the raw username through; the host validates it and reports a
-            // specific error (#128). Bare `register` → help.
-            Some(name) if !name.is_empty() => Some(Command::Register {
-                username: name.to_owned(),
-            }),
-            _ => Some(Command::Help {
+            Some(r) => {
+                let (name, password) = split_first_word(r);
+                if name.is_empty() {
+                    Some(Command::Help {
+                        topic: Some("register".to_owned()),
+                    })
+                } else if let Some(password) = password {
+                    Some(Command::RegisterOneShot {
+                        username: name.to_owned(),
+                        password: password.to_owned(),
+                    })
+                } else {
+                    Some(Command::Register {
+                        username: name.to_owned(),
+                    })
+                }
+            }
+            None => Some(Command::Help {
                 topic: Some("register".to_owned()),
             }),
         },
 
-        "login" => match rest.and_then(|s| Username::new(s).ok()) {
-            Some(username) => Some(Command::Login { username }),
+        // `login <user>` → interactive; `login <user> <password>` → one-shot.
+        "login" => match rest {
+            Some(r) => {
+                let (name, password) = split_first_word(r);
+                match (Username::new(name).ok(), password) {
+                    (Some(username), Some(password)) => Some(Command::LoginOneShot {
+                        username,
+                        password: password.to_owned(),
+                    }),
+                    (Some(username), None) => Some(Command::Login { username }),
+                    (None, _) => Some(Command::Help {
+                        topic: Some("login".to_owned()),
+                    }),
+                }
+            }
             None => Some(Command::Help {
                 topic: Some("login".to_owned()),
             }),
@@ -423,11 +452,48 @@ mod tests {
     #[test]
     fn register_passes_raw_username_to_host() {
         // The parser no longer rejects invalid usernames — it forwards the raw
-        // text so the host can return a specific error (#128).
+        // (single-word) text so the host can return a specific error (#128).
         assert_eq!(
-            cmd("register alice bob"),
+            cmd("register Bad!Name"),
             Some(Command::Register {
-                username: "alice bob".to_owned()
+                username: "Bad!Name".to_owned()
+            })
+        );
+    }
+
+    #[test]
+    fn register_with_password_is_one_shot() {
+        assert_eq!(
+            cmd("register alice hunter2!"),
+            Some(Command::RegisterOneShot {
+                username: "alice".to_owned(),
+                password: "hunter2!".to_owned(),
+            })
+        );
+        // Password may contain spaces (passphrase-friendly).
+        assert_eq!(
+            cmd("register alice my pass phrase"),
+            Some(Command::RegisterOneShot {
+                username: "alice".to_owned(),
+                password: "my pass phrase".to_owned(),
+            })
+        );
+    }
+
+    #[test]
+    fn login_with_password_is_one_shot() {
+        assert_eq!(
+            cmd("login bob s3cr3tpw"),
+            Some(Command::LoginOneShot {
+                username: Username::new("bob").unwrap(),
+                password: "s3cr3tpw".to_owned(),
+            })
+        );
+        // Bare login still starts the interactive flow.
+        assert_eq!(
+            cmd("login bob"),
+            Some(Command::Login {
+                username: Username::new("bob").unwrap()
             })
         );
     }

--- a/crates/bbs-mesh/tests/transport.rs
+++ b/crates/bbs-mesh/tests/transport.rs
@@ -767,3 +767,85 @@ async fn real_host_register_double_send_then_password() {
 
     transport.stop().await.unwrap();
 }
+
+/// Regression for the QA "logout-then-register" bug. A node logs out with `Q`,
+/// which ends its BBS session, but the transport still held the prefix →
+/// (now-dead) session mapping. The next `register` landed on the dead session,
+/// where `handle_register` fabricated a "choose a password" prompt WITHOUT
+/// storing the workflow (the session write silently no-opped on the missing
+/// session). The first password reply then hit `UnknownSession`, was reparsed
+/// with `awaiting_reply = false`, and fell through to the anonymous banner —
+/// exactly the over-the-air symptom QA reported. `handle_register` now returns
+/// `UnknownSession` on a missing session (mirroring `handle_login`, which is why
+/// interactive *login* never reproduced this), so the transport mints a fresh
+/// session, replays `REGISTER`, and the register→confirm flow survives the
+/// logout.
+#[tokio::test]
+async fn real_host_logout_then_register_prompt_reply_advances() {
+    let dbfile = tempfile::NamedTempFile::new().unwrap();
+    let db = bbs_core::Database::open(&dbfile.path().to_string_lossy())
+        .await
+        .unwrap();
+    let host: Arc<dyn bbs_plugin_api::Host> = Arc::new(bbs_core::BbsHost::new(db));
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let config = MeshConfig {
+        addr,
+        command_prefix: None,
+        welcome_message: String::new(),
+        reconnect_delay_initial_ms: 20,
+        reconnect_delay_max_ms: 50,
+        reply_max_attempts: 1,
+        ..MeshConfig::default()
+    };
+    let transport = MeshTransport::init(config, host).await.unwrap();
+    transport.start().await.unwrap();
+    let (stream, _) = listener.accept().await.unwrap();
+    let mut bridge = Bridge { stream };
+    bridge.complete_handshake("Node").await;
+
+    let sender = [0x99u8; 6];
+
+    // First contact establishes a session; `Q` immediately ends it. The host
+    // drops the session while the transport keeps the prefix → session mapping.
+    bridge.send(&contact_msg_frame(sender, "Q")).await;
+    let bye = tokio::time::timeout(Duration::from_secs(2), bridge.read_text_send())
+        .await
+        .expect("logout reply not sent");
+    let bye_text = String::from_utf8_lossy(&bye[13..]).to_string();
+    assert!(
+        bye_text.to_lowercase().contains("ended") || bye_text.to_lowercase().contains("goodbye"),
+        "expected a logout acknowledgement, got: {bye_text}"
+    );
+
+    // Register a new account on the SAME node after logout.
+    bridge
+        .send(&contact_msg_frame(sender, "register postlogout"))
+        .await;
+    let prompt = tokio::time::timeout(Duration::from_secs(2), bridge.read_text_send())
+        .await
+        .expect("register reply not sent");
+    let prompt_text = String::from_utf8_lossy(&prompt[13..]).to_string();
+    assert!(
+        prompt_text.to_lowercase().contains("password"),
+        "expected a password prompt after logout-then-register, got: {prompt_text}"
+    );
+
+    // The first password reply must advance to "Confirm", NOT the anonymous banner.
+    bridge.send(&contact_msg_frame(sender, "secretpw1")).await;
+    let reply = tokio::time::timeout(Duration::from_secs(2), bridge.read_text_send())
+        .await
+        .expect("password-reply response not sent");
+    let reply_text = String::from_utf8_lossy(&reply[13..]).to_string();
+    assert!(
+        !reply_text.contains("omit password to be prompted"),
+        "BUG: first password reply after logout dropped to the anonymous banner: {reply_text}"
+    );
+    assert!(
+        reply_text.to_lowercase().contains("confirm"),
+        "expected a confirm-password prompt, got: {reply_text}"
+    );
+
+    transport.stop().await.unwrap();
+}

--- a/crates/bbs-mesh/tests/transport.rs
+++ b/crates/bbs-mesh/tests/transport.rs
@@ -849,3 +849,104 @@ async fn real_host_logout_then_register_prompt_reply_advances() {
 
     transport.stop().await.unwrap();
 }
+
+/// End-to-end regression for the one-shot session-squash bug: after a node logs
+/// out (`Q`) the transport keeps its prefix → session mapping, so the next
+/// one-shot `LOGIN <user> <pw>` lands on the dead session. The host must surface
+/// `UnknownSession` so the transport refreshes to a live session — NOT report
+/// `LoggedIn` while writing nothing, which left every subsequent command failing
+/// with "Unknown session" / the anonymous banner.
+#[tokio::test]
+async fn real_host_oneshot_login_after_logout_yields_live_session() {
+    let dbfile = tempfile::NamedTempFile::new().unwrap();
+    let db = bbs_core::Database::open(&dbfile.path().to_string_lossy())
+        .await
+        .unwrap();
+    let host: Arc<dyn bbs_plugin_api::Host> = Arc::new(bbs_core::BbsHost::new(db));
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let config = MeshConfig {
+        addr,
+        command_prefix: None,
+        welcome_message: String::new(),
+        reconnect_delay_initial_ms: 20,
+        reconnect_delay_max_ms: 50,
+        reply_max_attempts: 1,
+        ..MeshConfig::default()
+    };
+    let transport = MeshTransport::init(config, host).await.unwrap();
+    transport.start().await.unwrap();
+    let (stream, _) = listener.accept().await.unwrap();
+    let mut bridge = Bridge { stream };
+    bridge.complete_handshake("Node").await;
+
+    let sender = [0x9Au8; 6];
+
+    // Read the next text-send frame body, or None on a short timeout. The host
+    // emits async sysop notifications (e.g. "New registration: …") on the same
+    // bridge, so callers skip frames by content rather than by position.
+    async fn next_text(bridge: &mut Bridge) -> Option<String> {
+        tokio::time::timeout(Duration::from_secs(2), bridge.read_text_send())
+            .await
+            .ok()
+            .map(|f| String::from_utf8_lossy(&f[13..]).to_string())
+    }
+    // Drain frames until one contains `want` (case-insensitive); panics on timeout.
+    async fn expect_text_containing(bridge: &mut Bridge, want: &str) -> String {
+        loop {
+            let t = next_text(bridge)
+                .await
+                .unwrap_or_else(|| panic!("expected a frame containing {want:?}; timed out"));
+            if t.to_lowercase().contains(&want.to_lowercase()) {
+                return t;
+            }
+        }
+    }
+
+    // One-shot register creates the account and logs in (first user → Sysop).
+    bridge
+        .send(&contact_msg_frame(sender, "register squashed secretpw1"))
+        .await;
+    expect_text_containing(&mut bridge, "welcome").await;
+
+    // Log out — host drops the session; transport keeps the prefix mapping.
+    bridge.send(&contact_msg_frame(sender, "Q")).await;
+    expect_text_containing(&mut bridge, "ended").await;
+
+    // One-shot login on the SAME node after logout (the squash trigger). With
+    // the bug this returned LoggedIn against the dead session (welcome shown)
+    // but wrote nothing; the fix surfaces UnknownSession so the transport
+    // refreshes to a live session before replaying the login.
+    bridge
+        .send(&contact_msg_frame(sender, "login squashed secretpw1"))
+        .await;
+    expect_text_containing(&mut bridge, "welcome").await;
+
+    // The decisive check: the NEXT command must hit a LIVE, authenticated
+    // session. Accept whichever outcome frame arrives (skipping async
+    // notifications) and assert it reports the logged-in user — NOT "Unknown
+    // session" and NOT the anonymous register/login banner.
+    bridge.send(&contact_msg_frame(sender, "whoami")).await;
+    let mut who_text = String::new();
+    for _ in 0..8 {
+        let Some(t) = next_text(&mut bridge).await else {
+            break;
+        };
+        let lower = t.to_lowercase();
+        if lower.contains("logged in as")
+            || lower.contains("unknown session")
+            || lower.contains("not logged in")
+            || lower.contains("register <user>")
+        {
+            who_text = t;
+            break;
+        }
+    }
+    assert!(
+        who_text.contains("Logged in as squashed"),
+        "BUG: session squashed after one-shot login — whoami got: {who_text:?}"
+    );
+
+    transport.stop().await.unwrap();
+}

--- a/crates/bbs-mesh/tests/transport.rs
+++ b/crates/bbs-mesh/tests/transport.rs
@@ -640,3 +640,130 @@ async fn confirmed_reply_is_not_retransmitted() {
 
     transport.stop().await.unwrap();
 }
+
+/// Reproduction harness: drive a **real** `BbsHost` (temp DB) through the bridge,
+/// so transport `awaiting_reply` ↔ host workflow ↔ session interactions are
+/// exercised end-to-end (MockHost can't model them). Regression for the QA bug
+/// where the first reply to the interactive "choose a password" prompt was
+/// dropped to the anonymous banner.
+#[tokio::test]
+async fn real_host_interactive_register_prompt_reply_advances() {
+    let dbfile = tempfile::NamedTempFile::new().unwrap();
+    let db = bbs_core::Database::open(&dbfile.path().to_string_lossy())
+        .await
+        .unwrap();
+    let host: Arc<dyn bbs_plugin_api::Host> = Arc::new(bbs_core::BbsHost::new(db));
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let config = MeshConfig {
+        addr,
+        command_prefix: None,
+        welcome_message: String::new(),
+        reconnect_delay_initial_ms: 20,
+        reconnect_delay_max_ms: 50,
+        reply_max_attempts: 1, // disable retransmission noise for this test
+        ..MeshConfig::default()
+    };
+    let transport = MeshTransport::init(config, host).await.unwrap();
+    transport.start().await.unwrap();
+    let (stream, _) = listener.accept().await.unwrap();
+    let mut bridge = Bridge { stream };
+    bridge.complete_handshake("Node").await;
+
+    let sender = [0x77u8; 6];
+
+    // First contact from a brand-new node: interactive register.
+    bridge
+        .send(&contact_msg_frame(sender, "register alice2"))
+        .await;
+    let prompt = tokio::time::timeout(Duration::from_secs(2), bridge.read_text_send())
+        .await
+        .expect("register reply not sent");
+    let prompt_text = String::from_utf8_lossy(&prompt[13..]).to_string();
+    assert!(
+        prompt_text.to_lowercase().contains("password"),
+        "expected a password prompt, got: {prompt_text}"
+    );
+
+    // Reply with the password — must advance to "Confirm", NOT fall back to the
+    // anonymous banner.
+    bridge.send(&contact_msg_frame(sender, "secretpw1")).await;
+    let reply = tokio::time::timeout(Duration::from_secs(2), bridge.read_text_send())
+        .await
+        .expect("password-reply response not sent");
+    let reply_text = String::from_utf8_lossy(&reply[13..]).to_string();
+    assert!(
+        !reply_text.contains("omit password to be prompted"),
+        "BUG: first password reply was dropped to the anonymous banner: {reply_text}"
+    );
+    assert!(
+        reply_text.to_lowercase().contains("confirm"),
+        "expected a confirm-password prompt, got: {reply_text}"
+    );
+
+    transport.stop().await.unwrap();
+}
+
+/// QA noted the MeshCore client re-sends messages (flaky automation). Reproduce
+/// the interactive register flow where the triggering command arrives TWICE
+/// before the password, exercising the dedup / awaiting / auth_escape path on a
+/// real host — the first password reply must still reach the Confirm step.
+#[tokio::test]
+async fn real_host_register_double_send_then_password() {
+    let dbfile = tempfile::NamedTempFile::new().unwrap();
+    let db = bbs_core::Database::open(&dbfile.path().to_string_lossy())
+        .await
+        .unwrap();
+    let host: Arc<dyn bbs_plugin_api::Host> = Arc::new(bbs_core::BbsHost::new(db));
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let config = MeshConfig {
+        addr,
+        command_prefix: None,
+        welcome_message: String::new(),
+        reconnect_delay_initial_ms: 20,
+        reconnect_delay_max_ms: 50,
+        reply_max_attempts: 1,
+        ..MeshConfig::default()
+    };
+    let transport = MeshTransport::init(config, host).await.unwrap();
+    transport.start().await.unwrap();
+    let (stream, _) = listener.accept().await.unwrap();
+    let mut bridge = Bridge { stream };
+    bridge.complete_handshake("Node").await;
+
+    let sender = [0x88u8; 6];
+
+    // The flaky client sends REGISTER twice in quick succession.
+    bridge
+        .send(&contact_msg_frame(sender, "register dupe"))
+        .await;
+    let _ = tokio::time::timeout(Duration::from_secs(2), bridge.read_text_send())
+        .await
+        .expect("first register reply");
+    bridge
+        .send(&contact_msg_frame(sender, "register dupe"))
+        .await;
+    // Second copy may or may not produce a frame depending on dedup; drain with a
+    // short timeout so we don't block.
+    let _ = tokio::time::timeout(Duration::from_millis(300), bridge.read_text_send()).await;
+
+    // Now the password.
+    bridge.send(&contact_msg_frame(sender, "secretpw1")).await;
+    let reply = tokio::time::timeout(Duration::from_secs(2), bridge.read_text_send())
+        .await
+        .expect("password-reply response");
+    let reply_text = String::from_utf8_lossy(&reply[13..]).to_string();
+    assert!(
+        !reply_text.contains("omit password to be prompted"),
+        "BUG: password reply dropped to the anonymous banner after double-send: {reply_text}"
+    );
+    assert!(
+        reply_text.to_lowercase().contains("confirm"),
+        "expected confirm-password prompt, got: {reply_text}"
+    );
+
+    transport.stop().await.unwrap();
+}

--- a/crates/bbs-meshtastic/src/command.rs
+++ b/crates/bbs-meshtastic/src/command.rs
@@ -36,16 +36,44 @@ pub fn parse_command(text: &str, prefix: Option<char>, awaiting_reply: bool) -> 
         "h" | "help" | "?" => Some(Command::Help {
             topic: rest.map(str::to_owned),
         }),
+        // `register <user>` → interactive; `register <user> <password>` → one-shot.
         "register" => match rest {
-            Some(name) if !name.is_empty() => Some(Command::Register {
-                username: name.to_owned(),
-            }),
-            _ => Some(Command::Help {
+            Some(r) => {
+                let (name, password) = split_first_word(r);
+                if name.is_empty() {
+                    Some(Command::Help {
+                        topic: Some("register".to_owned()),
+                    })
+                } else if let Some(password) = password {
+                    Some(Command::RegisterOneShot {
+                        username: name.to_owned(),
+                        password: password.to_owned(),
+                    })
+                } else {
+                    Some(Command::Register {
+                        username: name.to_owned(),
+                    })
+                }
+            }
+            None => Some(Command::Help {
                 topic: Some("register".to_owned()),
             }),
         },
-        "login" => match rest.and_then(|s| Username::new(s).ok()) {
-            Some(username) => Some(Command::Login { username }),
+        // `login <user>` → interactive; `login <user> <password>` → one-shot.
+        "login" => match rest {
+            Some(r) => {
+                let (name, password) = split_first_word(r);
+                match (Username::new(name).ok(), password) {
+                    (Some(username), Some(password)) => Some(Command::LoginOneShot {
+                        username,
+                        password: password.to_owned(),
+                    }),
+                    (Some(username), None) => Some(Command::Login { username }),
+                    (None, _) => Some(Command::Help {
+                        topic: Some("login".to_owned()),
+                    }),
+                }
+            }
             None => Some(Command::Help {
                 topic: Some("login".to_owned()),
             }),

--- a/crates/bbs-meshtastic/src/command.rs
+++ b/crates/bbs-meshtastic/src/command.rs
@@ -47,7 +47,7 @@ pub fn parse_command(text: &str, prefix: Option<char>, awaiting_reply: bool) -> 
                 } else if let Some(password) = password {
                     Some(Command::RegisterOneShot {
                         username: name.to_owned(),
-                        password: password.to_owned(),
+                        password: password.into(),
                     })
                 } else {
                     Some(Command::Register {
@@ -66,7 +66,7 @@ pub fn parse_command(text: &str, prefix: Option<char>, awaiting_reply: bool) -> 
                 match (Username::new(name).ok(), password) {
                     (Some(username), Some(password)) => Some(Command::LoginOneShot {
                         username,
-                        password: password.to_owned(),
+                        password: password.into(),
                     }),
                     (Some(username), None) => Some(Command::Login { username }),
                     (None, _) => Some(Command::Help {

--- a/crates/bbs-plugin-api/src/command.rs
+++ b/crates/bbs-plugin-api/src/command.rs
@@ -408,46 +408,21 @@ impl Command {
             "h" | "help" | "?" => Command::Help {
                 topic: rest.map(str::to_owned),
             },
-            // `register <user>` → interactive; `register <user> <password>` →
-            // one-shot (account created + logged in from one message). The host
-            // validates the username (#128) and password.
+            // One-shot auth (`register <user> <password>`) is a *radio-transport*
+            // feature for lossy multi-hop links; the canonical/CLI parser keeps
+            // the interactive flow (input is hidden at the prompt over the CLI).
             "register" => match rest {
-                Some(r) => {
-                    let (name, password) = split_first_word(r);
-                    if name.is_empty() {
-                        Command::Help {
-                            topic: Some("register".to_owned()),
-                        }
-                    } else if let Some(password) = password {
-                        Command::RegisterOneShot {
-                            username: name.to_owned(),
-                            password: password.to_owned(),
-                        }
-                    } else {
-                        Command::Register {
-                            username: name.to_owned(),
-                        }
-                    }
-                }
-                None => Command::Help {
+                // Pass the raw username through; the host validates it and
+                // reports a specific error (#128). Bare `register` → help.
+                Some(name) if !name.is_empty() => Command::Register {
+                    username: name.to_owned(),
+                },
+                _ => Command::Help {
                     topic: Some("register".to_owned()),
                 },
             },
-            // `login <user>` → interactive; `login <user> <password>` → one-shot.
-            "login" => match rest {
-                Some(r) => {
-                    let (name, password) = split_first_word(r);
-                    match (Username::new(name).ok(), password) {
-                        (Some(u), Some(password)) => Command::LoginOneShot {
-                            username: u,
-                            password: password.to_owned(),
-                        },
-                        (Some(u), None) => Command::Login { username: u },
-                        (None, _) => Command::Help {
-                            topic: Some("login".to_owned()),
-                        },
-                    }
-                }
+            "login" => match rest.and_then(|s| Username::new(s).ok()) {
+                Some(u) => Command::Login { username: u },
                 None => Command::Help {
                     topic: Some("login".to_owned()),
                 },
@@ -681,6 +656,22 @@ mod tests {
         assert!(matches!(
             Command::parse("i", false),
             Command::Unknown { .. }
+        ));
+    }
+
+    #[test]
+    fn canonical_parser_does_not_one_shot() {
+        // One-shot auth (`register <user> <password>`) is a radio-transport
+        // feature; the canonical/CLI parser keeps the interactive flow. The
+        // remainder is forwarded as a (host-rejected) raw username, never a
+        // RegisterOneShot/LoginOneShot.
+        assert!(matches!(
+            Command::parse("register alice hunter2pass", false),
+            Command::Register { .. }
+        ));
+        assert!(matches!(
+            Command::parse("login alice hunter2pass", false),
+            Command::Login { .. } | Command::Help { .. }
         ));
     }
 

--- a/crates/bbs-plugin-api/src/command.rs
+++ b/crates/bbs-plugin-api/src/command.rs
@@ -67,6 +67,30 @@ pub enum Command {
         username: Username,
     },
 
+    /// One-shot registration from a single message (`REGISTER <user> <password>`):
+    /// create the account and log in with no password prompt or confirmation
+    /// round-trips. Prototype for lossy multi-hop links, where each extra
+    /// round-trip sharply lowers end-to-end success. The password is taken
+    /// verbatim (may contain spaces); the host validates the username and
+    /// password length.
+    RegisterOneShot {
+        /// Desired username, as typed (raw); validated by the host.
+        username: String,
+        /// Chosen password, verbatim.
+        password: String,
+    },
+
+    /// One-shot login from a single message (`LOGIN <user> <password>`): no
+    /// password prompt. If the account was reset to a temporary password and
+    /// must change it, login still drops into the interactive change-password
+    /// prompt (that step can't be collapsed).
+    LoginOneShot {
+        /// The username being logged into.
+        username: Username,
+        /// Supplied password, verbatim.
+        password: String,
+    },
+
     /// End the session.
     Logout,
 
@@ -384,18 +408,46 @@ impl Command {
             "h" | "help" | "?" => Command::Help {
                 topic: rest.map(str::to_owned),
             },
+            // `register <user>` → interactive; `register <user> <password>` →
+            // one-shot (account created + logged in from one message). The host
+            // validates the username (#128) and password.
             "register" => match rest {
-                // Pass the raw username through; the host validates it and
-                // reports a specific error (#128). Bare `register` → help.
-                Some(name) if !name.is_empty() => Command::Register {
-                    username: name.to_owned(),
-                },
-                _ => Command::Help {
+                Some(r) => {
+                    let (name, password) = split_first_word(r);
+                    if name.is_empty() {
+                        Command::Help {
+                            topic: Some("register".to_owned()),
+                        }
+                    } else if let Some(password) = password {
+                        Command::RegisterOneShot {
+                            username: name.to_owned(),
+                            password: password.to_owned(),
+                        }
+                    } else {
+                        Command::Register {
+                            username: name.to_owned(),
+                        }
+                    }
+                }
+                None => Command::Help {
                     topic: Some("register".to_owned()),
                 },
             },
-            "login" => match rest.and_then(|s| Username::new(s).ok()) {
-                Some(u) => Command::Login { username: u },
+            // `login <user>` → interactive; `login <user> <password>` → one-shot.
+            "login" => match rest {
+                Some(r) => {
+                    let (name, password) = split_first_word(r);
+                    match (Username::new(name).ok(), password) {
+                        (Some(u), Some(password)) => Command::LoginOneShot {
+                            username: u,
+                            password: password.to_owned(),
+                        },
+                        (Some(u), None) => Command::Login { username: u },
+                        (None, _) => Command::Help {
+                            topic: Some("login".to_owned()),
+                        },
+                    }
+                }
                 None => Command::Help {
                     topic: Some("login".to_owned()),
                 },

--- a/crates/bbs-plugin-api/src/command.rs
+++ b/crates/bbs-plugin-api/src/command.rs
@@ -27,6 +27,45 @@ use crate::identity::Username;
 use crate::permissions::PermissionLevel;
 use serde::{Deserialize, Serialize};
 
+/// A secret string carried inside a [`Command`] (currently a one-shot password).
+///
+/// `Command` derives `Debug` and is logged at `debug` level on the hot path, so
+/// a one-shot password must **not** be a plain `String`. `Secret`'s `Debug`
+/// prints `<redacted>`, so the plaintext can never reach a log via `?cmd`.
+///
+/// `Serialize`/`Deserialize` are transparent (the wire form is the raw string)
+/// so the enum still round-trips across the process transport; only `Debug` is
+/// redacted. Call [`Secret::expose`] only where the plaintext is genuinely
+/// required (hashing/verifying) and never log the result.
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct Secret(String);
+
+impl Secret {
+    /// Borrow the plaintext. Use only for hashing/verification; never log it.
+    pub fn expose(&self) -> &str {
+        &self.0
+    }
+}
+
+impl std::fmt::Debug for Secret {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("<redacted>")
+    }
+}
+
+impl From<String> for Secret {
+    fn from(s: String) -> Self {
+        Secret(s)
+    }
+}
+
+impl From<&str> for Secret {
+    fn from(s: &str) -> Self {
+        Secret(s.to_owned())
+    }
+}
+
 // ── Parsing helpers (private) ─────────────────────────────────────────────────
 
 fn split_first_word(s: &str) -> (&str, Option<&str>) {
@@ -76,8 +115,8 @@ pub enum Command {
     RegisterOneShot {
         /// Desired username, as typed (raw); validated by the host.
         username: String,
-        /// Chosen password, verbatim.
-        password: String,
+        /// Chosen password, verbatim (redacted in `Debug`/logs).
+        password: Secret,
     },
 
     /// One-shot login from a single message (`LOGIN <user> <password>`): no
@@ -87,8 +126,8 @@ pub enum Command {
     LoginOneShot {
         /// The username being logged into.
         username: Username,
-        /// Supplied password, verbatim.
-        password: String,
+        /// Supplied password, verbatim (redacted in `Debug`/logs).
+        password: Secret,
     },
 
     /// End the session.
@@ -657,6 +696,34 @@ mod tests {
             Command::parse("i", false),
             Command::Unknown { .. }
         ));
+    }
+
+    #[test]
+    fn one_shot_password_is_redacted_in_debug() {
+        // Command derives Debug and is logged at debug level on the hot path, so
+        // a one-shot password must never appear in its Debug output.
+        let login = Command::LoginOneShot {
+            username: Username::new("alice").unwrap(),
+            password: "supersecretpw".into(),
+        };
+        let dbg = format!("{login:?}");
+        assert!(
+            !dbg.contains("supersecretpw"),
+            "password leaked into Debug: {dbg}"
+        );
+        assert!(
+            dbg.contains("redacted"),
+            "expected a redaction marker: {dbg}"
+        );
+
+        let register = Command::RegisterOneShot {
+            username: "bob".into(),
+            password: "hunter2pass".into(),
+        };
+        assert!(
+            !format!("{register:?}").contains("hunter2pass"),
+            "register password leaked into Debug"
+        );
     }
 
     #[test]

--- a/crates/bbs-plugin-api/src/lib.rs
+++ b/crates/bbs-plugin-api/src/lib.rs
@@ -56,7 +56,7 @@ pub use admin::{
     MeshtasticDeviceSnapshot, MeshtasticLoRaConfig, MeshtasticOwnerInfo, MeshtasticSecurityInfo,
 };
 pub use advert::{AdvertBus, AdvertRecord};
-pub use command::{Command, Response};
+pub use command::{Command, Response, Secret};
 pub use error::{HostError, PluginError, TransportError};
 pub use event::{DomainEvent, MessageRecipient, Notification, NotifyOutcome};
 pub use host::{Host, MeshKeyRequest, MeshtasticAdminRequest};

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -78,9 +78,10 @@ REGISTER alice
 - Case-insensitive at login (stored exactly as typed)
 - The names `bbs` and `system` are reserved and cannot be registered
 
-### One message (recommended on radio)
+### One message (radio only)
 
-Register in a **single message** by including a password after the username:
+On a **radio transport** (MeshCore or Meshtastic) you can register in a **single
+message** by including a password after the username:
 
 ```
 REGISTER alice hunter2pass
@@ -90,6 +91,9 @@ This creates the account and logs you straight in — no back-and-forth prompts.
 On a multi-hop mesh link every extra round-trip is another chance for a message
 to be lost, so the one-message form is far more reliable over radio. The password
 is everything after the username, so it may contain spaces (a passphrase works).
+
+This one-message form is offered only on the radio transports. Over the CLI
+socket, use the step-by-step flow below (where password input is hidden).
 
 > **Heads-up:** the password travels in that message, so it is visible over the
 > air (and in your client's sent history) — the same as typing a password at a
@@ -143,10 +147,10 @@ messages or read rooms.
 
 ### Logging in
 
-Like registration, login works in **one message** (recommended on radio) or
+Like registration, login works in **one message** (radio transports only) or
 step by step.
 
-**One message:**
+**One message (radio only):**
 
 ```
 LOGIN alice hunter2pass

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -78,10 +78,32 @@ REGISTER alice
 - Case-insensitive at login (stored exactly as typed)
 - The names `bbs` and `system` are reserved and cannot be registered
 
-The BBS then prompts for a password and a confirmation — two short steps,
-each naming the account so you always know where you are:
+### One message (recommended on radio)
+
+Register in a **single message** by including a password after the username:
 
 ```
+REGISTER alice hunter2pass
+```
+
+This creates the account and logs you straight in — no back-and-forth prompts.
+On a multi-hop mesh link every extra round-trip is another chance for a message
+to be lost, so the one-message form is far more reliable over radio. The password
+is everything after the username, so it may contain spaces (a passphrase works).
+
+> **Heads-up:** the password travels in that message, so it is visible over the
+> air (and in your client's sent history) — the same as typing a password at a
+> prompt on radio. Use something you don't reuse elsewhere. There is no
+> confirmation step, so type it carefully.
+
+### Step by step (password not on the command line)
+
+Send just the username and the BBS walks you through a password and a
+confirmation — two short steps, each naming the account so you always know where
+you are:
+
+```
+REGISTER alice
 Registering 'alice'. Choose a password (min 8 characters):
 > ••••••••
 
@@ -121,19 +143,32 @@ messages or read rooms.
 
 ### Logging in
 
+Like registration, login works in **one message** (recommended on radio) or
+step by step.
+
+**One message:**
+
+```
+LOGIN alice hunter2pass
+```
+
+Logs you straight in — no prompt round-trip. The same heads-up applies: the
+password is visible over the air.
+
+**Step by step** — send just the username and you'll be prompted (input is
+hidden on supporting clients):
+
 ```
 LOGIN alice
-```
-
-You'll be prompted for your password (input is hidden on supporting clients):
-
-```
 Enter the password for 'alice':
 > ••••••••
 ```
 
 After three wrong attempts the login workflow is cancelled and you must type
 `LOGIN <username>` again to retry.
+
+> If an operator reset your account to a temporary password, one-message login
+> still drops into a "choose a new password" prompt — that step can't be skipped.
 
 ### Logging out
 


### PR DESCRIPTION
**Prototype — left unmerged for review/QA.** First cut of the one-shot command model we discussed for multi-hop reliability.

## Why
Interactive, multi-round-trip auth is the worst fit for a lossy mesh: end-to-end success decays ~`p^(2N)` *per round trip*, and a 3-step registration over 3 hops is single-digit percent before retries. Collapsing register/login to **one message** turns a ~3-round-trip flow into one (~5% → ~38% at 3 hops, before retries).

## What
- `REGISTER <user> <password>` → create account + log in, no prompts.
- `LOGIN <user> <password>` → authenticate + log in, no prompt.
- `REGISTER <user>` / `LOGIN <user>` (no password) → the **existing interactive flow**, unchanged.
- Password is the message remainder, so it may contain spaces (passphrase-friendly).
- A temp-password account (`.PW` reset) logging in one-shot still drops into the forced change-password prompt — that step can't collapse.
- The lost-prompt command-escape understands one-shot: a re-sent `REGISTER <u> <pw>` mid-flow restarts as one-shot.

## Radio-only (resolved)
One-shot is gated to the **radio transports** (MeshCore/Meshtastic):
- The **CLI** parser is unchanged — its prompt input is hidden, so there's no reliability/visibility win; it keeps the interactive flow. (`canonical_parser_does_not_one_shot` guards this.)
- The **web admin** has no text-command user-add path, so it's unaffected.
- Gating lives at the parser (only radio parsers emit the variants); the host handles them transport-agnostically. Help is transport-aware (`session_on_radio`): radio sees the one-shot banner, CLI sees the generic one.

## Design notes for reviewers
- **New variants `RegisterOneShot`/`LoginOneShot`** rather than a field on `Register`/`Login` — keeps the interactive flow and its ~35 call sites untouched and makes the prototype trivially revertible. If promoted, folding to an optional-password field is a clean follow-up.
- Refactored shared logic out of the workflow arms into `create_user_and_login` and `record_login_failure` (**top review item** — verify the interactive path is behaviourally unchanged; existing tests cover it).

## Tradeoff still worth a look
- **No confirmation step** — a single message can't be typo-confirmed. Typo → can't log in → re-register or sysop reset. (Password visibility is moot now that it's radio-only.)

## Tests
Radio parser one-shot tests + `canonical_parser_does_not_one_shot`; host tests (create+login, short-password reject, login success/wrong-password, escape-to-one-shot); `auth_escape` password parsing; help byte-size includes the radio banner. Full `fmt`/`clippy -D warnings`/`test --workspace` green; VitePress builds clean.

The real evaluation is over-the-air: does collapsing the round-trips visibly improve multi-hop success? That's the QA ask (see the accompanying QA + reviewer guide).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #149
