### PR TITLE
feat(mesh): reply-delivery link-health metrics (counters, per-node, latency, trend, persistence)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -296,6 +296,7 @@ dependencies = [
  "bbs-plugin-api",
  "meshcore-companion",
  "serde",
+ "serde_json",
  "tempfile",
  "thiserror 1.0.69",
  "tokio",

--- a/crates/bbs-core/migrations/0012_delivery_samples.sql
+++ b/crates/bbs-core/migrations/0012_delivery_samples.sql
@@ -1,0 +1,27 @@
+-- Durable reply-delivery metric samples for transports (mesh link health).
+--
+-- The mesh transport snapshots its cumulative delivery counters once a minute.
+-- Persisting them here lets the admin UI keep its confirm-rate trend across a
+-- restart or redeploy — which is exactly when an operator wants to compare
+-- before/after a change (antenna, placement, radio params, retry budget).
+--
+-- transport       : transport name the sample belongs to (e.g. "meshcore").
+-- ts              : Unix timestamp (seconds) the sample was taken.
+-- The remaining columns are cumulative-since-process-start counters; consumers
+-- derive per-interval rates from the deltas between consecutive samples.
+
+CREATE TABLE IF NOT EXISTS delivery_samples (
+    id              INTEGER PRIMARY KEY AUTOINCREMENT,
+    transport       TEXT    NOT NULL,
+    ts              INTEGER NOT NULL,
+    sends_total     INTEGER NOT NULL,
+    accepted        INTEGER NOT NULL,
+    failed_no_route INTEGER NOT NULL,
+    confirmed       INTEGER NOT NULL,
+    latency_count   INTEGER NOT NULL,
+    latency_sum_ms  INTEGER NOT NULL
+);
+
+-- Reads are always "this transport, samples at/after a cutoff, in time order".
+CREATE INDEX IF NOT EXISTS idx_delivery_samples_transport_ts
+    ON delivery_samples (transport, ts);

--- a/crates/bbs-core/migrations/0013_delivery_samples_retransmits.sql
+++ b/crates/bbs-core/migrations/0013_delivery_samples_retransmits.sql
@@ -1,0 +1,11 @@
+-- Add a retransmits column to delivery_samples.
+--
+-- The confirm-rate trend must be per reply, not per transmission: its
+-- denominator is first sends (= sends_total − retransmits), not the cumulative
+-- accepted count (which includes every retransmission). Persisting retransmits
+-- lets the /history consumer derive first sends per interval after a restart.
+--
+-- Additive: existing rows (if any) default to 0, which slightly understates
+-- first-send deltas for pre-upgrade samples only.
+
+ALTER TABLE delivery_samples ADD COLUMN retransmits INTEGER NOT NULL DEFAULT 0;

--- a/crates/bbs-core/src/db/delivery_store.rs
+++ b/crates/bbs-core/src/db/delivery_store.rs
@@ -26,13 +26,14 @@ impl Database {
     ) -> Result<(), StoreError> {
         sqlx::query(
             "INSERT INTO delivery_samples \
-             (transport, ts, sends_total, accepted, failed_no_route, confirmed, \
+             (transport, ts, sends_total, retransmits, accepted, failed_no_route, confirmed, \
               latency_count, latency_sum_ms) \
-             VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
         )
         .bind(transport)
         .bind(s.ts as i64)
         .bind(s.sends_total as i64)
+        .bind(s.retransmits as i64)
         .bind(s.accepted as i64)
         .bind(s.failed_no_route as i64)
         .bind(s.confirmed as i64)
@@ -58,7 +59,7 @@ impl Database {
         since: u64,
     ) -> Result<Vec<DeliverySampleRecord>, StoreError> {
         let rows = sqlx::query(
-            "SELECT ts, sends_total, accepted, failed_no_route, confirmed, \
+            "SELECT ts, sends_total, retransmits, accepted, failed_no_route, confirmed, \
                     latency_count, latency_sum_ms \
              FROM delivery_samples \
              WHERE transport = ? AND ts >= ? \
@@ -74,6 +75,7 @@ impl Database {
                 Ok(DeliverySampleRecord {
                     ts: r.try_get::<i64, _>("ts")? as u64,
                     sends_total: r.try_get::<i64, _>("sends_total")? as u64,
+                    retransmits: r.try_get::<i64, _>("retransmits")? as u64,
                     accepted: r.try_get::<i64, _>("accepted")? as u64,
                     failed_no_route: r.try_get::<i64, _>("failed_no_route")? as u64,
                     confirmed: r.try_get::<i64, _>("confirmed")? as u64,
@@ -101,6 +103,7 @@ mod tests {
         DeliverySampleRecord {
             ts,
             sends_total: ts,
+            retransmits: ts / 10,
             accepted: ts,
             failed_no_route: 0,
             confirmed: ts,
@@ -126,6 +129,7 @@ mod tests {
         assert_eq!(all.len(), 2);
         assert_eq!(all[0].ts, 1000, "oldest first");
         assert_eq!(all[1].ts, 1060);
+        assert_eq!(all[1].retransmits, 106, "retransmits column round-trips");
         assert_eq!(
             all[1].confirmed, 1060,
             "u64 round-trips through i64 columns"

--- a/crates/bbs-core/src/db/delivery_store.rs
+++ b/crates/bbs-core/src/db/delivery_store.rs
@@ -1,0 +1,158 @@
+//! Persistence for transport delivery-metric samples (mesh link-health trends).
+//!
+//! The mesh transport snapshots its cumulative delivery counters once a minute
+//! and [`Database::delivery_sample_write`] appends them here, pruning rows older
+//! than the retention window so the table stays bounded.
+//! [`Database::delivery_samples_query`] returns a transport's recent samples to
+//! seed the in-memory trend on startup.
+
+use super::{error::StoreError, Database};
+use bbs_plugin_api::DeliverySampleRecord;
+use sqlx::Row;
+
+/// How long delivery samples are retained. Pruned on each write so the table
+/// never grows without bound (one row per minute per transport otherwise).
+const RETENTION_SECS: u64 = 7 * 24 * 60 * 60;
+
+// async_trait rewrites async fn bodies; Clippy's dead_code pass misses these.
+#[allow(dead_code)]
+impl Database {
+    /// Append one delivery sample for `transport`, then prune samples older than
+    /// the retention window (relative to this sample's timestamp).
+    pub(crate) async fn delivery_sample_write(
+        &self,
+        transport: &str,
+        s: &DeliverySampleRecord,
+    ) -> Result<(), StoreError> {
+        sqlx::query(
+            "INSERT INTO delivery_samples \
+             (transport, ts, sends_total, accepted, failed_no_route, confirmed, \
+              latency_count, latency_sum_ms) \
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+        )
+        .bind(transport)
+        .bind(s.ts as i64)
+        .bind(s.sends_total as i64)
+        .bind(s.accepted as i64)
+        .bind(s.failed_no_route as i64)
+        .bind(s.confirmed as i64)
+        .bind(s.latency_count as i64)
+        .bind(s.latency_sum_ms as i64)
+        .execute(&self.write_pool)
+        .await?;
+
+        let cutoff = s.ts.saturating_sub(RETENTION_SECS) as i64;
+        sqlx::query("DELETE FROM delivery_samples WHERE transport = ? AND ts < ?")
+            .bind(transport)
+            .bind(cutoff)
+            .execute(&self.write_pool)
+            .await?;
+        Ok(())
+    }
+
+    /// Return delivery samples for `transport` with `ts >= since` (Unix seconds),
+    /// oldest first.
+    pub(crate) async fn delivery_samples_query(
+        &self,
+        transport: &str,
+        since: u64,
+    ) -> Result<Vec<DeliverySampleRecord>, StoreError> {
+        let rows = sqlx::query(
+            "SELECT ts, sends_total, accepted, failed_no_route, confirmed, \
+                    latency_count, latency_sum_ms \
+             FROM delivery_samples \
+             WHERE transport = ? AND ts >= ? \
+             ORDER BY ts ASC",
+        )
+        .bind(transport)
+        .bind(since as i64)
+        .fetch_all(&self.read_pool)
+        .await?;
+
+        rows.into_iter()
+            .map(|r| {
+                Ok(DeliverySampleRecord {
+                    ts: r.try_get::<i64, _>("ts")? as u64,
+                    sends_total: r.try_get::<i64, _>("sends_total")? as u64,
+                    accepted: r.try_get::<i64, _>("accepted")? as u64,
+                    failed_no_route: r.try_get::<i64, _>("failed_no_route")? as u64,
+                    confirmed: r.try_get::<i64, _>("confirmed")? as u64,
+                    latency_count: r.try_get::<i64, _>("latency_count")? as u64,
+                    latency_sum_ms: r.try_get::<i64, _>("latency_sum_ms")? as u64,
+                })
+            })
+            .collect::<Result<Vec<_>, sqlx::Error>>()
+            .map_err(StoreError::Db)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    async fn test_db() -> (Database, tempfile::TempDir) {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("delivery.sqlite");
+        let db = Database::open(path.to_str().unwrap()).await.unwrap();
+        (db, dir)
+    }
+
+    fn rec(ts: u64) -> DeliverySampleRecord {
+        DeliverySampleRecord {
+            ts,
+            sends_total: ts,
+            accepted: ts,
+            failed_no_route: 0,
+            confirmed: ts,
+            latency_count: 1,
+            latency_sum_ms: 200,
+        }
+    }
+
+    #[tokio::test]
+    async fn write_query_round_trip_with_since_and_transport_isolation() {
+        let (db, _dir) = test_db().await;
+        db.delivery_sample_write("meshcore", &rec(1000))
+            .await
+            .unwrap();
+        db.delivery_sample_write("meshcore", &rec(1060))
+            .await
+            .unwrap();
+        db.delivery_sample_write("meshtastic", &rec(1060))
+            .await
+            .unwrap();
+
+        let all = db.delivery_samples_query("meshcore", 0).await.unwrap();
+        assert_eq!(all.len(), 2);
+        assert_eq!(all[0].ts, 1000, "oldest first");
+        assert_eq!(all[1].ts, 1060);
+        assert_eq!(
+            all[1].confirmed, 1060,
+            "u64 round-trips through i64 columns"
+        );
+
+        let recent = db.delivery_samples_query("meshcore", 1060).await.unwrap();
+        assert_eq!(recent.len(), 1, "since filter is inclusive");
+        assert_eq!(recent[0].ts, 1060);
+
+        let mt = db.delivery_samples_query("meshtastic", 0).await.unwrap();
+        assert_eq!(mt.len(), 1, "samples are isolated per transport");
+    }
+
+    #[tokio::test]
+    async fn retention_prunes_old_samples_on_write() {
+        let (db, _dir) = test_db().await;
+        db.delivery_sample_write("meshcore", &rec(1000))
+            .await
+            .unwrap();
+        // A sample more than the retention window later evicts the old one.
+        let future = 1000 + RETENTION_SECS + 60;
+        db.delivery_sample_write("meshcore", &rec(future))
+            .await
+            .unwrap();
+
+        let all = db.delivery_samples_query("meshcore", 0).await.unwrap();
+        assert_eq!(all.len(), 1);
+        assert_eq!(all[0].ts, future);
+    }
+}

--- a/crates/bbs-core/src/db/mod.rs
+++ b/crates/bbs-core/src/db/mod.rs
@@ -12,6 +12,7 @@ mod admin_queries;
 mod audit_store;
 mod block_store;
 mod credential_store;
+mod delivery_store;
 mod error;
 mod invariants;
 mod message_store;

--- a/crates/bbs-core/src/host.rs
+++ b/crates/bbs-core/src/host.rs
@@ -1316,6 +1316,28 @@ impl Host for BbsHost {
             .map_err(|e| HostError::Storage(format!("{e}")))
     }
 
+    async fn record_delivery_sample(
+        &self,
+        transport: &str,
+        sample: bbs_plugin_api::DeliverySampleRecord,
+    ) -> Result<(), HostError> {
+        self.db
+            .delivery_sample_write(transport, &sample)
+            .await
+            .map_err(|e| HostError::Storage(format!("{e}")))
+    }
+
+    async fn delivery_samples(
+        &self,
+        transport: &str,
+        since: u64,
+    ) -> Result<Vec<bbs_plugin_api::DeliverySampleRecord>, HostError> {
+        self.db
+            .delivery_samples_query(transport, since)
+            .await
+            .map_err(|e| HostError::Storage(format!("{e}")))
+    }
+
     async fn admin_trigger_backup(&self, backup_dir: &str) -> Result<AdminBackupRecord, HostError> {
         use time::format_description::well_known::Rfc3339;
 

--- a/crates/bbs-mesh/Cargo.toml
+++ b/crates/bbs-mesh/Cargo.toml
@@ -15,6 +15,7 @@ bbs-plugin-api.workspace     = true
 meshcore-companion.workspace = true
 async-trait.workspace = true
 serde.workspace       = true
+serde_json.workspace  = true
 thiserror.workspace   = true
 tracing.workspace     = true
 # sync (Mutex, watch) + rt (spawn) are the only extras we need on top of workspace defaults.

--- a/crates/bbs-mesh/src/lib.rs
+++ b/crates/bbs-mesh/src/lib.rs
@@ -55,6 +55,6 @@ pub mod session;
 pub mod transport;
 
 pub use config::{ConnectionType, MeshConfig};
-pub use metrics::{DeliveryStats, DeliveryStatsSnapshot};
+pub use metrics::{DeliverySample, DeliveryStats, DeliveryStatsSnapshot, NodeDeliverySnapshot};
 pub use session::{SessionEntry, SessionState};
 pub use transport::MeshTransport;

--- a/crates/bbs-mesh/src/lib.rs
+++ b/crates/bbs-mesh/src/lib.rs
@@ -49,10 +49,12 @@
 
 pub mod command;
 pub mod config;
+pub mod metrics;
 mod send_tracker;
 pub mod session;
 pub mod transport;
 
 pub use config::{ConnectionType, MeshConfig};
+pub use metrics::{DeliveryStats, DeliveryStatsSnapshot};
 pub use session::{SessionEntry, SessionState};
 pub use transport::MeshTransport;

--- a/crates/bbs-mesh/src/metrics.rs
+++ b/crates/bbs-mesh/src/metrics.rs
@@ -21,15 +21,62 @@
 //! persisted time-series for trend analysis is a separate, later layer — this
 //! module is the live snapshot only.
 
+use std::collections::HashMap;
 use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Mutex;
+use std::time::Instant;
 
 use bbs_plugin_api::TransportStats;
 use serde::Serialize;
 use serde_json::Value;
 
+/// Cap on the number of per-node delivery records kept in memory. When the map
+/// is full and a new node appears, the least-recently-active record is evicted —
+/// the operator cares about nodes currently exchanging traffic, not stale ones.
+const MAX_TRACKED_NODES: usize = 256;
+
+/// Cap on how many per-node records are serialised in a snapshot (worst-first).
+const MAX_NODES_IN_SNAPSHOT: usize = 50;
+
+/// Per-node delivery counters. Plain integers — guarded by the `nodes` mutex,
+/// not atomics, since they are only touched under that lock.
+#[derive(Debug, Default, Clone)]
+struct NodeCounters {
+    sends: u64,
+    accepted: u64,
+    failed_no_route: u64,
+    confirmed: u64,
+    gave_up: u64,
+    latency_count: u64,
+    latency_sum_ms: u64,
+    latency_min_ms: u64,
+    latency_max_ms: u64,
+}
+
+impl NodeCounters {
+    fn record_latency(&mut self, ms: u64) {
+        if self.latency_count == 0 || ms < self.latency_min_ms {
+            self.latency_min_ms = ms;
+        }
+        if ms > self.latency_max_ms {
+            self.latency_max_ms = ms;
+        }
+        self.latency_count += 1;
+        self.latency_sum_ms += ms;
+    }
+}
+
+/// A per-node record plus the last time it was touched (for stale eviction).
+#[derive(Debug)]
+struct NodeEntry {
+    counters: NodeCounters,
+    last_update: Instant,
+}
+
 /// Cumulative reply-delivery counters, updated from the transport's send path
-/// and inbound-frame handlers. Shared via `Arc`; all methods take `&self`
-/// (atomic, lock-free) so they can be called from any task without coordination.
+/// and inbound-frame handlers. Shared via `Arc`. The global counters are
+/// lock-free atomics; the per-node map is behind a short-lived mutex (mesh
+/// traffic is low-frequency, so contention is negligible).
 #[derive(Debug)]
 pub struct DeliveryStats {
     /// Outbound text frames handed to the companion client (first sends and
@@ -64,6 +111,9 @@ pub struct DeliveryStats {
     latency_min_ms: AtomicU64,
     /// Largest round-trip latency seen, in milliseconds.
     latency_max_ms: AtomicU64,
+    /// Per-destination delivery counters, keyed by 6-byte pubkey prefix. Bounded
+    /// at [`MAX_TRACKED_NODES`]; the stalest entry is evicted when full.
+    nodes: Mutex<HashMap<[u8; 6], NodeEntry>>,
 }
 
 impl Default for DeliveryStats {
@@ -81,19 +131,42 @@ impl Default for DeliveryStats {
             // Sentinel so the first recorded sample becomes the minimum.
             latency_min_ms: AtomicU64::new(u64::MAX),
             latency_max_ms: AtomicU64::new(0),
+            nodes: Mutex::new(HashMap::new()),
         }
     }
 }
 
 impl DeliveryStats {
-    /// Record an outbound text frame accepted by the command channel.
-    /// `attempt` is the 1-based transmission count (1 = first send); anything
-    /// greater is a retransmission.
-    pub fn on_send(&self, attempt: u8) {
+    /// Update one node's counters under the map lock, evicting the stalest entry
+    /// first if the map is full and this node is new.
+    fn with_node<F: FnOnce(&mut NodeCounters)>(&self, prefix: [u8; 6], f: F) {
+        let mut map = self.nodes.lock().expect("nodes mutex poisoned");
+        if !map.contains_key(&prefix) && map.len() >= MAX_TRACKED_NODES {
+            if let Some(stalest) = map
+                .iter()
+                .min_by_key(|(_, e)| e.last_update)
+                .map(|(k, _)| *k)
+            {
+                map.remove(&stalest);
+            }
+        }
+        let entry = map.entry(prefix).or_insert_with(|| NodeEntry {
+            counters: NodeCounters::default(),
+            last_update: Instant::now(),
+        });
+        f(&mut entry.counters);
+        entry.last_update = Instant::now();
+    }
+
+    /// Record an outbound text frame accepted by the command channel, addressed
+    /// to `prefix`. `attempt` is the 1-based transmission count (1 = first send);
+    /// anything greater is a retransmission.
+    pub fn on_send(&self, prefix: [u8; 6], attempt: u8) {
         self.sends_total.fetch_add(1, Ordering::Relaxed);
         if attempt > 1 {
             self.retransmits.fetch_add(1, Ordering::Relaxed);
         }
+        self.with_node(prefix, |c| c.sends += 1);
     }
 
     /// Record an outbound text frame dropped before the wire (channel full/closed).
@@ -101,8 +174,8 @@ impl DeliveryStats {
         self.dropped.fetch_add(1, Ordering::Relaxed);
     }
 
-    /// Record the device's `RESP_CODE_SENT` outcome: `accepted = true` when the
-    /// device queued the message, `false` for `MSG_SEND_FAILED` (no route).
+    /// Record the device's `RESP_CODE_SENT` outcome (global): `accepted = true`
+    /// when the device queued the message, `false` for `MSG_SEND_FAILED`.
     pub fn on_sent_result(&self, accepted: bool) {
         if accepted {
             self.accepted.fetch_add(1, Ordering::Relaxed);
@@ -111,14 +184,40 @@ impl DeliveryStats {
         }
     }
 
-    /// Record an end-to-end delivery confirmation.
+    /// Attribute a `RESP_CODE_SENT` outcome to a specific node. Driven by the
+    /// retransmission tracker's correlation, so it is only called when retries
+    /// are enabled (the global [`Self::on_sent_result`] is always called).
+    pub fn on_node_sent_result(&self, prefix: [u8; 6], accepted: bool) {
+        self.with_node(prefix, |c| {
+            if accepted {
+                c.accepted += 1;
+            } else {
+                c.failed_no_route += 1;
+            }
+        });
+    }
+
+    /// Record an end-to-end delivery confirmation (global).
     pub fn on_confirmed(&self) {
         self.confirmed.fetch_add(1, Ordering::Relaxed);
     }
 
-    /// Record a reply abandoned after exhausting its retransmission budget.
+    /// Attribute a confirmation and its round-trip latency to a specific node.
+    pub fn on_node_confirmed(&self, prefix: [u8; 6], latency_ms: u64) {
+        self.with_node(prefix, |c| {
+            c.confirmed += 1;
+            c.record_latency(latency_ms);
+        });
+    }
+
+    /// Record a reply abandoned after exhausting its retransmission budget (global).
     pub fn on_gave_up(&self) {
         self.gave_up.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Attribute a give-up to a specific node.
+    pub fn on_node_gave_up(&self, prefix: [u8; 6]) {
+        self.with_node(prefix, |c| c.gave_up += 1);
     }
 
     /// Record a round-trip latency sample (send → end-to-end confirmation), in
@@ -163,6 +262,8 @@ impl DeliveryStats {
         let max_latency_ms =
             (latency_count > 0).then(|| self.latency_max_ms.load(Ordering::Relaxed));
 
+        let (per_node, nodes_tracked) = self.node_snapshots();
+
         DeliveryStatsSnapshot {
             sends_total,
             retransmits,
@@ -177,7 +278,47 @@ impl DeliveryStats {
             avg_latency_ms,
             min_latency_ms,
             max_latency_ms,
+            nodes_tracked,
+            per_node,
         }
+    }
+
+    /// Build the per-node snapshot list, sorted worst-first (lowest confirm rate,
+    /// then highest volume) and capped at [`MAX_NODES_IN_SNAPSHOT`]. Returns the
+    /// capped list and the total number of nodes tracked.
+    fn node_snapshots(&self) -> (Vec<NodeDeliverySnapshot>, usize) {
+        let map = self.nodes.lock().expect("nodes mutex poisoned");
+        let total = map.len();
+        let mut rows: Vec<NodeDeliverySnapshot> = map
+            .iter()
+            .map(|(prefix, e)| {
+                let c = &e.counters;
+                let prefix_hex = prefix.iter().map(|b| format!("{b:02x}")).collect();
+                let avg_latency_ms =
+                    (c.latency_count > 0).then(|| c.latency_sum_ms as f64 / c.latency_count as f64);
+                NodeDeliverySnapshot {
+                    prefix: prefix_hex,
+                    sends: c.sends,
+                    accepted: c.accepted,
+                    failed_no_route: c.failed_no_route,
+                    confirmed: c.confirmed,
+                    gave_up: c.gave_up,
+                    confirm_rate: ratio(c.confirmed, c.accepted),
+                    avg_latency_ms,
+                }
+            })
+            .collect();
+        // Worst link first: lowest confirm rate (a node with no confirmations
+        // sorts as 0.0), then highest send volume so busy bad links lead.
+        rows.sort_by(|a, b| {
+            let ra = a.confirm_rate.unwrap_or(0.0);
+            let rb = b.confirm_rate.unwrap_or(0.0);
+            ra.partial_cmp(&rb)
+                .unwrap_or(std::cmp::Ordering::Equal)
+                .then(b.sends.cmp(&a.sends))
+        });
+        rows.truncate(MAX_NODES_IN_SNAPSHOT);
+        (rows, total)
     }
 }
 
@@ -218,6 +359,34 @@ pub struct DeliveryStatsSnapshot {
     pub min_latency_ms: Option<u64>,
     /// Slowest round-trip in milliseconds, or `null` when there are no samples.
     pub max_latency_ms: Option<u64>,
+    /// Total number of nodes currently tracked (may exceed `per_node.len()`,
+    /// which is capped).
+    pub nodes_tracked: usize,
+    /// Per-node delivery breakdown, worst link first, capped at the 50 worst.
+    /// Populated from the retransmission tracker, so it reflects reply traffic
+    /// when `reply_max_attempts > 1`.
+    pub per_node: Vec<NodeDeliverySnapshot>,
+}
+
+/// Per-destination delivery view: how well one node's replies are getting through.
+#[derive(Debug, Clone, Serialize, PartialEq)]
+pub struct NodeDeliverySnapshot {
+    /// Destination pubkey prefix, 12 hex chars (the first 6 bytes).
+    pub prefix: String,
+    /// Outbound frames addressed to this node (first sends + retransmissions).
+    pub sends: u64,
+    /// Sends the device accepted for delivery to this node.
+    pub accepted: u64,
+    /// Sends to this node the device could not route.
+    pub failed_no_route: u64,
+    /// End-to-end confirmations from this node.
+    pub confirmed: u64,
+    /// Replies to this node abandoned after exhausting retransmissions.
+    pub gave_up: u64,
+    /// `confirmed / accepted` for this node, or `null` when nothing accepted yet.
+    pub confirm_rate: Option<f64>,
+    /// Mean round-trip to this node in milliseconds, or `null` with no samples.
+    pub avg_latency_ms: Option<f64>,
 }
 
 impl TransportStats for DeliveryStats {
@@ -232,12 +401,15 @@ impl TransportStats for DeliveryStats {
 mod tests {
     use super::*;
 
+    const P1: [u8; 6] = [1, 1, 1, 1, 1, 1];
+    const P2: [u8; 6] = [2, 2, 2, 2, 2, 2];
+
     #[test]
     fn counts_sends_and_retransmits() {
         let s = DeliveryStats::default();
-        s.on_send(1); // first send
-        s.on_send(2); // retransmission
-        s.on_send(3); // retransmission
+        s.on_send(P1, 1); // first send
+        s.on_send(P1, 2); // retransmission
+        s.on_send(P1, 3); // retransmission
         let snap = s.snapshot();
         assert_eq!(snap.sends_total, 3);
         assert_eq!(snap.retransmits, 2);
@@ -298,9 +470,50 @@ mod tests {
     #[test]
     fn transport_stats_trait_emits_object() {
         let s = DeliveryStats::default();
-        s.on_send(1);
+        s.on_send(P1, 1);
         let v = TransportStats::snapshot(&s);
         assert_eq!(v["sends_total"], 1);
         assert!(v["confirm_rate"].is_null());
+    }
+
+    #[test]
+    fn per_node_breakdown_sorts_worst_first() {
+        let s = DeliveryStats::default();
+        // Node 1: healthy — 4 accepted, 4 confirmed.
+        for _ in 0..4 {
+            s.on_send(P1, 1);
+            s.on_node_sent_result(P1, true);
+            s.on_node_confirmed(P1, 150);
+        }
+        // Node 2: bad — 4 accepted, only 1 confirmed.
+        for _ in 0..4 {
+            s.on_send(P2, 1);
+            s.on_node_sent_result(P2, true);
+        }
+        s.on_node_confirmed(P2, 900);
+
+        let snap = s.snapshot();
+        assert_eq!(snap.nodes_tracked, 2);
+        assert_eq!(snap.per_node.len(), 2);
+        // Worst (lowest confirm rate) is listed first.
+        assert_eq!(snap.per_node[0].prefix, "020202020202");
+        assert_eq!(snap.per_node[0].confirm_rate, Some(0.25));
+        assert_eq!(snap.per_node[0].avg_latency_ms, Some(900.0));
+        assert_eq!(snap.per_node[1].prefix, "010101010101");
+        assert_eq!(snap.per_node[1].confirm_rate, Some(1.0));
+    }
+
+    #[test]
+    fn per_node_map_is_bounded_and_evicts_stalest() {
+        let s = DeliveryStats::default();
+        // Insert more than the cap; the map must not grow without bound.
+        for i in 0..(MAX_TRACKED_NODES + 10) {
+            let b = (i % 256) as u8;
+            let b2 = (i / 256) as u8;
+            s.on_send([b, b2, 0, 0, 0, 0], 1);
+        }
+        let snap = s.snapshot();
+        assert_eq!(snap.nodes_tracked, MAX_TRACKED_NODES);
+        assert!(snap.per_node.len() <= MAX_NODES_IN_SNAPSHOT);
     }
 }

--- a/crates/bbs-mesh/src/metrics.rs
+++ b/crates/bbs-mesh/src/metrics.rs
@@ -21,7 +21,7 @@
 //! persisted time-series for trend analysis is a separate, later layer — this
 //! module is the live snapshot only.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, VecDeque};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Mutex;
 use std::time::Instant;
@@ -37,6 +37,12 @@ const MAX_TRACKED_NODES: usize = 256;
 
 /// Cap on how many per-node records are serialised in a snapshot (worst-first).
 const MAX_NODES_IN_SNAPSHOT: usize = 50;
+
+/// Cap on retained history samples. At one sample per minute this is 8 hours of
+/// trend — enough to watch reliability change while tuning a link, without the
+/// memory or payload of a full day. History is in-memory only and resets on
+/// restart; durable persistence is a separate layer.
+const MAX_HISTORY_SAMPLES: usize = 480;
 
 /// Per-node delivery counters. Plain integers — guarded by the `nodes` mutex,
 /// not atomics, since they are only touched under that lock.
@@ -114,6 +120,10 @@ pub struct DeliveryStats {
     /// Per-destination delivery counters, keyed by 6-byte pubkey prefix. Bounded
     /// at [`MAX_TRACKED_NODES`]; the stalest entry is evicted when full.
     nodes: Mutex<HashMap<[u8; 6], NodeEntry>>,
+    /// Rolling history of cumulative-counter snapshots, appended on a timer.
+    /// Bounded at [`MAX_HISTORY_SAMPLES`]; consumers derive per-interval rates
+    /// from the deltas between consecutive samples.
+    history: Mutex<VecDeque<DeliverySample>>,
 }
 
 impl Default for DeliveryStats {
@@ -132,6 +142,7 @@ impl Default for DeliveryStats {
             latency_min_ms: AtomicU64::new(u64::MAX),
             latency_max_ms: AtomicU64::new(0),
             nodes: Mutex::new(HashMap::new()),
+            history: Mutex::new(VecDeque::new()),
         }
     }
 }
@@ -218,6 +229,36 @@ impl DeliveryStats {
     /// Attribute a give-up to a specific node.
     pub fn on_node_gave_up(&self, prefix: [u8; 6]) {
         self.with_node(prefix, |c| c.gave_up += 1);
+    }
+
+    /// Append a history sample of the current cumulative counters, stamped with
+    /// `ts` (Unix seconds). Called on a timer; the oldest sample is dropped once
+    /// the buffer is full. Consumers diff consecutive samples for interval rates.
+    pub fn sample(&self, ts: u64) {
+        let s = DeliverySample {
+            ts,
+            sends_total: self.sends_total.load(Ordering::Relaxed),
+            accepted: self.accepted.load(Ordering::Relaxed),
+            failed_no_route: self.failed_no_route.load(Ordering::Relaxed),
+            confirmed: self.confirmed.load(Ordering::Relaxed),
+            latency_count: self.latency_count.load(Ordering::Relaxed),
+            latency_sum_ms: self.latency_sum_ms.load(Ordering::Relaxed),
+        };
+        let mut h = self.history.lock().expect("history mutex poisoned");
+        if h.len() >= MAX_HISTORY_SAMPLES {
+            h.pop_front();
+        }
+        h.push_back(s);
+    }
+
+    /// The retained history samples, oldest first.
+    pub fn history(&self) -> Vec<DeliverySample> {
+        self.history
+            .lock()
+            .expect("history mutex poisoned")
+            .iter()
+            .cloned()
+            .collect()
     }
 
     /// Record a round-trip latency sample (send → end-to-end confirmation), in
@@ -389,11 +430,36 @@ pub struct NodeDeliverySnapshot {
     pub avg_latency_ms: Option<f64>,
 }
 
+/// One point in the delivery history: cumulative counters at a moment in time.
+/// Consumers derive per-interval rates from the deltas between samples.
+#[derive(Debug, Clone, Serialize, PartialEq)]
+pub struct DeliverySample {
+    /// Unix timestamp (seconds) the sample was taken.
+    pub ts: u64,
+    /// Cumulative frames sent at this point.
+    pub sends_total: u64,
+    /// Cumulative device-accepted sends.
+    pub accepted: u64,
+    /// Cumulative no-route failures.
+    pub failed_no_route: u64,
+    /// Cumulative end-to-end confirmations.
+    pub confirmed: u64,
+    /// Cumulative latency sample count (for deriving interval average latency).
+    pub latency_count: u64,
+    /// Cumulative latency sum in milliseconds.
+    pub latency_sum_ms: u64,
+}
+
 impl TransportStats for DeliveryStats {
     fn snapshot(&self) -> Value {
         // Snapshot is a flat struct of plain numbers; serialisation cannot fail.
         serde_json::to_value(DeliveryStats::snapshot(self))
             .unwrap_or_else(|_| Value::Object(Default::default()))
+    }
+
+    fn history(&self) -> Value {
+        serde_json::to_value(DeliveryStats::history(self))
+            .unwrap_or_else(|_| Value::Array(Vec::new()))
     }
 }
 
@@ -501,6 +567,30 @@ mod tests {
         assert_eq!(snap.per_node[0].avg_latency_ms, Some(900.0));
         assert_eq!(snap.per_node[1].prefix, "010101010101");
         assert_eq!(snap.per_node[1].confirm_rate, Some(1.0));
+    }
+
+    #[test]
+    fn history_samples_accumulate_and_are_bounded() {
+        let s = DeliveryStats::default();
+        s.on_send(P1, 1);
+        s.sample(100);
+        s.on_send(P1, 1);
+        s.sample(160);
+        let h = s.history();
+        assert_eq!(h.len(), 2);
+        assert_eq!(h[0].ts, 100);
+        assert_eq!(h[0].sends_total, 1);
+        assert_eq!(h[1].ts, 160);
+        assert_eq!(h[1].sends_total, 2);
+
+        // Buffer is bounded: pushing past the cap drops the oldest.
+        for i in 0..(MAX_HISTORY_SAMPLES + 5) {
+            s.sample(1000 + i as u64);
+        }
+        let h = s.history();
+        assert_eq!(h.len(), MAX_HISTORY_SAMPLES);
+        // Oldest retained sample is newer than the very first ones we pushed.
+        assert!(h.first().unwrap().ts > 100);
     }
 
     #[test]

--- a/crates/bbs-mesh/src/metrics.rs
+++ b/crates/bbs-mesh/src/metrics.rs
@@ -256,7 +256,7 @@ impl DeliveryStats {
 
     /// Seed the in-memory history from persisted samples (oldest first), e.g. on
     /// startup so the trend survives a restart. Keeps only the most recent
-    /// [`MAX_HISTORY_SAMPLES`]. Replaces any existing in-memory history.
+    /// `MAX_HISTORY_SAMPLES`. Replaces any existing in-memory history.
     pub fn load_history(&self, samples: Vec<DeliverySample>) {
         let mut h = self.history.lock().expect("history mutex poisoned");
         h.clear();
@@ -446,7 +446,7 @@ pub struct NodeDeliverySnapshot {
 /// One point in the delivery history: cumulative counters at a moment in time.
 /// Consumers derive per-interval rates from the deltas between samples.
 ///
-/// This is the host-boundary [`DeliverySampleRecord`] so the same value flows
+/// This is the host-boundary `DeliverySampleRecord` so the same value flows
 /// from the in-memory ring to durable storage and the `/history` endpoint
 /// without conversion.
 pub use bbs_plugin_api::DeliverySampleRecord as DeliverySample;

--- a/crates/bbs-mesh/src/metrics.rs
+++ b/crates/bbs-mesh/src/metrics.rs
@@ -30,7 +30,7 @@ use serde_json::Value;
 /// Cumulative reply-delivery counters, updated from the transport's send path
 /// and inbound-frame handlers. Shared via `Arc`; all methods take `&self`
 /// (atomic, lock-free) so they can be called from any task without coordination.
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub struct DeliveryStats {
     /// Outbound text frames handed to the companion client (first sends and
     /// retransmissions both count). The denominator for "did the device even
@@ -53,6 +53,36 @@ pub struct DeliveryStats {
     /// Replies abandoned after exhausting the retransmission budget without a
     /// confirmation.
     gave_up: AtomicU64,
+    /// Number of round-trip latency samples. A sample is recorded when a
+    /// confirmation correlates to a tracked send, so this is only populated when
+    /// retransmission tracking is enabled (`reply_max_attempts > 1`).
+    latency_count: AtomicU64,
+    /// Sum of round-trip latencies in milliseconds, for the average.
+    latency_sum_ms: AtomicU64,
+    /// Smallest round-trip latency seen, in milliseconds. Initialised to
+    /// `u64::MAX` so the first `fetch_min` wins; ignore unless `latency_count > 0`.
+    latency_min_ms: AtomicU64,
+    /// Largest round-trip latency seen, in milliseconds.
+    latency_max_ms: AtomicU64,
+}
+
+impl Default for DeliveryStats {
+    fn default() -> Self {
+        Self {
+            sends_total: AtomicU64::new(0),
+            retransmits: AtomicU64::new(0),
+            dropped: AtomicU64::new(0),
+            accepted: AtomicU64::new(0),
+            failed_no_route: AtomicU64::new(0),
+            confirmed: AtomicU64::new(0),
+            gave_up: AtomicU64::new(0),
+            latency_count: AtomicU64::new(0),
+            latency_sum_ms: AtomicU64::new(0),
+            // Sentinel so the first recorded sample becomes the minimum.
+            latency_min_ms: AtomicU64::new(u64::MAX),
+            latency_max_ms: AtomicU64::new(0),
+        }
+    }
 }
 
 impl DeliveryStats {
@@ -91,6 +121,16 @@ impl DeliveryStats {
         self.gave_up.fetch_add(1, Ordering::Relaxed);
     }
 
+    /// Record a round-trip latency sample (send → end-to-end confirmation), in
+    /// milliseconds. Only called when a confirmation correlates to a tracked
+    /// send, so it requires retransmission tracking to be enabled.
+    pub fn record_latency(&self, ms: u64) {
+        self.latency_count.fetch_add(1, Ordering::Relaxed);
+        self.latency_sum_ms.fetch_add(ms, Ordering::Relaxed);
+        self.latency_min_ms.fetch_min(ms, Ordering::Relaxed);
+        self.latency_max_ms.fetch_max(ms, Ordering::Relaxed);
+    }
+
     /// Take a consistent-enough point-in-time snapshot for serialisation.
     ///
     /// Counters are read independently (no global lock), so a snapshot taken
@@ -112,6 +152,17 @@ impl DeliveryStats {
         // many it could not route.
         let route_failure_rate = ratio(failed_no_route, accepted + failed_no_route);
 
+        // Round-trip latency. Only meaningful once at least one confirmation
+        // correlated to a tracked send.
+        let latency_count = self.latency_count.load(Ordering::Relaxed);
+        let latency_sum_ms = self.latency_sum_ms.load(Ordering::Relaxed);
+        let avg_latency_ms =
+            (latency_count > 0).then(|| latency_sum_ms as f64 / latency_count as f64);
+        let min_latency_ms =
+            (latency_count > 0).then(|| self.latency_min_ms.load(Ordering::Relaxed));
+        let max_latency_ms =
+            (latency_count > 0).then(|| self.latency_max_ms.load(Ordering::Relaxed));
+
         DeliveryStatsSnapshot {
             sends_total,
             retransmits,
@@ -122,6 +173,10 @@ impl DeliveryStats {
             gave_up,
             confirm_rate,
             route_failure_rate,
+            latency_count,
+            avg_latency_ms,
+            min_latency_ms,
+            max_latency_ms,
         }
     }
 }
@@ -153,6 +208,16 @@ pub struct DeliveryStatsSnapshot {
     /// `failed_no_route / (accepted + failed_no_route)`, or `null` when the
     /// device has not reported on any send yet.
     pub route_failure_rate: Option<f64>,
+    /// Number of round-trip latency samples behind the latency figures. Zero
+    /// when retransmission tracking is disabled.
+    pub latency_count: u64,
+    /// Mean send→confirmation round-trip in milliseconds, or `null` when there
+    /// are no samples.
+    pub avg_latency_ms: Option<f64>,
+    /// Fastest round-trip in milliseconds, or `null` when there are no samples.
+    pub min_latency_ms: Option<u64>,
+    /// Slowest round-trip in milliseconds, or `null` when there are no samples.
+    pub max_latency_ms: Option<u64>,
 }
 
 impl TransportStats for DeliveryStats {
@@ -203,6 +268,20 @@ mod tests {
         assert_eq!(snap.confirmed, 3);
         assert_eq!(snap.confirm_rate, Some(0.75));
         assert_eq!(snap.route_failure_rate, Some(0.2));
+    }
+
+    #[test]
+    fn latency_tracks_avg_min_max() {
+        let s = DeliveryStats::default();
+        assert_eq!(s.snapshot().avg_latency_ms, None, "no samples yet");
+        s.record_latency(100);
+        s.record_latency(300);
+        s.record_latency(200);
+        let snap = s.snapshot();
+        assert_eq!(snap.latency_count, 3);
+        assert_eq!(snap.avg_latency_ms, Some(200.0));
+        assert_eq!(snap.min_latency_ms, Some(100));
+        assert_eq!(snap.max_latency_ms, Some(300));
     }
 
     #[test]

--- a/crates/bbs-mesh/src/metrics.rs
+++ b/crates/bbs-mesh/src/metrics.rs
@@ -234,7 +234,9 @@ impl DeliveryStats {
     /// Append a history sample of the current cumulative counters, stamped with
     /// `ts` (Unix seconds). Called on a timer; the oldest sample is dropped once
     /// the buffer is full. Consumers diff consecutive samples for interval rates.
-    pub fn sample(&self, ts: u64) {
+    ///
+    /// Returns the sample so the caller can also persist it durably.
+    pub fn sample(&self, ts: u64) -> DeliverySample {
         let s = DeliverySample {
             ts,
             sends_total: self.sends_total.load(Ordering::Relaxed),
@@ -248,7 +250,18 @@ impl DeliveryStats {
         if h.len() >= MAX_HISTORY_SAMPLES {
             h.pop_front();
         }
-        h.push_back(s);
+        h.push_back(s.clone());
+        s
+    }
+
+    /// Seed the in-memory history from persisted samples (oldest first), e.g. on
+    /// startup so the trend survives a restart. Keeps only the most recent
+    /// [`MAX_HISTORY_SAMPLES`]. Replaces any existing in-memory history.
+    pub fn load_history(&self, samples: Vec<DeliverySample>) {
+        let mut h = self.history.lock().expect("history mutex poisoned");
+        h.clear();
+        let skip = samples.len().saturating_sub(MAX_HISTORY_SAMPLES);
+        h.extend(samples.into_iter().skip(skip));
     }
 
     /// The retained history samples, oldest first.
@@ -432,23 +445,11 @@ pub struct NodeDeliverySnapshot {
 
 /// One point in the delivery history: cumulative counters at a moment in time.
 /// Consumers derive per-interval rates from the deltas between samples.
-#[derive(Debug, Clone, Serialize, PartialEq)]
-pub struct DeliverySample {
-    /// Unix timestamp (seconds) the sample was taken.
-    pub ts: u64,
-    /// Cumulative frames sent at this point.
-    pub sends_total: u64,
-    /// Cumulative device-accepted sends.
-    pub accepted: u64,
-    /// Cumulative no-route failures.
-    pub failed_no_route: u64,
-    /// Cumulative end-to-end confirmations.
-    pub confirmed: u64,
-    /// Cumulative latency sample count (for deriving interval average latency).
-    pub latency_count: u64,
-    /// Cumulative latency sum in milliseconds.
-    pub latency_sum_ms: u64,
-}
+///
+/// This is the host-boundary [`DeliverySampleRecord`] so the same value flows
+/// from the in-memory ring to durable storage and the `/history` endpoint
+/// without conversion.
+pub use bbs_plugin_api::DeliverySampleRecord as DeliverySample;
 
 impl TransportStats for DeliveryStats {
     fn snapshot(&self) -> Value {

--- a/crates/bbs-mesh/src/metrics.rs
+++ b/crates/bbs-mesh/src/metrics.rs
@@ -1,0 +1,227 @@
+//! Reply-delivery counters for the MeshCore transport.
+//!
+//! # Why
+//!
+//! The companion link is fire-and-forget and the return path on a multi-hop
+//! mesh is lossy (see the `send_tracker` module). `SendTracker` already turns
+//! the device's `RESP_CODE_SENT` / `PUSH_CODE_SEND_CONFIRMED` signals into
+//! at-least-once delivery, but those signals were previously consumed and
+//! discarded — the operator had no way to see how healthy the link actually is.
+//!
+//! [`DeliveryStats`] taps the same signal points and keeps cumulative counters
+//! so the admin UI can show round-trip success on the radio link. It is pure
+//! counting — no clock, no I/O, no influence on delivery behaviour — and works
+//! regardless of whether retransmission is enabled (it counts every outbound
+//! text frame at the point it is handed to the companion client, not via the
+//! tracker, which only records sends when retries are on).
+//!
+//! # Lifetime
+//!
+//! Counters are cumulative since process start; they reset on restart. A
+//! persisted time-series for trend analysis is a separate, later layer — this
+//! module is the live snapshot only.
+
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use bbs_plugin_api::TransportStats;
+use serde::Serialize;
+use serde_json::Value;
+
+/// Cumulative reply-delivery counters, updated from the transport's send path
+/// and inbound-frame handlers. Shared via `Arc`; all methods take `&self`
+/// (atomic, lock-free) so they can be called from any task without coordination.
+#[derive(Debug, Default)]
+pub struct DeliveryStats {
+    /// Outbound text frames handed to the companion client (first sends and
+    /// retransmissions both count). The denominator for "did the device even
+    /// take it".
+    sends_total: AtomicU64,
+    /// Subset of `sends_total` that were retransmissions (attempt > 1).
+    retransmits: AtomicU64,
+    /// Outbound text frames dropped before the wire because the command channel
+    /// was full or closed (never reached the device).
+    dropped: AtomicU64,
+    /// Device accepted a send for delivery — `RESP_CODE_SENT` with a non-zero
+    /// ACK CRC, or a flood send.
+    accepted: AtomicU64,
+    /// Device reported `MSG_SEND_FAILED` (ACK CRC 0, not flood): no route /
+    /// unknown contact. The send never left the device.
+    failed_no_route: AtomicU64,
+    /// End-to-end delivery confirmations (`PUSH_CODE_SEND_CONFIRMED`): the
+    /// destination acknowledged receipt.
+    confirmed: AtomicU64,
+    /// Replies abandoned after exhausting the retransmission budget without a
+    /// confirmation.
+    gave_up: AtomicU64,
+}
+
+impl DeliveryStats {
+    /// Record an outbound text frame accepted by the command channel.
+    /// `attempt` is the 1-based transmission count (1 = first send); anything
+    /// greater is a retransmission.
+    pub fn on_send(&self, attempt: u8) {
+        self.sends_total.fetch_add(1, Ordering::Relaxed);
+        if attempt > 1 {
+            self.retransmits.fetch_add(1, Ordering::Relaxed);
+        }
+    }
+
+    /// Record an outbound text frame dropped before the wire (channel full/closed).
+    pub fn on_dropped(&self) {
+        self.dropped.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Record the device's `RESP_CODE_SENT` outcome: `accepted = true` when the
+    /// device queued the message, `false` for `MSG_SEND_FAILED` (no route).
+    pub fn on_sent_result(&self, accepted: bool) {
+        if accepted {
+            self.accepted.fetch_add(1, Ordering::Relaxed);
+        } else {
+            self.failed_no_route.fetch_add(1, Ordering::Relaxed);
+        }
+    }
+
+    /// Record an end-to-end delivery confirmation.
+    pub fn on_confirmed(&self) {
+        self.confirmed.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Record a reply abandoned after exhausting its retransmission budget.
+    pub fn on_gave_up(&self) {
+        self.gave_up.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Take a consistent-enough point-in-time snapshot for serialisation.
+    ///
+    /// Counters are read independently (no global lock), so a snapshot taken
+    /// mid-update may be off by one between fields. That is fine for a metrics
+    /// display and avoids any contention on the hot send path.
+    pub fn snapshot(&self) -> DeliveryStatsSnapshot {
+        let sends_total = self.sends_total.load(Ordering::Relaxed);
+        let retransmits = self.retransmits.load(Ordering::Relaxed);
+        let dropped = self.dropped.load(Ordering::Relaxed);
+        let accepted = self.accepted.load(Ordering::Relaxed);
+        let failed_no_route = self.failed_no_route.load(Ordering::Relaxed);
+        let confirmed = self.confirmed.load(Ordering::Relaxed);
+        let gave_up = self.gave_up.load(Ordering::Relaxed);
+
+        // Confirm rate: of the sends the device accepted, how many were
+        // confirmed end-to-end. `None` until there is something to divide.
+        let confirm_rate = ratio(confirmed, accepted);
+        // Route-failure rate: of the sends the device gave a verdict on, how
+        // many it could not route.
+        let route_failure_rate = ratio(failed_no_route, accepted + failed_no_route);
+
+        DeliveryStatsSnapshot {
+            sends_total,
+            retransmits,
+            dropped,
+            accepted,
+            failed_no_route,
+            confirmed,
+            gave_up,
+            confirm_rate,
+            route_failure_rate,
+        }
+    }
+}
+
+/// Ratio of `num / den` as a 0.0–1.0 fraction, or `None` when `den == 0`.
+fn ratio(num: u64, den: u64) -> Option<f64> {
+    (den > 0).then(|| num as f64 / den as f64)
+}
+
+/// A serialisable point-in-time view of [`DeliveryStats`].
+#[derive(Debug, Clone, Serialize, PartialEq)]
+pub struct DeliveryStatsSnapshot {
+    /// Outbound text frames handed to the device (first sends + retransmissions).
+    pub sends_total: u64,
+    /// Retransmissions among `sends_total`.
+    pub retransmits: u64,
+    /// Outbound frames dropped before the wire (channel full/closed).
+    pub dropped: u64,
+    /// Sends the device accepted for delivery.
+    pub accepted: u64,
+    /// Sends the device could not route (`MSG_SEND_FAILED`).
+    pub failed_no_route: u64,
+    /// End-to-end delivery confirmations received.
+    pub confirmed: u64,
+    /// Replies abandoned after exhausting all retransmission attempts.
+    pub gave_up: u64,
+    /// `confirmed / accepted`, or `null` when nothing has been accepted yet.
+    pub confirm_rate: Option<f64>,
+    /// `failed_no_route / (accepted + failed_no_route)`, or `null` when the
+    /// device has not reported on any send yet.
+    pub route_failure_rate: Option<f64>,
+}
+
+impl TransportStats for DeliveryStats {
+    fn snapshot(&self) -> Value {
+        // Snapshot is a flat struct of plain numbers; serialisation cannot fail.
+        serde_json::to_value(DeliveryStats::snapshot(self))
+            .unwrap_or_else(|_| Value::Object(Default::default()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn counts_sends_and_retransmits() {
+        let s = DeliveryStats::default();
+        s.on_send(1); // first send
+        s.on_send(2); // retransmission
+        s.on_send(3); // retransmission
+        let snap = s.snapshot();
+        assert_eq!(snap.sends_total, 3);
+        assert_eq!(snap.retransmits, 2);
+    }
+
+    #[test]
+    fn rates_are_none_until_there_is_data() {
+        let snap = DeliveryStats::default().snapshot();
+        assert_eq!(snap.confirm_rate, None);
+        assert_eq!(snap.route_failure_rate, None);
+    }
+
+    #[test]
+    fn confirm_and_route_failure_rates() {
+        let s = DeliveryStats::default();
+        // 4 accepted, 1 no-route → route failure 1/5.
+        for _ in 0..4 {
+            s.on_sent_result(true);
+        }
+        s.on_sent_result(false);
+        // 3 of the 4 accepted were confirmed.
+        for _ in 0..3 {
+            s.on_confirmed();
+        }
+        let snap = s.snapshot();
+        assert_eq!(snap.accepted, 4);
+        assert_eq!(snap.failed_no_route, 1);
+        assert_eq!(snap.confirmed, 3);
+        assert_eq!(snap.confirm_rate, Some(0.75));
+        assert_eq!(snap.route_failure_rate, Some(0.2));
+    }
+
+    #[test]
+    fn dropped_and_gave_up_are_counted() {
+        let s = DeliveryStats::default();
+        s.on_dropped();
+        s.on_gave_up();
+        s.on_gave_up();
+        let snap = s.snapshot();
+        assert_eq!(snap.dropped, 1);
+        assert_eq!(snap.gave_up, 2);
+    }
+
+    #[test]
+    fn transport_stats_trait_emits_object() {
+        let s = DeliveryStats::default();
+        s.on_send(1);
+        let v = TransportStats::snapshot(&s);
+        assert_eq!(v["sends_total"], 1);
+        assert!(v["confirm_rate"].is_null());
+    }
+}

--- a/crates/bbs-mesh/src/metrics.rs
+++ b/crates/bbs-mesh/src/metrics.rs
@@ -21,7 +21,7 @@
 //! persisted time-series for trend analysis is a separate, later layer — this
 //! module is the live snapshot only.
 
-use std::collections::{HashMap, VecDeque};
+use std::collections::{HashMap, HashSet, VecDeque};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Mutex;
 use std::time::Instant;
@@ -44,11 +44,20 @@ const MAX_NODES_IN_SNAPSHOT: usize = 50;
 /// restart; durable persistence is a separate layer.
 const MAX_HISTORY_SAMPLES: usize = 480;
 
+/// Size of the recent-confirmation CRC window used to drop duplicate end-to-end
+/// ACK frames. Duplicates arrive close together, so a small window suffices; a
+/// legitimate CRC reuse for a later reply falls outside it.
+const RECENT_CONFIRMED_CAP: usize = 256;
+
 /// Per-node delivery counters. Plain integers — guarded by the `nodes` mutex,
 /// not atomics, since they are only touched under that lock.
 #[derive(Debug, Default, Clone)]
 struct NodeCounters {
     sends: u64,
+    /// First sends (attempt == 1) — i.e. distinct replies addressed to this
+    /// node. The per-reply confirm-rate denominator, so retransmissions don't
+    /// deflate it.
+    first_sends: u64,
     accepted: u64,
     failed_no_route: u64,
     confirmed: u64,
@@ -100,8 +109,10 @@ pub struct DeliveryStats {
     /// Device reported `MSG_SEND_FAILED` (ACK CRC 0, not flood): no route /
     /// unknown contact. The send never left the device.
     failed_no_route: AtomicU64,
-    /// End-to-end delivery confirmations (`PUSH_CODE_SEND_CONFIRMED`): the
-    /// destination acknowledged receipt.
+    /// Distinct end-to-end delivery confirmations (`PUSH_CODE_SEND_CONFIRMED`):
+    /// the destination acknowledged receipt. Deduplicated against
+    /// [`Self::recent_confirmed`] so a repeated ACK frame can't push the rate
+    /// over 100%.
     confirmed: AtomicU64,
     /// Replies abandoned after exhausting the retransmission budget without a
     /// confirmation.
@@ -124,6 +135,10 @@ pub struct DeliveryStats {
     /// Bounded at [`MAX_HISTORY_SAMPLES`]; consumers derive per-interval rates
     /// from the deltas between consecutive samples.
     history: Mutex<VecDeque<DeliverySample>>,
+    /// Recent confirmation CRCs (FIFO + membership set) for deduplicating
+    /// duplicate `SendConfirmed` frames on the global counter, independent of the
+    /// retransmission tracker so it works with retries off too.
+    recent_confirmed: Mutex<(VecDeque<u32>, HashSet<u32>)>,
 }
 
 impl Default for DeliveryStats {
@@ -143,6 +158,7 @@ impl Default for DeliveryStats {
             latency_max_ms: AtomicU64::new(0),
             nodes: Mutex::new(HashMap::new()),
             history: Mutex::new(VecDeque::new()),
+            recent_confirmed: Mutex::new((VecDeque::new(), HashSet::new())),
         }
     }
 }
@@ -174,10 +190,16 @@ impl DeliveryStats {
     /// anything greater is a retransmission.
     pub fn on_send(&self, prefix: [u8; 6], attempt: u8) {
         self.sends_total.fetch_add(1, Ordering::Relaxed);
-        if attempt > 1 {
+        let first = attempt <= 1;
+        if !first {
             self.retransmits.fetch_add(1, Ordering::Relaxed);
         }
-        self.with_node(prefix, |c| c.sends += 1);
+        self.with_node(prefix, |c| {
+            c.sends += 1;
+            if first {
+                c.first_sends += 1;
+            }
+        });
     }
 
     /// Record an outbound text frame dropped before the wire (channel full/closed).
@@ -208,8 +230,28 @@ impl DeliveryStats {
         });
     }
 
-    /// Record an end-to-end delivery confirmation (global).
-    pub fn on_confirmed(&self) {
+    /// Record an end-to-end delivery confirmation (global), keyed by ACK `crc`
+    /// so a duplicate `SendConfirmed` frame is counted once. The per-node path is
+    /// already deduped by the retransmission tracker; this dedups the global
+    /// counter the same way without depending on the tracker (so it holds with
+    /// retries off too).
+    pub fn on_confirmed(&self, crc: u32) {
+        {
+            let mut g = self
+                .recent_confirmed
+                .lock()
+                .expect("recent_confirmed mutex poisoned");
+            let (queue, seen) = &mut *g;
+            if !seen.insert(crc) {
+                return; // duplicate within the recent window — already counted
+            }
+            queue.push_back(crc);
+            if queue.len() > RECENT_CONFIRMED_CAP {
+                if let Some(old) = queue.pop_front() {
+                    seen.remove(&old);
+                }
+            }
+        }
         self.confirmed.fetch_add(1, Ordering::Relaxed);
     }
 
@@ -240,6 +282,7 @@ impl DeliveryStats {
         let s = DeliverySample {
             ts,
             sends_total: self.sends_total.load(Ordering::Relaxed),
+            retransmits: self.retransmits.load(Ordering::Relaxed),
             accepted: self.accepted.load(Ordering::Relaxed),
             failed_no_route: self.failed_no_route.load(Ordering::Relaxed),
             confirmed: self.confirmed.load(Ordering::Relaxed),
@@ -298,11 +341,18 @@ impl DeliveryStats {
         let confirmed = self.confirmed.load(Ordering::Relaxed);
         let gave_up = self.gave_up.load(Ordering::Relaxed);
 
-        // Confirm rate: of the sends the device accepted, how many were
-        // confirmed end-to-end. `None` until there is something to divide.
-        let confirm_rate = ratio(confirmed, accepted);
+        // Confirm rate is PER REPLY, not per transmission: the denominator is
+        // first sends (distinct replies), not `accepted` (which counts every
+        // retransmission and every flood send). Otherwise a reply delivered on
+        // attempt 3 would score 1/3, and the headline would move *against* the
+        // reliability the retransmission layer provides on a recovering link.
+        // `confirmed` is deduplicated (see `on_confirmed`), so the ratio is
+        // clamped only as a defensive guard against a stray confirm.
+        let first_sends = sends_total.saturating_sub(retransmits);
+        let confirm_rate = ratio(confirmed, first_sends).map(|r| r.min(1.0));
         // Route-failure rate: of the sends the device gave a verdict on, how
-        // many it could not route.
+        // many it could not route. Per-verdict (device-level), kept distinct from
+        // the per-reply confirm rate above.
         let route_failure_rate = ratio(failed_no_route, accepted + failed_no_route);
 
         // Round-trip latency. Only meaningful once at least one confirmation
@@ -321,6 +371,7 @@ impl DeliveryStats {
         DeliveryStatsSnapshot {
             sends_total,
             retransmits,
+            first_sends,
             dropped,
             accepted,
             failed_no_route,
@@ -352,24 +403,26 @@ impl DeliveryStats {
                     (c.latency_count > 0).then(|| c.latency_sum_ms as f64 / c.latency_count as f64);
                 NodeDeliverySnapshot {
                     prefix: prefix_hex,
-                    sends: c.sends,
+                    first_sends: c.first_sends,
                     accepted: c.accepted,
                     failed_no_route: c.failed_no_route,
                     confirmed: c.confirmed,
                     gave_up: c.gave_up,
-                    confirm_rate: ratio(c.confirmed, c.accepted),
+                    // Per reply (first sends), not per transmission — and the
+                    // per-node `confirmed` is already deduped by the tracker.
+                    confirm_rate: ratio(c.confirmed, c.first_sends).map(|r| r.min(1.0)),
                     avg_latency_ms,
                 }
             })
             .collect();
         // Worst link first: lowest confirm rate (a node with no confirmations
-        // sorts as 0.0), then highest send volume so busy bad links lead.
+        // sorts as 0.0), then highest volume so busy bad links lead.
         rows.sort_by(|a, b| {
             let ra = a.confirm_rate.unwrap_or(0.0);
             let rb = b.confirm_rate.unwrap_or(0.0);
             ra.partial_cmp(&rb)
                 .unwrap_or(std::cmp::Ordering::Equal)
-                .then(b.sends.cmp(&a.sends))
+                .then(b.first_sends.cmp(&a.first_sends))
         });
         rows.truncate(MAX_NODES_IN_SNAPSHOT);
         (rows, total)
@@ -388,17 +441,22 @@ pub struct DeliveryStatsSnapshot {
     pub sends_total: u64,
     /// Retransmissions among `sends_total`.
     pub retransmits: u64,
+    /// First sends (`sends_total − retransmits`) — distinct replies originated.
+    /// The denominator for the per-reply `confirm_rate`.
+    pub first_sends: u64,
     /// Outbound frames dropped before the wire (channel full/closed).
     pub dropped: u64,
-    /// Sends the device accepted for delivery.
+    /// Sends the device accepted for delivery (counts each retransmission).
     pub accepted: u64,
     /// Sends the device could not route (`MSG_SEND_FAILED`).
     pub failed_no_route: u64,
-    /// End-to-end delivery confirmations received.
+    /// Distinct end-to-end delivery confirmations received (deduplicated).
     pub confirmed: u64,
     /// Replies abandoned after exhausting all retransmission attempts.
     pub gave_up: u64,
-    /// `confirmed / accepted`, or `null` when nothing has been accepted yet.
+    /// Per-reply confirm rate: `confirmed / first_sends` (clamped to ≤ 1.0), or
+    /// `null` before any reply has been sent. Not per-transmission, so retries
+    /// and floods don't deflate it.
     pub confirm_rate: Option<f64>,
     /// `failed_no_route / (accepted + failed_no_route)`, or `null` when the
     /// device has not reported on any send yet.
@@ -427,17 +485,19 @@ pub struct DeliveryStatsSnapshot {
 pub struct NodeDeliverySnapshot {
     /// Destination pubkey prefix, 12 hex chars (the first 6 bytes).
     pub prefix: String,
-    /// Outbound frames addressed to this node (first sends + retransmissions).
-    pub sends: u64,
-    /// Sends the device accepted for delivery to this node.
+    /// First sends (distinct replies) addressed to this node. The per-reply
+    /// confirm-rate denominator.
+    pub first_sends: u64,
+    /// Sends the device accepted for delivery to this node (counts retransmissions).
     pub accepted: u64,
     /// Sends to this node the device could not route.
     pub failed_no_route: u64,
-    /// End-to-end confirmations from this node.
+    /// Distinct end-to-end confirmations from this node.
     pub confirmed: u64,
     /// Replies to this node abandoned after exhausting retransmissions.
     pub gave_up: u64,
-    /// `confirmed / accepted` for this node, or `null` when nothing accepted yet.
+    /// Per-reply confirm rate `confirmed / first_sends` (clamped ≤ 1.0), or
+    /// `null` when nothing has been sent to this node yet.
     pub confirm_rate: Option<f64>,
     /// Mean round-trip to this node in milliseconds, or `null` with no samples.
     pub avg_latency_ms: Option<f64>,
@@ -492,21 +552,60 @@ mod tests {
     #[test]
     fn confirm_and_route_failure_rates() {
         let s = DeliveryStats::default();
-        // 4 accepted, 1 no-route → route failure 1/5.
+        // 5 replies sent (first sends); the device routed 4 and failed 1.
+        for _ in 0..5 {
+            s.on_send(P1, 1);
+        }
         for _ in 0..4 {
             s.on_sent_result(true);
         }
         s.on_sent_result(false);
-        // 3 of the 4 accepted were confirmed.
-        for _ in 0..3 {
-            s.on_confirmed();
-        }
+        // 3 of the 5 replies were confirmed end-to-end (distinct CRCs).
+        s.on_confirmed(0x1);
+        s.on_confirmed(0x2);
+        s.on_confirmed(0x3);
         let snap = s.snapshot();
+        assert_eq!(snap.first_sends, 5);
         assert_eq!(snap.accepted, 4);
         assert_eq!(snap.failed_no_route, 1);
         assert_eq!(snap.confirmed, 3);
-        assert_eq!(snap.confirm_rate, Some(0.75));
+        // Per reply: confirmed / first_sends = 3/5.
+        assert_eq!(snap.confirm_rate, Some(0.6));
+        // Per device verdict: failed / (accepted + failed) = 1/5.
         assert_eq!(snap.route_failure_rate, Some(0.2));
+    }
+
+    #[test]
+    fn confirm_rate_is_per_reply_not_per_transmission() {
+        let s = DeliveryStats::default();
+        // One reply, delivered on the third transmission.
+        s.on_send(P1, 1); // first send
+        s.on_send(P1, 2); // retransmit
+        s.on_send(P1, 3); // retransmit
+        for _ in 0..3 {
+            s.on_sent_result(true); // device accepted each attempt
+        }
+        s.on_confirmed(0xAB); // confirmed once
+        let snap = s.snapshot();
+        // 1 confirmed / 1 first-send = 100%, NOT 1/3. The headline must not be
+        // deflated by the retransmissions the retry layer is doing.
+        assert_eq!(snap.first_sends, 1);
+        assert_eq!(snap.confirm_rate, Some(1.0));
+    }
+
+    #[test]
+    fn duplicate_confirm_is_deduplicated() {
+        let s = DeliveryStats::default();
+        s.on_send(P1, 1);
+        s.on_confirmed(0xCD);
+        s.on_confirmed(0xCD); // duplicate ACK frame for the same reply
+        let snap = s.snapshot();
+        assert_eq!(snap.confirmed, 1, "duplicate confirm counted once");
+        assert_eq!(
+            snap.confirm_rate,
+            Some(1.0),
+            "rate stays at 100%, never exceeds it"
+        );
     }
 
     #[test]
@@ -540,7 +639,9 @@ mod tests {
         s.on_send(P1, 1);
         let v = TransportStats::snapshot(&s);
         assert_eq!(v["sends_total"], 1);
-        assert!(v["confirm_rate"].is_null());
+        assert_eq!(v["first_sends"], 1);
+        // One reply sent, none confirmed yet → 0%, not null.
+        assert_eq!(v["confirm_rate"], 0.0);
     }
 
     #[test]

--- a/crates/bbs-mesh/src/send_tracker.rs
+++ b/crates/bbs-mesh/src/send_tracker.rs
@@ -66,6 +66,10 @@ pub(crate) struct PendingSend {
     pub txt_type: u8,
     /// 1-based count of transmissions made so far (1 = first send).
     pub attempt: u8,
+    /// When this attempt was written to the wire. Used to measure round-trip
+    /// latency when a `SendConfirmed` arrives. A retransmission carries the time
+    /// of the retransmission, so latency is from the delivered attempt.
+    pub sent_at: Instant,
     /// When the wait for this attempt's `SendConfirmed` expires. Only meaningful
     /// once the record is in `awaiting_ack`; a placeholder while in
     /// `awaiting_sent`.
@@ -122,6 +126,7 @@ impl SendTracker {
             text,
             txt_type,
             attempt,
+            sent_at: now,
             deadline: now, // replaced when the CRC + timeout arrive
         });
     }
@@ -141,10 +146,11 @@ impl SendTracker {
         SentOutcome::Accepted
     }
 
-    /// Mark a message delivered (`SendConfirmed`). Returns true if it was being
-    /// tracked (false for an unknown/duplicate CRC).
-    pub fn on_confirmed(&mut self, crc: u32) -> bool {
-        self.awaiting_ack.remove(&crc).is_some()
+    /// Mark a message delivered (`SendConfirmed`). Returns the tracked record
+    /// (so the caller can read its prefix and `sent_at` for per-node and latency
+    /// metrics), or `None` for an unknown/duplicate CRC.
+    pub fn on_confirmed(&mut self, crc: u32) -> Option<PendingSend> {
+        self.awaiting_ack.remove(&crc)
     }
 
     /// Remove and return all entries whose ACK deadline has passed, split into
@@ -207,7 +213,7 @@ mod tests {
         let mut t = SendTracker::new(cfg(3));
         rec(&mut t, "hi", 1, now);
         assert_eq!(t.on_sent(0xABCD, 5_000, now), SentOutcome::Accepted);
-        assert!(t.on_confirmed(0xABCD));
+        assert!(t.on_confirmed(0xABCD).is_some());
         // Past the deadline, nothing is due — it was delivered.
         let due = t.collect_due(now + Duration::from_secs(60));
         assert!(due.to_retry.is_empty() && due.gave_up.is_empty());
@@ -272,10 +278,25 @@ mod tests {
         t.on_sent(0xAA, 5_000, now);
         t.on_sent(0xBB, 5_000, now);
         // Confirm the second; the first is still in flight.
-        assert!(t.on_confirmed(0xBB));
+        assert!(t.on_confirmed(0xBB).is_some());
         let due = t.collect_due(now + Duration::from_secs(10));
         assert_eq!(due.to_retry.len(), 1);
         assert_eq!(due.to_retry[0].text, "first");
+    }
+
+    #[test]
+    fn confirmed_returns_record_with_send_time_and_prefix() {
+        let now = Instant::now();
+        let mut t = SendTracker::new(cfg(3));
+        t.record([9, 9, 9, 9, 9, 9], "hi".to_owned(), 0, 1, now);
+        // on_sent happens slightly later but must not overwrite the wire-send time.
+        t.on_sent(0x55, 5_000, now + Duration::from_millis(1));
+        let rec = t.on_confirmed(0x55).expect("tracked send");
+        assert_eq!(rec.prefix, [9, 9, 9, 9, 9, 9]);
+        assert_eq!(
+            rec.sent_at, now,
+            "sent_at is the record() time, used to measure round-trip latency"
+        );
     }
 
     #[test]

--- a/crates/bbs-mesh/src/send_tracker.rs
+++ b/crates/bbs-mesh/src/send_tracker.rs
@@ -79,8 +79,9 @@ pub(crate) struct PendingSend {
 /// Outcome of an `on_sent` correlation.
 #[derive(Debug, PartialEq, Eq)]
 pub(crate) enum SentOutcome {
-    /// Device accepted the message; now awaiting end-to-end confirmation.
-    Accepted,
+    /// Device accepted the message; now awaiting end-to-end confirmation. Carries
+    /// the destination prefix so the caller can attribute the accept per node.
+    Accepted([u8; 6]),
     /// Device reported `MSG_SEND_FAILED` (CRC 0). The record is returned so the
     /// caller can retransmit immediately if attempts remain.
     Failed(PendingSend),
@@ -141,9 +142,10 @@ impl SendTracker {
             return SentOutcome::Failed(rec);
         }
         rec.deadline = now + self.cfg.ack_wait(timeout_ms);
+        let prefix = rec.prefix;
         // A CRC collision (same message retransmitted) simply refreshes the entry.
         self.awaiting_ack.insert(crc, rec);
-        SentOutcome::Accepted
+        SentOutcome::Accepted(prefix)
     }
 
     /// Mark a message delivered (`SendConfirmed`). Returns the tracked record
@@ -212,7 +214,10 @@ mod tests {
         let now = Instant::now();
         let mut t = SendTracker::new(cfg(3));
         rec(&mut t, "hi", 1, now);
-        assert_eq!(t.on_sent(0xABCD, 5_000, now), SentOutcome::Accepted);
+        assert_eq!(
+            t.on_sent(0xABCD, 5_000, now),
+            SentOutcome::Accepted([1, 2, 3, 4, 5, 6])
+        );
         assert!(t.on_confirmed(0xABCD).is_some());
         // Past the deadline, nothing is due — it was delivered.
         let due = t.collect_due(now + Duration::from_secs(60));

--- a/crates/bbs-mesh/src/transport.rs
+++ b/crates/bbs-mesh/src/transport.rs
@@ -1090,12 +1090,17 @@ async fn handle_frame(
         // Clear the pending retransmission for this message.
         InboundFrame::SendConfirmed { crc } => {
             delivery_stats.on_confirmed();
-            if send_tracker
+            let confirmed = send_tracker
                 .lock()
                 .expect("send tracker mutex poisoned")
-                .on_confirmed(crc)
-            {
-                debug!(crc, "mesh: reply delivery confirmed");
+                .on_confirmed(crc);
+            if let Some(rec) = confirmed {
+                // Round-trip latency of the delivered transmission. Available
+                // only when retransmission tracking kept a record for this CRC.
+                let latency = Instant::now().saturating_duration_since(rec.sent_at);
+                let latency_ms = latency.as_millis() as u64;
+                delivery_stats.record_latency(latency_ms);
+                debug!(crc, latency_ms, "mesh: reply delivery confirmed");
             }
         }
 

--- a/crates/bbs-mesh/src/transport.rs
+++ b/crates/bbs-mesh/src/transport.rs
@@ -70,6 +70,8 @@ const REPLY_ACK_MIN_WAIT: Duration = Duration::from_secs(4);
 const REPLY_ACK_MAX_WAIT: Duration = Duration::from_secs(30);
 /// How often the event loop checks for replies that timed out awaiting an ACK.
 const RETRY_TICK: Duration = Duration::from_millis(500);
+/// How often the event loop appends a delivery-history sample for trend display.
+const SAMPLE_TICK: Duration = Duration::from_secs(60);
 
 /// Enqueue a plain-text reply to the companion client and, when retransmission
 /// is enabled, record it in `tracker` for delivery tracking.
@@ -667,6 +669,10 @@ async fn event_loop(
     let mut retry_tick = tokio::time::interval(RETRY_TICK);
     retry_tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
 
+    // Periodically snapshot the delivery counters into the trend history.
+    let mut sample_tick = tokio::time::interval(SAMPLE_TICK);
+    sample_tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+
     loop {
         tokio::select! {
             event = client.recv() => {
@@ -849,6 +855,9 @@ async fn event_loop(
             }
             _ = retry_tick.tick() => {
                 retransmit_due_replies(&cmd_tx, &state, &send_tracker, &delivery_stats, flood_after_send);
+            }
+            _ = sample_tick.tick() => {
+                delivery_stats.sample(now_unix_secs() as u64);
             }
             Some(req) = key_rx.recv() => {
                 use bbs_plugin_api::MeshKeyRequest;

--- a/crates/bbs-mesh/src/transport.rs
+++ b/crates/bbs-mesh/src/transport.rs
@@ -101,7 +101,7 @@ fn enqueue_text(
         Ok(()) => {
             // Count every frame that reaches the wire, independent of whether
             // retransmission (and hence the tracker's record) is enabled.
-            stats.on_send(attempt);
+            stats.on_send(prefix, attempt);
             if t.retries_enabled() {
                 t.record(prefix, text, TXT_TYPE_PLAIN, attempt, Instant::now());
             }
@@ -133,6 +133,7 @@ fn retransmit_due_replies(
     };
     for rec in due.gave_up {
         stats.on_gave_up();
+        stats.on_node_gave_up(rec.prefix);
         warn!(
             attempts = rec.attempt,
             "mesh: reply undelivered after all retries — giving up"
@@ -1080,8 +1081,18 @@ async fn handle_frame(
                 .lock()
                 .expect("send tracker mutex poisoned")
                 .on_sent(result.expected_ack, result.timeout_ms, Instant::now());
-            if matches!(outcome, SentOutcome::Spurious) {
-                debug!("mesh: Sent frame with no tracked send (retries off or already resolved)");
+            // Attribute the device verdict to the destination node (best-effort:
+            // requires the tracker to have correlated a record, i.e. retries on).
+            match outcome {
+                SentOutcome::Accepted(prefix) => delivery_stats.on_node_sent_result(prefix, true),
+                SentOutcome::Failed(ref rec) => {
+                    delivery_stats.on_node_sent_result(rec.prefix, false)
+                }
+                SentOutcome::Spurious => {
+                    debug!(
+                        "mesh: Sent frame with no tracked send (retries off or already resolved)"
+                    );
+                }
             }
         }
 
@@ -1100,6 +1111,7 @@ async fn handle_frame(
                 let latency = Instant::now().saturating_duration_since(rec.sent_at);
                 let latency_ms = latency.as_millis() as u64;
                 delivery_stats.record_latency(latency_ms);
+                delivery_stats.on_node_confirmed(rec.prefix, latency_ms);
                 debug!(crc, latency_ms, "mesh: reply delivery confirmed");
             }
         }

--- a/crates/bbs-mesh/src/transport.rs
+++ b/crates/bbs-mesh/src/transport.rs
@@ -1133,7 +1133,7 @@ async fn handle_frame(
         // PUSH_CODE_SEND_CONFIRMED (0x82): the destination acknowledged receipt.
         // Clear the pending retransmission for this message.
         InboundFrame::SendConfirmed { crc } => {
-            delivery_stats.on_confirmed();
+            delivery_stats.on_confirmed(crc);
             let confirmed = send_tracker
                 .lock()
                 .expect("send tracker mutex poisoned")

--- a/crates/bbs-mesh/src/transport.rs
+++ b/crates/bbs-mesh/src/transport.rs
@@ -59,6 +59,7 @@ use tracing::{debug, error, info, warn};
 use crate::{
     command::{format_response, parse_command, render_notification},
     config::{ConnectionType, MeshConfig},
+    metrics::DeliveryStats,
     send_tracker::{RetryConfig, SendTracker, SentOutcome},
     session::SessionState,
 };
@@ -80,6 +81,7 @@ const RETRY_TICK: Duration = Duration::from_millis(500);
 /// (logged) rather than blocking the caller; depth is generous and this is rare.
 fn enqueue_text(
     tracker: &Mutex<SendTracker>,
+    stats: &DeliveryStats,
     cmd_tx: &mpsc::Sender<OutboundFrame>,
     prefix: [u8; 6],
     text: String,
@@ -97,11 +99,17 @@ fn enqueue_text(
     let mut t = tracker.lock().expect("send tracker mutex poisoned");
     match cmd_tx.try_send(frame) {
         Ok(()) => {
+            // Count every frame that reaches the wire, independent of whether
+            // retransmission (and hence the tracker's record) is enabled.
+            stats.on_send(attempt);
             if t.retries_enabled() {
                 t.record(prefix, text, TXT_TYPE_PLAIN, attempt, Instant::now());
             }
         }
-        Err(e) => warn!(error = %e, "mesh: command channel full/closed — reply dropped"),
+        Err(e) => {
+            stats.on_dropped();
+            warn!(error = %e, "mesh: command channel full/closed — reply dropped");
+        }
     }
 }
 
@@ -113,6 +121,7 @@ fn retransmit_due_replies(
     cmd_tx: &mpsc::Sender<OutboundFrame>,
     state: &Arc<Mutex<SessionState>>,
     tracker: &Arc<Mutex<SendTracker>>,
+    stats: &DeliveryStats,
     flood_after_send: bool,
 ) {
     let due = {
@@ -123,6 +132,7 @@ fn retransmit_due_replies(
         t.collect_due(Instant::now())
     };
     for rec in due.gave_up {
+        stats.on_gave_up();
         warn!(
             attempts = rec.attempt,
             "mesh: reply undelivered after all retries — giving up"
@@ -142,7 +152,14 @@ fn retransmit_due_replies(
             next_attempt = rec.attempt + 1,
             "mesh: retransmitting unacknowledged reply"
         );
-        enqueue_text(tracker, cmd_tx, rec.prefix, rec.text, rec.attempt + 1);
+        enqueue_text(
+            tracker,
+            stats,
+            cmd_tx,
+            rec.prefix,
+            rec.text,
+            rec.attempt + 1,
+        );
     }
 }
 
@@ -206,6 +223,19 @@ pub struct MeshTransport {
     /// Shared with the event-loop task (which owns the retry timer and the
     /// `Sent`/`SendConfirmed` correlation). See [`crate::send_tracker`].
     send_tracker: Arc<Mutex<SendTracker>>,
+    /// Cumulative reply-delivery counters, surfaced to the admin UI. Shared with
+    /// the event-loop and notification tasks; lock-free. See [`crate::metrics`].
+    delivery_stats: Arc<DeliveryStats>,
+}
+
+impl MeshTransport {
+    /// Shared handle to this transport's reply-delivery counters.
+    ///
+    /// The host binary clones this and registers it with the web admin (as an
+    /// `Arc<dyn TransportStats>`) so the operator can see round-trip link health.
+    pub fn delivery_stats(&self) -> Arc<DeliveryStats> {
+        Arc::clone(&self.delivery_stats)
+    }
 }
 
 #[async_trait]
@@ -283,6 +313,7 @@ impl Plugin for MeshTransport {
                 min_timeout: REPLY_ACK_MIN_WAIT,
                 max_timeout: REPLY_ACK_MAX_WAIT,
             }))),
+            delivery_stats: Arc::new(DeliveryStats::default()),
         })
     }
 
@@ -370,6 +401,7 @@ impl Plugin for MeshTransport {
         let notif_cmd_tx = self.cmd_tx.clone();
         let notif_host = Arc::clone(&self.host);
         let notif_tracker = Arc::clone(&self.send_tracker);
+        let notif_stats = Arc::clone(&self.delivery_stats);
         let mut notif_shutdown_rx = self.shutdown_tx.subscribe();
         tokio::spawn(async move {
             loop {
@@ -383,6 +415,7 @@ impl Plugin for MeshTransport {
                                     &notif_cmd_tx,
                                     &notif_state,
                                     &notif_tracker,
+                                    &notif_stats,
                                     flood_after_send,
                                 )
                                 .await;
@@ -400,6 +433,7 @@ impl Plugin for MeshTransport {
 
         let draining = Arc::clone(&self.draining);
         let send_tracker = Arc::clone(&self.send_tracker);
+        let delivery_stats = Arc::clone(&self.delivery_stats);
         tokio::spawn(event_loop(
             client,
             host,
@@ -412,6 +446,7 @@ impl Plugin for MeshTransport {
             draining,
             flood_after_send,
             send_tracker,
+            delivery_stats,
             key_rx,
         ));
 
@@ -462,7 +497,14 @@ impl TransportEngine for MeshTransport {
         };
 
         let text = render_notification(&payload);
-        enqueue_text(&self.send_tracker, &self.cmd_tx, pubkey_prefix, text, 1);
+        enqueue_text(
+            &self.send_tracker,
+            &self.delivery_stats,
+            &self.cmd_tx,
+            pubkey_prefix,
+            text,
+            1,
+        );
 
         if self.flood_after_send {
             let full_pubkey = self
@@ -491,6 +533,7 @@ async fn push_domain_notification(
     cmd_tx: &mpsc::Sender<OutboundFrame>,
     state: &Arc<Mutex<SessionState>>,
     send_tracker: &Arc<Mutex<SendTracker>>,
+    stats: &Arc<DeliveryStats>,
     flood_after_send: bool,
 ) {
     let sessions: Vec<SessionId> = state
@@ -519,6 +562,7 @@ async fn push_domain_notification(
                 if let Some(prefix) = prefix {
                     enqueue_text(
                         send_tracker,
+                        stats,
                         cmd_tx,
                         prefix,
                         "Your account has been validated. You now have full access. Type 'H'."
@@ -554,6 +598,7 @@ async fn push_domain_notification(
                 if let Some(prefix) = prefix {
                     enqueue_text(
                         send_tracker,
+                        stats,
                         cmd_tx,
                         prefix,
                         format!(
@@ -611,6 +656,7 @@ async fn event_loop(
     draining: Arc<AtomicBool>,
     flood_after_send: bool,
     send_tracker: Arc<Mutex<SendTracker>>,
+    delivery_stats: Arc<DeliveryStats>,
     mut key_rx: tokio::sync::mpsc::Receiver<bbs_plugin_api::MeshKeyRequest>,
 ) {
     // Pending one-shot key operation. At most one at a time.
@@ -795,13 +841,13 @@ async fn event_loop(
                             _ => false,
                         };
                         if !consumed {
-                            handle_frame(frame, &host, &cmd_tx, &state, command_prefix, &welcome_message, node_credential_ttl_days, &draining, flood_after_send, &send_tracker).await;
+                            handle_frame(frame, &host, &cmd_tx, &state, command_prefix, &welcome_message, node_credential_ttl_days, &draining, flood_after_send, &send_tracker, &delivery_stats).await;
                         }
                     }
                 }
             }
             _ = retry_tick.tick() => {
-                retransmit_due_replies(&cmd_tx, &state, &send_tracker, flood_after_send);
+                retransmit_due_replies(&cmd_tx, &state, &send_tracker, &delivery_stats, flood_after_send);
             }
             Some(req) = key_rx.recv() => {
                 use bbs_plugin_api::MeshKeyRequest;
@@ -862,6 +908,7 @@ async fn handle_frame(
     draining: &Arc<AtomicBool>,
     flood_after_send: bool,
     send_tracker: &Arc<Mutex<SendTracker>>,
+    delivery_stats: &Arc<DeliveryStats>,
 ) {
     use meshcore_companion::frame::InboundFrame;
 
@@ -913,6 +960,7 @@ async fn handle_frame(
                 node_credential_ttl_days,
                 flood_after_send,
                 send_tracker,
+                delivery_stats,
             )
             .await;
         }
@@ -1004,7 +1052,9 @@ async fn handle_frame(
         // Log a warning if the device could not route the message so operators
         // can diagnose delivery failures without digging through device logs.
         InboundFrame::Sent(result) => {
-            if !result.is_flood && result.expected_ack == 0 {
+            let accepted = result.is_flood || result.expected_ack != 0;
+            delivery_stats.on_sent_result(accepted);
+            if !accepted {
                 // MSG_SEND_FAILED — device could not route the message.
                 // Common causes: no path to the destination, contact not in
                 // the device's table, or the destination is out of range.
@@ -1039,6 +1089,7 @@ async fn handle_frame(
         // PUSH_CODE_SEND_CONFIRMED (0x82): the destination acknowledged receipt.
         // Clear the pending retransmission for this message.
         InboundFrame::SendConfirmed { crc } => {
+            delivery_stats.on_confirmed();
             if send_tracker
                 .lock()
                 .expect("send tracker mutex poisoned")
@@ -1175,6 +1226,7 @@ async fn dispatch_message(
     node_credential_ttl_days: u32,
     flood_after_send: bool,
     send_tracker: &Arc<Mutex<SendTracker>>,
+    delivery_stats: &Arc<DeliveryStats>,
 ) {
     // ── Get or create a session for this node ─────────────────────────────────
     let Some((session, is_new)) = get_or_create_session(sender_prefix, host, state).await else {
@@ -1472,7 +1524,14 @@ async fn dispatch_message(
             "mesh: sending reply to node"
         );
 
-        enqueue_text(send_tracker, cmd_tx, sender_prefix, reply_text, 1);
+        enqueue_text(
+            send_tracker,
+            delivery_stats,
+            cmd_tx,
+            sender_prefix,
+            reply_text,
+            1,
+        );
         // Reset path only after the last frame so intermediate frames travel
         // the same (possibly direct) route as the first.
         if is_last && flood_after_send {

--- a/crates/bbs-mesh/src/transport.rs
+++ b/crates/bbs-mesh/src/transport.rs
@@ -72,6 +72,9 @@ const REPLY_ACK_MAX_WAIT: Duration = Duration::from_secs(30);
 const RETRY_TICK: Duration = Duration::from_millis(500);
 /// How often the event loop appends a delivery-history sample for trend display.
 const SAMPLE_TICK: Duration = Duration::from_secs(60);
+/// How far back to seed the in-memory trend from persisted samples on startup
+/// (matches the in-memory ring's ~8h capacity).
+const HISTORY_SEED_SECS: u64 = 8 * 60 * 60;
 
 /// Enqueue a plain-text reply to the companion client and, when retransmission
 /// is enabled, record it in `tracker` for delivery tracking.
@@ -673,6 +676,21 @@ async fn event_loop(
     let mut sample_tick = tokio::time::interval(SAMPLE_TICK);
     sample_tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
 
+    // Seed the in-memory trend from persisted samples so the confirm-rate chart
+    // survives a restart. Best-effort: an empty/erroring store just starts fresh.
+    let since = (now_unix_secs() as u64).saturating_sub(HISTORY_SEED_SECS);
+    match host.delivery_samples(TRANSPORT_NAME, since).await {
+        Ok(samples) if !samples.is_empty() => {
+            info!(
+                count = samples.len(),
+                "mesh: seeded delivery trend from storage"
+            );
+            delivery_stats.load_history(samples);
+        }
+        Ok(_) => {}
+        Err(e) => debug!("mesh: loading delivery history failed: {e}"),
+    }
+
     loop {
         tokio::select! {
             event = client.recv() => {
@@ -857,7 +875,13 @@ async fn event_loop(
                 retransmit_due_replies(&cmd_tx, &state, &send_tracker, &delivery_stats, flood_after_send);
             }
             _ = sample_tick.tick() => {
-                delivery_stats.sample(now_unix_secs() as u64);
+                let s = delivery_stats.sample(now_unix_secs() as u64);
+                // Persist durably so the trend survives a restart. Best-effort:
+                // a host without metrics storage just no-ops, and a write error
+                // must not disturb the event loop.
+                if let Err(e) = host.record_delivery_sample(TRANSPORT_NAME, s).await {
+                    debug!("mesh: persisting delivery sample failed: {e}");
+                }
             }
             Some(req) = key_rx.recv() => {
                 use bbs_plugin_api::MeshKeyRequest;

--- a/crates/bbs-plugin-api/Cargo.toml
+++ b/crates/bbs-plugin-api/Cargo.toml
@@ -15,14 +15,16 @@ publish      = false
 [dependencies]
 async-trait.workspace = true
 serde.workspace       = true
+# Light, ubiquitous, and already in the graph. Used for the
+# `TransportStats` snapshot type that transports expose to the admin UI.
+serde_json.workspace  = true
 thiserror.workspace   = true
 tokio.workspace       = true
 
 [dev-dependencies]
 # Tokio with the full feature set for tests (we use the macro
 # attributes for #[tokio::test]).
-tokio      = { workspace = true, features = ["macros", "rt-multi-thread"] }
-serde_json = { workspace = true }
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 
 [lints]
 workspace = true

--- a/crates/bbs-plugin-api/src/admin.rs
+++ b/crates/bbs-plugin-api/src/admin.rs
@@ -15,8 +15,11 @@ use serde::{Deserialize, Serialize};
 pub struct DeliverySampleRecord {
     /// Unix timestamp (seconds) the sample was taken.
     pub ts: u64,
-    /// Cumulative frames sent at this point.
+    /// Cumulative frames sent at this point (first sends + retransmissions).
     pub sends_total: u64,
+    /// Cumulative retransmissions. `sends_total − retransmits` gives first sends,
+    /// the per-reply confirm-rate denominator a trend consumer should use.
+    pub retransmits: u64,
     /// Cumulative device-accepted sends.
     pub accepted: u64,
     /// Cumulative no-route failures.

--- a/crates/bbs-plugin-api/src/admin.rs
+++ b/crates/bbs-plugin-api/src/admin.rs
@@ -7,6 +7,28 @@
 
 use serde::{Deserialize, Serialize};
 
+/// One point in a transport's delivery history: cumulative counters stamped with
+/// a wall-clock time. Persisted by the host and consumed to draw reliability
+/// trends. Field names match the mesh transport's in-memory sample so the same
+/// shape serves the `/history` endpoint whether read from memory or the DB.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DeliverySampleRecord {
+    /// Unix timestamp (seconds) the sample was taken.
+    pub ts: u64,
+    /// Cumulative frames sent at this point.
+    pub sends_total: u64,
+    /// Cumulative device-accepted sends.
+    pub accepted: u64,
+    /// Cumulative no-route failures.
+    pub failed_no_route: u64,
+    /// Cumulative end-to-end confirmations.
+    pub confirmed: u64,
+    /// Cumulative latency sample count (for deriving interval average latency).
+    pub latency_count: u64,
+    /// Cumulative latency sum in milliseconds.
+    pub latency_sum_ms: u64,
+}
+
 /// A live BBS session as seen by the admin.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AdminSessionInfo {

--- a/crates/bbs-plugin-api/src/host.rs
+++ b/crates/bbs-plugin-api/src/host.rs
@@ -99,8 +99,8 @@ pub enum MeshtasticAdminRequest {
 
 use crate::admin::{
     AdminAccessPolicy, AdminAuditEntry, AdminBackupRecord, AdminMessageRecord, AdminReports,
-    AdminRoomSummary, AdminSessionInfo, AdminStats, AdminUserInfo, MeshRadioParams,
-    MeshtasticLoRaConfig, MeshtasticOwnerInfo, MeshtasticSecurityInfo,
+    AdminRoomSummary, AdminSessionInfo, AdminStats, AdminUserInfo, DeliverySampleRecord,
+    MeshRadioParams, MeshtasticLoRaConfig, MeshtasticOwnerInfo, MeshtasticSecurityInfo,
 };
 use crate::advert::AdvertBus;
 use crate::command::{Command, Response};
@@ -313,6 +313,30 @@ pub trait Host: Send + Sync {
     /// Return analytics reports: top senders, top rooms, daily volume, stale rooms.
     async fn admin_reports(&self) -> Result<AdminReports, HostError> {
         Err(HostError::NotSupported("admin_reports".into()))
+    }
+
+    /// Persist one delivery-metrics sample for a transport (keyed by transport
+    /// name). Used to retain reply-delivery trends across restarts. Hosts that
+    /// keep no durable metrics may leave the default (a no-op success).
+    async fn record_delivery_sample(
+        &self,
+        transport: &str,
+        sample: DeliverySampleRecord,
+    ) -> Result<(), HostError> {
+        let _ = (transport, sample);
+        Ok(())
+    }
+
+    /// Return persisted delivery samples for a transport with `ts >= since`
+    /// (Unix seconds), oldest first. Defaults to empty for hosts without durable
+    /// metrics storage.
+    async fn delivery_samples(
+        &self,
+        transport: &str,
+        since: u64,
+    ) -> Result<Vec<DeliverySampleRecord>, HostError> {
+        let _ = (transport, since);
+        Ok(Vec::new())
     }
 
     /// Trigger a `VACUUM INTO` backup written to `backup_dir`.

--- a/crates/bbs-plugin-api/src/lib.rs
+++ b/crates/bbs-plugin-api/src/lib.rs
@@ -66,4 +66,4 @@ pub use plugin::Plugin;
 pub use registry::{
     PluginRegistryApi, PluginState, PluginStatus, ProcessPluginConfig, RegistryError,
 };
-pub use transport::TransportEngine;
+pub use transport::{TransportEngine, TransportStats};

--- a/crates/bbs-plugin-api/src/lib.rs
+++ b/crates/bbs-plugin-api/src/lib.rs
@@ -52,8 +52,9 @@ pub mod transport;
 pub use admin::{
     AdminAccessPolicy, AdminAuditEntry, AdminBackupRecord, AdminDailyVolume, AdminHourlyActivity,
     AdminMessageRecord, AdminReports, AdminRoomSummary, AdminSessionInfo, AdminStaleRoom,
-    AdminStats, AdminTopRoom, AdminTopSender, AdminUserInfo, AdminWeeklySignups, MeshRadioParams,
-    MeshtasticDeviceSnapshot, MeshtasticLoRaConfig, MeshtasticOwnerInfo, MeshtasticSecurityInfo,
+    AdminStats, AdminTopRoom, AdminTopSender, AdminUserInfo, AdminWeeklySignups,
+    DeliverySampleRecord, MeshRadioParams, MeshtasticDeviceSnapshot, MeshtasticLoRaConfig,
+    MeshtasticOwnerInfo, MeshtasticSecurityInfo,
 };
 pub use advert::{AdvertBus, AdvertRecord};
 pub use command::{Command, Response, Secret};

--- a/crates/bbs-plugin-api/src/transport.rs
+++ b/crates/bbs-plugin-api/src/transport.rs
@@ -41,3 +41,20 @@ pub trait TransportEngine: Plugin {
         payload: Notification,
     ) -> Result<NotifyOutcome, TransportError>;
 }
+
+/// A source of transport-specific operational metrics for the admin UI.
+///
+/// Implemented by transports that track delivery or link health — e.g. the
+/// mesh transport's reply-delivery counters (sends, device accepts, route
+/// failures, end-to-end confirmations, retransmissions, give-ups).
+///
+/// The host binary injects an `Arc<dyn TransportStats>` per transport into the
+/// web admin, which serves the snapshot at `GET /api/v1/transports/:name/stats`.
+/// A transport with nothing useful to report simply does not register one.
+pub trait TransportStats: Send + Sync + 'static {
+    /// A JSON snapshot of the transport's current counters.
+    ///
+    /// Called on demand when the admin UI polls; implementations should make
+    /// this cheap (read a handful of atomics) and must not block.
+    fn snapshot(&self) -> serde_json::Value;
+}

--- a/crates/bbs-plugin-api/src/transport.rs
+++ b/crates/bbs-plugin-api/src/transport.rs
@@ -57,4 +57,12 @@ pub trait TransportStats: Send + Sync + 'static {
     /// Called on demand when the admin UI polls; implementations should make
     /// this cheap (read a handful of atomics) and must not block.
     fn snapshot(&self) -> serde_json::Value;
+
+    /// A JSON array of historical samples for trend display, oldest first.
+    ///
+    /// Optional — defaults to an empty array for transports that keep no
+    /// history. Served at `GET /api/v1/transports/:name/history`.
+    fn history(&self) -> serde_json::Value {
+        serde_json::Value::Array(Vec::new())
+    }
 }

--- a/crates/bbs-web/src/lib.rs
+++ b/crates/bbs-web/src/lib.rs
@@ -16,6 +16,7 @@
 //! │  │  GET  /api/v1/status               (auth)       │    │
 //! │  │  GET  /api/v1/transports           (auth)       │    │
 //! │  │  GET  /api/v1/transports/:name/stats (auth)     │    │
+//! │  │  GET  /api/v1/transports/:name/history (auth)   │    │
 //! │  │  GET  /api/v1/native-plugins       (auth)       │    │
 //! │  │  PATCH /api/v1/native-plugins/:name (auth)      │    │
 //! │  │  GET  /api/v1/adverts              (auth)       │    │
@@ -614,6 +615,7 @@ fn build_router(state: Arc<AppState>) -> Router {
         .route("/status", get(api_status))
         .route("/transports", get(api_active_transports))
         .route("/transports/:name/stats", get(api_transport_stats))
+        .route("/transports/:name/history", get(api_transport_history))
         .route("/native-plugins", get(api_list_native_plugins))
         .route("/native-plugins/:name", patch(api_update_native_plugin))
         .route("/adverts", get(api_adverts))
@@ -881,6 +883,31 @@ async fn api_transport_stats(
     };
     match stats {
         Some(stats) => Json(stats.snapshot()).into_response(),
+        None => (
+            StatusCode::NOT_FOUND,
+            Json(json_error(&format!("no metrics for transport '{name}'"))),
+        )
+            .into_response(),
+    }
+}
+
+/// Historical metric samples for a transport, oldest first, for trend display.
+///
+/// Returns a JSON array (possibly empty if the transport keeps no history).
+/// 404 if the named transport did not register a metrics source.
+async fn api_transport_history(
+    State(state): State<Arc<AppState>>,
+    Path(name): Path<String>,
+) -> Response {
+    let stats = {
+        let map = state
+            .transport_stats
+            .lock()
+            .expect("transport_stats poisoned");
+        map.get(&name).cloned()
+    };
+    match stats {
+        Some(stats) => Json(stats.history()).into_response(),
         None => (
             StatusCode::NOT_FOUND,
             Json(json_error(&format!("no metrics for transport '{name}'"))),

--- a/crates/bbs-web/src/lib.rs
+++ b/crates/bbs-web/src/lib.rs
@@ -15,6 +15,7 @@
 //! │  │  POST /api/v1/auth/logout          (auth)       │    │
 //! │  │  GET  /api/v1/status               (auth)       │    │
 //! │  │  GET  /api/v1/transports           (auth)       │    │
+//! │  │  GET  /api/v1/transports/:name/stats (auth)     │    │
 //! │  │  GET  /api/v1/native-plugins       (auth)       │    │
 //! │  │  PATCH /api/v1/native-plugins/:name (auth)      │    │
 //! │  │  GET  /api/v1/adverts              (auth)       │    │
@@ -96,6 +97,7 @@ use bbs_plugin_api::event::{DomainEvent, MessageRecipient};
 use bbs_plugin_api::host::Host;
 use bbs_plugin_api::plugin::Plugin;
 use bbs_plugin_api::registry::{PluginRegistryApi, ProcessPluginConfig, RegistryError};
+use bbs_plugin_api::transport::TransportStats;
 use rust_embed::RustEmbed;
 use serde::{Deserialize, Serialize};
 use tokio::net::TcpListener;
@@ -249,6 +251,10 @@ struct AppState {
     ext_log_buf: std::sync::Mutex<Option<Arc<Mutex<LogBuffer>>>>,
     plugin_registry: std::sync::Mutex<Option<Arc<dyn PluginRegistryApi>>>,
     active_transports: std::sync::Mutex<TransportFlags>,
+    /// Per-transport operational metrics sources, keyed by transport name.
+    /// Populated by the host binary after plugin init; served at
+    /// `GET /api/v1/transports/:name/stats`.
+    transport_stats: std::sync::Mutex<HashMap<String, Arc<dyn TransportStats>>>,
     pending_restart: AtomicBool,
     log_reload: std::sync::Mutex<Option<LogReloadFn>>,
     error_store: std::sync::Mutex<Option<Arc<Mutex<ErrorStore>>>>,
@@ -270,6 +276,7 @@ impl AppState {
             ext_log_buf: std::sync::Mutex::new(None),
             plugin_registry: std::sync::Mutex::new(None),
             active_transports: std::sync::Mutex::new(TransportFlags::default()),
+            transport_stats: std::sync::Mutex::new(HashMap::new()),
             pending_restart: AtomicBool::new(false),
             log_reload: std::sync::Mutex::new(None),
             error_store: std::sync::Mutex::new(None),
@@ -501,6 +508,23 @@ impl WebPlugin {
             .expect("active_transports poisoned") = flags;
     }
 
+    /// Register a transport's operational-metrics source.
+    ///
+    /// `name` is the transport name as used in the session registry and API
+    /// paths (e.g. `"meshcore"`). The snapshot is served at
+    /// `GET /api/v1/transports/:name/stats`. Call before `start()`.
+    pub fn register_transport_stats(
+        &self,
+        name: impl Into<String>,
+        stats: Arc<dyn TransportStats>,
+    ) {
+        self.state
+            .transport_stats
+            .lock()
+            .expect("transport_stats poisoned")
+            .insert(name.into(), stats);
+    }
+
     /// Inject the tracing-subscriber reload handle so the web API can change
     /// the log level at runtime without a restart.
     ///
@@ -589,6 +613,7 @@ fn build_router(state: Arc<AppState>) -> Router {
         .route("/auth/logout", post(api_logout))
         .route("/status", get(api_status))
         .route("/transports", get(api_active_transports))
+        .route("/transports/:name/stats", get(api_transport_stats))
         .route("/native-plugins", get(api_list_native_plugins))
         .route("/native-plugins/:name", patch(api_update_native_plugin))
         .route("/adverts", get(api_adverts))
@@ -836,6 +861,32 @@ async fn api_active_transports(State(state): State<Arc<AppState>>) -> impl IntoR
         .lock()
         .expect("active_transports poisoned");
     Json(flags)
+}
+
+/// Operational-metrics snapshot for a single transport.
+///
+/// Returns the transport's live counters (delivery rates, link health) as JSON.
+/// 404 if the named transport did not register a metrics source — either it is
+/// not compiled in / enabled, or it has no stats to report.
+async fn api_transport_stats(
+    State(state): State<Arc<AppState>>,
+    Path(name): Path<String>,
+) -> Response {
+    let stats = {
+        let map = state
+            .transport_stats
+            .lock()
+            .expect("transport_stats poisoned");
+        map.get(&name).cloned()
+    };
+    match stats {
+        Some(stats) => Json(stats.snapshot()).into_response(),
+        None => (
+            StatusCode::NOT_FOUND,
+            Json(json_error(&format!("no metrics for transport '{name}'"))),
+        )
+            .into_response(),
+    }
 }
 
 // ── Native plugins ────────────────────────────────────────────────────────────

--- a/crates/bbs-web/web/src/pages/MetricsPage.vue
+++ b/crates/bbs-web/web/src/pages/MetricsPage.vue
@@ -5,6 +5,14 @@ import { useStatsStore } from '../stores/stats'
 
 const stats = useStatsStore()
 
+// Reliability-trend chart geometry.
+const CHART_W = 600
+const CHART_H = 120
+const PAD_L = 30
+const PAD_R = 8
+const PAD_T = 8
+const PAD_B = 18
+
 interface DiskInfo {
   name: string
   mount: string
@@ -65,8 +73,19 @@ interface Advert {
   name: string
 }
 
+interface DeliverySample {
+  ts: number
+  sends_total: number
+  accepted: number
+  failed_no_route: number
+  confirmed: number
+  latency_count: number
+  latency_sum_ms: number
+}
+
 const snap = ref<MetricsSnapshot | null>(null)
 const delivery = ref<DeliveryStats | null>(null)
+const history = ref<DeliverySample[]>([])
 const nodeNames = ref<Record<string, string>>({})
 const loading = ref(false)
 const error = ref<string | null>(null)
@@ -88,6 +107,15 @@ async function load() {
   } catch {
     delivery.value = null
   }
+  if (delivery.value) {
+    try {
+      history.value = await api.get<DeliverySample[]>('/api/v1/transports/meshcore/history')
+    } catch {
+      history.value = []
+    }
+  } else {
+    history.value = []
+  }
   // Best-effort node-name lookup so the per-node table reads in node names
   // rather than key prefixes. The per-node prefix is the first 12 hex chars
   // (6 bytes) of the advert pubkey.
@@ -108,6 +136,45 @@ async function load() {
 function nodeLabel(prefix: string): string {
   return nodeNames.value[prefix.toLowerCase()] ?? prefix
 }
+
+// Per-interval confirm rate derived from the deltas between cumulative samples.
+interface TrendPt {
+  x: number
+  rate: number | null
+}
+const trend = computed<TrendPt[]>(() => {
+  const h = history.value
+  const n = h.length
+  const out: TrendPt[] = []
+  const denom = n - 2 > 0 ? n - 2 : 1
+  for (let i = 1; i < n; i++) {
+    const dAcc = h[i].accepted - h[i - 1].accepted
+    const dConf = h[i].confirmed - h[i - 1].confirmed
+    const rate = dAcc > 0 ? dConf / dAcc : null
+    const x = PAD_L + ((i - 1) / denom) * (CHART_W - PAD_L - PAD_R)
+    out.push({ x, rate })
+  }
+  return out
+})
+
+function trendY(rate: number): number {
+  return PAD_T + (1 - rate) * (CHART_H - PAD_T - PAD_B)
+}
+const confirmLinePoints = computed(() =>
+  trend.value
+    .filter((p) => p.rate !== null)
+    .map((p) => `${p.x.toFixed(1)},${trendY(p.rate as number).toFixed(1)}`)
+    .join(' ')
+)
+const trendHasData = computed(() => trend.value.filter((p) => p.rate !== null).length >= 2)
+
+function sampleTime(ts: number): string {
+  return new Date(ts * 1000).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })
+}
+const trendStart = computed(() => (history.value.length ? sampleTime(history.value[0].ts) : ''))
+const trendEnd = computed(() =>
+  history.value.length ? sampleTime(history.value[history.value.length - 1].ts) : ''
+)
 
 function ratePct(r: number | null): string {
   return r === null ? '—' : `${(r * 100).toFixed(1)}%`
@@ -269,6 +336,25 @@ onUnmounted(() => {
           <div class="big-num">{{ fmtMs(delivery.avg_latency_ms) }}</div>
           <div class="card-sub muted">min {{ fmtMs(delivery.min_latency_ms) }} / max {{ fmtMs(delivery.max_latency_ms) }}</div>
         </div>
+      </div>
+    </section>
+
+    <!-- Reliability trend -->
+    <section v-if="delivery && trendHasData" class="section">
+      <h2 class="section-title">Confirm-rate trend (per-minute, last few hours)</h2>
+      <svg class="trend-chart" :viewBox="`0 0 ${CHART_W} ${CHART_H}`" preserveAspectRatio="none" role="img" aria-label="Confirm rate over time">
+        <line :x1="PAD_L" :y1="trendY(0)" :x2="CHART_W - PAD_R" :y2="trendY(0)" class="grid-line" />
+        <line :x1="PAD_L" :y1="trendY(0.5)" :x2="CHART_W - PAD_R" :y2="trendY(0.5)" class="grid-line" />
+        <line :x1="PAD_L" :y1="trendY(1)" :x2="CHART_W - PAD_R" :y2="trendY(1)" class="grid-line" />
+        <text :x="PAD_L - 4" :y="trendY(1) + 3" class="axis-label" text-anchor="end">100</text>
+        <text :x="PAD_L - 4" :y="trendY(0.5) + 3" class="axis-label" text-anchor="end">50</text>
+        <text :x="PAD_L - 4" :y="trendY(0) + 3" class="axis-label" text-anchor="end">0</text>
+        <polyline :points="confirmLinePoints" class="trend-line" />
+      </svg>
+      <div class="trend-axis muted">
+        <span>{{ trendStart }}</span>
+        <span>confirm rate % — gaps are minutes with no reply traffic</span>
+        <span>{{ trendEnd }}</span>
       </div>
     </section>
 
@@ -453,6 +539,27 @@ p { margin: 0; }
 .pct-label { font-size: 0.82em; margin-left: 0.4rem; }
 
 .sampled-at { font-size: 0.8em; }
+
+.trend-chart {
+  width: 100%;
+  height: 120px;
+  display: block;
+}
+.grid-line { stroke: var(--border); stroke-width: 1; vector-effect: non-scaling-stroke; }
+.axis-label { fill: var(--muted); font-size: 9px; }
+.trend-line {
+  fill: none;
+  stroke: var(--accent, #22c55e);
+  stroke-width: 1.5;
+  vector-effect: non-scaling-stroke;
+  stroke-linejoin: round;
+}
+.trend-axis {
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.75em;
+  margin-top: 0.25rem;
+}
 
 .rss-alert-banner {
   background: rgba(217, 119, 6, 0.12);

--- a/crates/bbs-web/web/src/pages/MetricsPage.vue
+++ b/crates/bbs-web/web/src/pages/MetricsPage.vue
@@ -31,7 +31,20 @@ interface MetricsSnapshot {
   sampled_at: number
 }
 
+interface DeliveryStats {
+  sends_total: number
+  retransmits: number
+  dropped: number
+  accepted: number
+  failed_no_route: number
+  confirmed: number
+  gave_up: number
+  confirm_rate: number | null
+  route_failure_rate: number | null
+}
+
 const snap = ref<MetricsSnapshot | null>(null)
+const delivery = ref<DeliveryStats | null>(null)
 const loading = ref(false)
 const error = ref<string | null>(null)
 
@@ -45,6 +58,17 @@ async function load() {
   } finally {
     loading.value = false
   }
+  // Mesh delivery counters are optional — a 404 just means the mesh transport
+  // is not compiled in / enabled, so hide the section rather than erroring.
+  try {
+    delivery.value = await api.get<DeliveryStats>('/api/v1/transports/meshcore/stats')
+  } catch {
+    delivery.value = null
+  }
+}
+
+function ratePct(r: number | null): string {
+  return r === null ? '—' : `${(r * 100).toFixed(1)}%`
 }
 
 function fmt(bytes: number): string {
@@ -142,6 +166,33 @@ onUnmounted(() => {
       </div>
 
     </div>
+
+    <!-- Mesh link health -->
+    <section v-if="delivery" class="section">
+      <h2 class="section-title">Mesh link health (cumulative since start)</h2>
+      <div class="metrics-grid">
+        <div class="card">
+          <div class="card-label">Confirm rate</div>
+          <div class="big-num">{{ ratePct(delivery.confirm_rate) }}</div>
+          <div class="card-sub muted">{{ delivery.confirmed }} ACK'd / {{ delivery.accepted }} accepted</div>
+        </div>
+        <div class="card">
+          <div class="card-label">Route failures</div>
+          <div class="big-num">{{ ratePct(delivery.route_failure_rate) }}</div>
+          <div class="card-sub muted">{{ delivery.failed_no_route }} of {{ delivery.accepted + delivery.failed_no_route }} had no route</div>
+        </div>
+        <div class="card">
+          <div class="card-label">Sends</div>
+          <div class="big-num">{{ delivery.sends_total }}</div>
+          <div class="card-sub muted">{{ delivery.retransmits }} retransmit(s), {{ delivery.dropped }} dropped</div>
+        </div>
+        <div class="card">
+          <div class="card-label">Gave up</div>
+          <div class="big-num">{{ delivery.gave_up }}</div>
+          <div class="card-sub muted">undelivered after all retries</div>
+        </div>
+      </div>
+    </section>
 
     <!-- Disks -->
     <section v-if="snap && snap.disks.length > 0" class="section">

--- a/crates/bbs-web/web/src/pages/MetricsPage.vue
+++ b/crates/bbs-web/web/src/pages/MetricsPage.vue
@@ -71,6 +71,28 @@ function ratePct(r: number | null): string {
   return r === null ? '—' : `${(r * 100).toFixed(1)}%`
 }
 
+// Width of a rate bar, 0–100. `null` (no data yet) renders an empty track.
+function rateWidth(r: number | null): number {
+  return r === null ? 0 : Math.round(r * 100)
+}
+
+// Confirm rate: higher is better, so the colour scale is inverted relative to
+// the usage bars — green when most replies are getting through, red when few are.
+function confirmBarClass(r: number | null): string {
+  if (r === null) return ''
+  if (r < 0.7) return 'bar-critical'
+  if (r < 0.9) return 'bar-warn'
+  return ''
+}
+
+// Route-failure rate: higher is worse, same direction as the usage bars.
+function failBarClass(r: number | null): string {
+  if (r === null) return ''
+  if (r >= 0.3) return 'bar-critical'
+  if (r >= 0.1) return 'bar-warn'
+  return ''
+}
+
 function fmt(bytes: number): string {
   if (bytes >= 1_073_741_824) return `${(bytes / 1_073_741_824).toFixed(1)} GB`
   if (bytes >= 1_048_576) return `${(bytes / 1_048_576).toFixed(1)} MB`
@@ -174,11 +196,13 @@ onUnmounted(() => {
         <div class="card">
           <div class="card-label">Confirm rate</div>
           <div class="big-num">{{ ratePct(delivery.confirm_rate) }}</div>
+          <div class="bar-track"><div class="bar-fill" :style="{ width: rateWidth(delivery.confirm_rate) + '%' }" :class="confirmBarClass(delivery.confirm_rate)"></div></div>
           <div class="card-sub muted">{{ delivery.confirmed }} ACK'd / {{ delivery.accepted }} accepted</div>
         </div>
         <div class="card">
           <div class="card-label">Route failures</div>
           <div class="big-num">{{ ratePct(delivery.route_failure_rate) }}</div>
+          <div class="bar-track"><div class="bar-fill" :style="{ width: rateWidth(delivery.route_failure_rate) + '%' }" :class="failBarClass(delivery.route_failure_rate)"></div></div>
           <div class="card-sub muted">{{ delivery.failed_no_route }} of {{ delivery.accepted + delivery.failed_no_route }} had no route</div>
         </div>
         <div class="card">

--- a/crates/bbs-web/web/src/pages/MetricsPage.vue
+++ b/crates/bbs-web/web/src/pages/MetricsPage.vue
@@ -31,6 +31,17 @@ interface MetricsSnapshot {
   sampled_at: number
 }
 
+interface NodeRow {
+  prefix: string
+  sends: number
+  accepted: number
+  failed_no_route: number
+  confirmed: number
+  gave_up: number
+  confirm_rate: number | null
+  avg_latency_ms: number | null
+}
+
 interface DeliveryStats {
   sends_total: number
   retransmits: number
@@ -45,10 +56,18 @@ interface DeliveryStats {
   avg_latency_ms: number | null
   min_latency_ms: number | null
   max_latency_ms: number | null
+  nodes_tracked: number
+  per_node: NodeRow[]
+}
+
+interface Advert {
+  pubkey: string
+  name: string
 }
 
 const snap = ref<MetricsSnapshot | null>(null)
 const delivery = ref<DeliveryStats | null>(null)
+const nodeNames = ref<Record<string, string>>({})
 const loading = ref(false)
 const error = ref<string | null>(null)
 
@@ -69,6 +88,25 @@ async function load() {
   } catch {
     delivery.value = null
   }
+  // Best-effort node-name lookup so the per-node table reads in node names
+  // rather than key prefixes. The per-node prefix is the first 12 hex chars
+  // (6 bytes) of the advert pubkey.
+  if (delivery.value && delivery.value.per_node.length > 0) {
+    try {
+      const adverts = await api.get<Advert[]>('/api/v1/adverts')
+      const map: Record<string, string> = {}
+      for (const a of adverts) {
+        if (a.name) map[a.pubkey.slice(0, 12).toLowerCase()] = a.name
+      }
+      nodeNames.value = map
+    } catch {
+      nodeNames.value = {}
+    }
+  }
+}
+
+function nodeLabel(prefix: string): string {
+  return nodeNames.value[prefix.toLowerCase()] ?? prefix
 }
 
 function ratePct(r: number | null): string {
@@ -231,6 +269,42 @@ onUnmounted(() => {
           <div class="big-num">{{ fmtMs(delivery.avg_latency_ms) }}</div>
           <div class="card-sub muted">min {{ fmtMs(delivery.min_latency_ms) }} / max {{ fmtMs(delivery.max_latency_ms) }}</div>
         </div>
+      </div>
+    </section>
+
+    <!-- Per-node link health -->
+    <section v-if="delivery && delivery.per_node.length > 0" class="section">
+      <h2 class="section-title">Per-node link health — worst first ({{ delivery.nodes_tracked }} node{{ delivery.nodes_tracked === 1 ? '' : 's' }} tracked)</h2>
+      <div class="table-wrap">
+        <table class="data-table">
+          <thead>
+            <tr>
+              <th>node</th>
+              <th style="min-width:130px">confirm rate</th>
+              <th>sends</th>
+              <th>no route</th>
+              <th>confirmed</th>
+              <th>gave up</th>
+              <th>avg rtt</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr v-for="n in delivery.per_node" :key="n.prefix">
+              <td><span :class="{ mono: nodeLabel(n.prefix) === n.prefix }">{{ nodeLabel(n.prefix) }}</span></td>
+              <td>
+                <div class="bar-track inline">
+                  <div class="bar-fill" :style="{ width: rateWidth(n.confirm_rate) + '%' }" :class="confirmBarClass(n.confirm_rate)"></div>
+                </div>
+                <span class="muted pct-label">{{ ratePct(n.confirm_rate) }}</span>
+              </td>
+              <td>{{ n.sends }}</td>
+              <td>{{ n.failed_no_route }}</td>
+              <td>{{ n.confirmed }} / {{ n.accepted }}</td>
+              <td>{{ n.gave_up }}</td>
+              <td>{{ fmtMs(n.avg_latency_ms) }}</td>
+            </tr>
+          </tbody>
+        </table>
       </div>
     </section>
 

--- a/crates/bbs-web/web/src/pages/MetricsPage.vue
+++ b/crates/bbs-web/web/src/pages/MetricsPage.vue
@@ -41,6 +41,10 @@ interface DeliveryStats {
   gave_up: number
   confirm_rate: number | null
   route_failure_rate: number | null
+  latency_count: number
+  avg_latency_ms: number | null
+  min_latency_ms: number | null
+  max_latency_ms: number | null
 }
 
 const snap = ref<MetricsSnapshot | null>(null)
@@ -91,6 +95,13 @@ function failBarClass(r: number | null): string {
   if (r >= 0.3) return 'bar-critical'
   if (r >= 0.1) return 'bar-warn'
   return ''
+}
+
+// Round-trip latency: ms under a second, otherwise seconds.
+function fmtMs(ms: number | null): string {
+  if (ms === null) return '—'
+  if (ms >= 1000) return `${(ms / 1000).toFixed(1)} s`
+  return `${Math.round(ms)} ms`
 }
 
 function fmt(bytes: number): string {
@@ -214,6 +225,11 @@ onUnmounted(() => {
           <div class="card-label">Gave up</div>
           <div class="big-num">{{ delivery.gave_up }}</div>
           <div class="card-sub muted">undelivered after all retries</div>
+        </div>
+        <div class="card" v-if="delivery.latency_count > 0">
+          <div class="card-label">Avg round-trip</div>
+          <div class="big-num">{{ fmtMs(delivery.avg_latency_ms) }}</div>
+          <div class="card-sub muted">min {{ fmtMs(delivery.min_latency_ms) }} / max {{ fmtMs(delivery.max_latency_ms) }}</div>
         </div>
       </div>
     </section>

--- a/crates/bbs-web/web/src/pages/MetricsPage.vue
+++ b/crates/bbs-web/web/src/pages/MetricsPage.vue
@@ -41,7 +41,7 @@ interface MetricsSnapshot {
 
 interface NodeRow {
   prefix: string
-  sends: number
+  first_sends: number
   accepted: number
   failed_no_route: number
   confirmed: number
@@ -53,6 +53,7 @@ interface NodeRow {
 interface DeliveryStats {
   sends_total: number
   retransmits: number
+  first_sends: number
   dropped: number
   accepted: number
   failed_no_route: number
@@ -76,6 +77,7 @@ interface Advert {
 interface DeliverySample {
   ts: number
   sends_total: number
+  retransmits: number
   accepted: number
   failed_no_route: number
   confirmed: number
@@ -148,9 +150,14 @@ const trend = computed<TrendPt[]>(() => {
   const out: TrendPt[] = []
   const denom = n - 2 > 0 ? n - 2 : 1
   for (let i = 1; i < n; i++) {
-    const dAcc = h[i].accepted - h[i - 1].accepted
+    // Per-reply confirm rate over the interval: confirmed / first-sends, where
+    // first-sends = sends_total − retransmits. Matches the headline card, so
+    // retransmissions don't deflate the trend.
+    const firstPrev = h[i - 1].sends_total - h[i - 1].retransmits
+    const firstCur = h[i].sends_total - h[i].retransmits
+    const dFirst = firstCur - firstPrev
     const dConf = h[i].confirmed - h[i - 1].confirmed
-    const rate = dAcc > 0 ? dConf / dAcc : null
+    const rate = dFirst > 0 ? Math.min(1, dConf / dFirst) : null
     const x = PAD_L + ((i - 1) / denom) * (CHART_W - PAD_L - PAD_R)
     out.push({ x, rate })
   }
@@ -313,7 +320,7 @@ onUnmounted(() => {
           <div class="card-label">Confirm rate</div>
           <div class="big-num">{{ ratePct(delivery.confirm_rate) }}</div>
           <div class="bar-track"><div class="bar-fill" :style="{ width: rateWidth(delivery.confirm_rate) + '%' }" :class="confirmBarClass(delivery.confirm_rate)"></div></div>
-          <div class="card-sub muted">{{ delivery.confirmed }} ACK'd / {{ delivery.accepted }} accepted</div>
+          <div class="card-sub muted">{{ delivery.confirmed }} of {{ delivery.first_sends }} replies confirmed</div>
         </div>
         <div class="card">
           <div class="card-label">Route failures</div>
@@ -367,7 +374,7 @@ onUnmounted(() => {
             <tr>
               <th>node</th>
               <th style="min-width:130px">confirm rate</th>
-              <th>sends</th>
+              <th>replies</th>
               <th>no route</th>
               <th>confirmed</th>
               <th>gave up</th>
@@ -383,9 +390,9 @@ onUnmounted(() => {
                 </div>
                 <span class="muted pct-label">{{ ratePct(n.confirm_rate) }}</span>
               </td>
-              <td>{{ n.sends }}</td>
+              <td>{{ n.first_sends }}</td>
               <td>{{ n.failed_no_route }}</td>
-              <td>{{ n.confirmed }} / {{ n.accepted }}</td>
+              <td>{{ n.confirmed }} / {{ n.first_sends }}</td>
               <td>{{ n.gave_up }}</td>
               <td>{{ fmtMs(n.avg_latency_ms) }}</td>
             </tr>

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -386,6 +386,15 @@ pub trait TransportEngine: Send + Sync + 'static {
 }
 ```
 
+A transport may also implement the optional `TransportStats` trait (also
+in `bbs-plugin-api`), exposing operational metrics as JSON via `snapshot()`
+and `history()`. The mesh transport implements it to surface reply-delivery
+"link health"; the web admin reads it through
+`GET /api/v1/transports/:name/stats` and `.../history`. Samples are stored
+durably via two defaulted `Host` methods (`record_delivery_sample` /
+`delivery_samples`) backing the `delivery_samples` table, so the trend
+survives a restart.
+
 ### 5.3 The Host interface
 
 What the BBS-core exposes **to** transports. Lives in
@@ -512,6 +521,15 @@ binary via `rust-embed`. Speaks a JSON API documented as OpenAPI.
 - View reports: message volume over time, top senders, top rooms,
   activity heatmap, validation funnel, failed login attempts,
   stale rooms. Aggregations only - no new sampling tables.
+- View mesh link health: reply-delivery metrics per mesh transport -
+  confirm rate (confirmed replies / first sends), route failures,
+  sends, gave-up count, average round-trip latency, a per-node "worst
+  links" table joined to advert names, and a per-minute confirm-rate
+  trend. This one *does* sample: it writes the `delivery_samples` table
+  (about once a minute, pruned after 7 days) and re-seeds the trend
+  from it on startup so it survives a restart. Latency and the per-node
+  breakdown populate only when reply retransmission is on
+  (`reply_max_attempts > 1`, the default).
 - Manage backups: list, trigger manual backup, download.
 - View logs: tail the structured-log feed live.
 - View audit log: read-only, append-only history of sysop actions.

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -729,6 +729,32 @@ If the web admin plugin is enabled, `GET /health` returns:
 `status` is `"healthy"` only if every transport reports running and the bridge
 is connected; otherwise `"degraded"`.
 
+### Mesh link health
+
+When the web admin UI is enabled, the **Metrics** page includes a **Mesh link
+health** section that surfaces reply-delivery quality for the MeshCore
+transport — so you can see whether replies are reaching users, which nodes have
+bad links, how fast round-trips are, and whether reliability is trending up or
+down as you tune the link:
+
+- summary cards — confirm rate (per reply), route failures, total sends,
+  gave-up count, and average round-trip latency
+- a **worst-links** table — per-node delivery stats, joined to advert names
+- a per-minute confirm-rate trend sparkline
+
+The same data backs a sysop-authenticated JSON API (handy for external
+dashboards or scripting against a logged-in session):
+
+```
+GET /api/v1/transports/meshcore/stats     # current snapshot
+GET /api/v1/transports/meshcore/history   # recent ~8h of samples
+```
+
+Latency and the per-node breakdown are populated only when reply retransmission
+is active (`reply_max_attempts > 1`, the default — see
+[CONFIG.md](CONFIG.md)). Samples are persisted in the database and pruned after
+7 days, so the trend survives a service restart or upgrade rather than resetting.
+
 ### Logs
 
 ```sh

--- a/docs/PLUGIN_API.md
+++ b/docs/PLUGIN_API.md
@@ -142,9 +142,12 @@ traits:
 | `EventConsumer`      | Subscribe to domain events                    | React to messages posted, users validated, etc.|
 | `MetricsContributor` | Add metrics to the Prometheus exporter        | Plugin tracks something operators want to see  |
 | `HealthCheck`        | Contribute to the `/health` endpoint           | Plugin has a meaningful health state          |
+| `TransportStats`     | Expose operational metrics as JSON (`snapshot` + `history`) | Transport tracks link/delivery health operators want to see |
 
 A plugin can implement any combination. The mesh transport
-implements `TransportEngine`. The web admin plugin implements
+implements `TransportEngine` and `TransportStats` (the latter exposes
+its reply-delivery "link health" — confirm rate, per-node breakdown,
+latency, and a trend). The web admin plugin implements
 `TransportEngine` (the HTTP socket itself), `RouteContributor` (its
 own admin endpoints), `StaticFileMount` (the Vue bundle), and
 `HealthCheck`.
@@ -230,6 +233,31 @@ pub trait Host: Send + Sync {
         before: Option<serde_json::Value>,
         after: Option<serde_json::Value>,
     ) -> Result<(), HostError>;
+
+    // ── Transport metrics ───────────────────────────────────────
+    //
+    // Durable storage for a transport's `TransportStats` samples.
+    // Both have default implementations (no-op / empty), so existing
+    // Host impls and plugins that don't track delivery metrics are
+    // unaffected.
+
+    /// Persist one delivery-metrics sample for `transport`. Called
+    /// periodically (about once a minute) by transports that track
+    /// reply-delivery link health.
+    async fn record_delivery_sample(
+        &self,
+        transport: &str,
+        sample: DeliverySampleRecord,
+    ) -> Result<(), HostError> { Ok(()) }
+
+    /// Read back persisted delivery samples for `transport` with
+    /// `ts >= since` (Unix seconds), oldest first — used to seed the
+    /// in-memory trend after a restart.
+    async fn delivery_samples(
+        &self,
+        transport: &str,
+        since: u64,
+    ) -> Result<Vec<DeliverySampleRecord>, HostError> { Ok(Vec::new()) }
 }
 ```
 
@@ -520,6 +548,17 @@ canonical reference.
 
 Each release section below lists whether it requires code changes
 in existing out-of-tree plugins. No entry means no action needed.
+
+#### v0.10.0
+
+**Additive API change — no code changes required for existing
+plugins.** A new optional capability trait `TransportStats` lets a
+transport expose operational metrics (`snapshot()` + `history()`), and
+two new *defaulted* `Host` methods — `record_delivery_sample` and
+`delivery_samples`, backed by the new `DeliverySampleRecord` type —
+provide durable storage for those samples. The trait is opt-in and the
+Host methods have default implementations, so out-of-tree plugins
+compile unchanged; recompile against `0.10.0` to pick them up.
 
 #### v0.6.0
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -842,6 +842,11 @@ async fn cmd_run(cli: &Cli) {
                 compiled_cli: cfg!(feature = "transport-cli"),
             });
         }
+        // Expose mesh reply-delivery counters at /api/v1/transports/meshcore/stats.
+        #[cfg(feature = "transport-mesh")]
+        if let (Some(ref plugin), Some(ref transport)) = (&wp, &mesh_transport) {
+            plugin.register_transport_stats("meshcore", transport.delivery_stats());
+        }
         wp
     };
 


### PR DESCRIPTION
Closes #153

## What & why

The MeshCore companion link is fire-and-forget and the multi-hop return path is lossy: a user
sends a command, the BBS processes it, but the reply (or its end-to-end ACK) is routinely
dropped, so the BBS looks unresponsive. The transport already had the firmware signals to tell
when a reply was accepted, confirmed, or failed (`SendTracker`), but discarded them. This PR
turns those signals into operator-visible **link-health metrics** on the admin web UI: how many
replies get through, **which nodes** have bad links, **how fast** round-trips are, and **whether
reliability is trending up or down** — persisted across restarts so you can compare before/after
a change (antenna, placement, radio params, retry budget).

## What's included

- **Global delivery counters** — sends, retransmits, drops, device-accepts, no-route failures,
  end-to-end confirmations, give-ups, plus derived confirm-rate and route-failure-rate. New
  `TransportStats` trait in the plugin API; served at `GET /api/v1/transports/:name/stats`;
  rendered as "Mesh link health" cards with colored bars.
- **Round-trip latency** — send→confirmation time (avg/min/max), measured off the retransmission
  record.
- **Per-node breakdown** — per-destination counters + latency, bounded map (256 nodes, stalest
  evicted), serialised worst-first (top 50). "Per-node link health" table, joined to advert
  names client-side so rows read as node names, not key prefixes.
- **Trend history** — once-a-minute samples in a bounded ring (8h); `GET .../history`; a
  hand-rolled SVG confirm-rate sparkline (no new JS dependency).
- **SQLite persistence** — migration `0012_delivery_samples`, a shared `DeliverySampleRecord`,
  two **defaulted** `Host` methods (`record_delivery_sample` / `delivery_samples`) so `MockHost`
  and other hosts are untouched, and a `delivery_store` (runtime sqlx, prunes >7 days). The mesh
  event loop persists each minute and **seeds the trend from the last 8h on startup**, so the
  chart survives a restart.

## Metric semantics (per code review)

Confirm rate is **per reply**, not per transmission: `confirmed / first_sends` where
`first_sends = sends_total − retransmits`. A reply delivered on attempt 3 scores 100%, not 33%,
so the headline tracks *with* the retransmission layer's recovery rather than against it.
Duplicate end-to-end ACKs are deduplicated (rate can't exceed 100%). Route-failure rate stays
per-device-verdict by design.

## Important nuance for reviewers/testers

Latency and the per-node breakdown are driven by the retransmission tracker, so they populate
whenever `reply_max_attempts > 1` (config default is **3**). With retries off, the **global**
counters still work; per-node rows and latency stay empty. This asymmetry is intentional and
documented in the code.

## Tests

- Unit tests in `bbs-mesh` (`metrics.rs`, `send_tracker.rs`): counters, rates, latency, per-node
  worst-first sort, bounded map + stalest eviction, history bounding, per-reply confirm rate +
  duplicate-confirm dedup, and that `sent_at`/prefix survive to confirm.
- `bbs-core` (`delivery_store.rs`): write/query round-trip, `since` filter, transport isolation,
  retention pruning — these also prove migrations 0012/0013 apply cleanly.
- Existing `bbs-mesh` integration (Bridge) tests still pass, including the auth/session
  regression tests.
- Frontend `vue-tsc` typecheck + vite build pass.

Every commit passes the repo pre-commit gate (`cargo fmt --check`, `clippy --workspace
--all-targets --all-features -D warnings`, `cargo test --workspace`, `cargo doc`). Build on
Linux only.

## Known limitations (intentional)

- Global cumulative counters reset on restart; only the per-minute time-series persists.
- The chart/endpoint show the in-memory ring (~8h); the DB retains 7 days. Surfacing a longer
  window would be a `?hours=` query param reading the DB directly — noted as a follow-up.
- Retention (7d), sample cadence (60s), seed window (8h), map cap (256), ring cap (480) are
  constants, not config knobs yet.

## Review order

Reviewing commit-by-commit is recommended — each is self-contained and green:
`0a4bf12` global counters → `969214b` bars → `06cf341` latency → `47e0c4f` per-node →
`4136933` trend → `ff54c89` persistence → `92b342b` rustdoc cleanup → `640a5d3` per-reply
confirm-rate + dedup (review fix) → `74b681d` docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
