### PR TITLE
fix(web): hide deleted users from admin list and add delete action

### DIFF
--- a/crates/bbs-core/src/db/user_store.rs
+++ b/crates/bbs-core/src/db/user_store.rs
@@ -61,6 +61,18 @@ pub trait UserStore: Send + Sync {
         offset: u32,
     ) -> Result<Vec<User>, StoreError>;
 
+    /// Like [`list`](Self::list) but never returns `Deleted` users.
+    ///
+    /// Used by the admin web UI, which hides deleted accounts entirely — a
+    /// deleted account is recovered by setting its status back via SQL, not
+    /// through the UI. A `filter_status` of `Deleted` therefore yields nothing.
+    async fn list_visible(
+        &self,
+        filter_status: Option<UserStatus>,
+        limit: u32,
+        offset: u32,
+    ) -> Result<Vec<User>, StoreError>;
+
     /// Insert a new user row and return its auto-assigned ID.
     ///
     /// The new user starts with `status = Active` and no
@@ -195,6 +207,58 @@ impl UserStore for Database {
         } else {
             self.list_all_users(limit as i64, offset as i64).await
         }
+    }
+
+    async fn list_visible(
+        &self,
+        filter_status: Option<UserStatus>,
+        limit: u32,
+        offset: u32,
+    ) -> Result<Vec<User>, StoreError> {
+        use sqlx::Row;
+        // Runtime query (not the query! macro) so the deleted-exclusion composes
+        // with the optional status filter without regenerating the offline sqlx
+        // cache. The exclusion is in SQL so pagination stays correct.
+        let deleted = UserStatus::Deleted as i64;
+        let lim = limit as i64;
+        let off = offset as i64;
+        let cols =
+            "id, username, display_name, status, permission_level, created_at, last_login_at";
+        let rows = if let Some(s) = filter_status {
+            sqlx::query(&format!(
+                "SELECT {cols} FROM users WHERE status != ? AND status = ? \
+                 ORDER BY created_at LIMIT ? OFFSET ?"
+            ))
+            .bind(deleted)
+            .bind(s as i64)
+            .bind(lim)
+            .bind(off)
+            .fetch_all(&self.read_pool)
+            .await?
+        } else {
+            sqlx::query(&format!(
+                "SELECT {cols} FROM users WHERE status != ? \
+                 ORDER BY created_at LIMIT ? OFFSET ?"
+            ))
+            .bind(deleted)
+            .bind(lim)
+            .bind(off)
+            .fetch_all(&self.read_pool)
+            .await?
+        };
+        rows.into_iter()
+            .map(|r| -> Result<User, StoreError> {
+                map_user_row(
+                    r.try_get("id")?,
+                    r.try_get("username")?,
+                    r.try_get("display_name")?,
+                    r.try_get("status")?,
+                    r.try_get("permission_level")?,
+                    r.try_get("created_at")?,
+                    r.try_get("last_login_at")?,
+                )
+            })
+            .collect()
     }
 
     async fn create(

--- a/crates/bbs-core/src/host.rs
+++ b/crates/bbs-core/src/host.rs
@@ -1125,6 +1125,12 @@ impl Host for BbsHost {
             new_status,
             Some(UserStatus::Banned) | Some(UserStatus::Deleted)
         ) {
+            // Reflect the actual action in the end reason rather than always "banned".
+            let reason = if matches!(new_status, Some(UserStatus::Deleted)) {
+                "user deleted"
+            } else {
+                "user banned"
+            };
             let to_end: Vec<SessionId> = {
                 let mut sessions = self.sessions.write().await;
                 let ids: Vec<SessionId> = sessions
@@ -1140,7 +1146,7 @@ impl Host for BbsHost {
             for id in to_end {
                 let _ = self.events_tx.send(DomainEvent::SessionEnded {
                     session: id,
-                    reason: "user banned".into(),
+                    reason: reason.into(),
                 });
             }
         }

--- a/crates/bbs-core/src/host.rs
+++ b/crates/bbs-core/src/host.rs
@@ -1025,7 +1025,8 @@ impl Host for BbsHost {
             }
         };
 
-        let users = UserStore::list(&self.db, filter, limit, offset)
+        // Deleted accounts are hidden from the admin UI entirely (recover via SQL).
+        let users = UserStore::list_visible(&self.db, filter, limit, offset)
             .await
             .map_err(|e| HostError::Storage(format!("{e}")))?;
 

--- a/crates/bbs-core/tests/user_store.rs
+++ b/crates/bbs-core/tests/user_store.rs
@@ -156,6 +156,52 @@ async fn list_filters_by_status() {
     assert_eq!(banned[0].username.as_str(), "bob");
 }
 
+#[tokio::test]
+async fn list_visible_hides_deleted_users() {
+    let (db, _dir) = test_db().await;
+    use bbs_core::user::UserStatus;
+
+    for name in ["alice", "bob"] {
+        let u = Username::new(name).unwrap();
+        db.create(&u, None, PermissionLevel::User, Timestamp::now())
+            .await
+            .unwrap();
+    }
+    // Soft-delete alice.
+    let alice = db
+        .get_by_username(&Username::new("alice").unwrap())
+        .await
+        .unwrap()
+        .unwrap();
+    db.update(alice.id, None, Some(UserStatus::Deleted), None, None)
+        .await
+        .unwrap();
+
+    // Plain list() still includes the deleted row (used by internal callers).
+    let all = db.list(None, 100, 0).await.unwrap();
+    assert!(all.iter().any(|u| u.username.as_str() == "alice"));
+
+    // list_visible() excludes it, keeping the active user.
+    let visible = db.list_visible(None, 100, 0).await.unwrap();
+    assert!(!visible.iter().any(|u| u.username.as_str() == "alice"));
+    assert!(visible.iter().any(|u| u.username.as_str() == "bob"));
+
+    // Even an explicit Deleted filter returns nothing through list_visible.
+    let deleted = db
+        .list_visible(Some(UserStatus::Deleted), 100, 0)
+        .await
+        .unwrap();
+    assert!(deleted.is_empty());
+
+    // A non-deleted status filter still works.
+    let active = db
+        .list_visible(Some(UserStatus::Active), 100, 0)
+        .await
+        .unwrap();
+    assert_eq!(active.len(), 1);
+    assert_eq!(active[0].username.as_str(), "bob");
+}
+
 // ── Proptest: username round-trip ─────────────────────────────────────
 
 use proptest::prelude::*;

--- a/crates/bbs-web/src/lib.rs
+++ b/crates/bbs-web/src/lib.rs
@@ -1289,7 +1289,11 @@ async fn api_update_user(
                 // a banned or demoted user cannot continue using a cached web token.
                 state.invalidate_sessions_for(&username);
                 if let Some(s) = body.status {
-                    let action = if s == 1 { "ban" } else { "unban" };
+                    let action = match s {
+                        1 => "ban",
+                        2 => "delete_user",
+                        _ => "unban",
+                    };
                     if let Err(e) = state
                         .host
                         .admin_write_audit(&actor_str, action, Some(username.as_str()), None)

--- a/crates/bbs-web/web/src/pages/UsersPage.vue
+++ b/crates/bbs-web/web/src/pages/UsersPage.vue
@@ -87,6 +87,10 @@ async function doAction(username: string, body: object, okMsg: string) {
 const validate   = (u: string) => doAction(u, { status: 0, permission_level: 10 }, `${u} verified`)
 const ban        = (u: string) => doAction(u, { status: 1 }, `${u} banned`)
 const unban      = (u: string) => doAction(u, { status: 0 }, `${u} unbanned`)
+const del        = (u: string) => {
+  if (!confirm(`Delete user "${u}"? They will be removed from this list. Recovery is only possible via SQL.`)) return
+  doAction(u, { status: 2 }, `${u} deleted`)
+}
 
 async function setLevel(u: UserInfo, level: number) {
   if (level === u.permission_level) return
@@ -256,6 +260,11 @@ onUnmounted(() => { if (pollTimer !== null) clearInterval(pollTimer) })
               :disabled="acting"
               @click="unban(u.username)"
             >unban</button>
+            <button
+              class="small-btn danger"
+              :disabled="acting"
+              @click="del(u.username)"
+            >delete</button>
           </td>
         </tr>
       </tbody>

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -961,6 +961,12 @@ From the **Users** page you can:
 - Filter to **"pending verification"** to see only unvalidated accounts
 - Click **verify** to approve an account
 - Click **ban** / **unban** to manage banned users
+- Click **delete** to soft-delete an account — the same effect as `.DU`
+  (status becomes **deleted** and active sessions end immediately)
+
+Deleted accounts no longer appear in the Users list at all. The record is
+retained, so recovering one is a server-side operation (restore its status
+with a SQL query), not something done through the web UI.
 
 An orange **"N pending"** badge appears in the page header whenever there are
 accounts waiting for approval.


### PR DESCRIPTION
Closes #154

## What & why

Two problems with the admin **Users** page:

1. **Deleted accounts showed in the list.** The list endpoint returns every user and the SPA
   shows all of them under "all", so soft-deleted accounts (status = `Deleted`) stayed visible.
   They should never appear in the UI — recovery, if ever needed, is a SQL operation.
2. **No way to delete a user from the web UI.**

## Changes

- **Hide deleted (backend).** New `UserStore::list_visible`, which excludes `Deleted` in SQL
  (so it's correct under pagination). `admin_list_users` now uses it. Implemented as a runtime
  sqlx query so the exclusion composes with the optional status filter without regenerating the
  offline `.sqlx` cache. The shared `list()` / `list(None)` is left unchanged — internal callers
  rely on it returning all rows (first-registrant check, sysop lookup for registration DMs).
- **Delete (frontend).** A confirm-guarded "delete" button that soft-deletes via the existing
  `PATCH /users/:username { status: 2 }`. The account drops out of the list and is recoverable
  via SQL. No new backend logic: `admin_update_user` already accepts `Deleted` and (like
  `Banned`) ends the user's live sessions; the handler already blocks changing your own status,
  so a sysop can't delete themselves — meaning at least one Sysop always remains (no lockout).
  Soft delete (status change) is used rather than `hard_delete`, which fails when the user has
  authored messages.
- **Audit fix (bonus).** A status change to `Deleted` was being audited as `"unban"`; it now
  logs `"delete_user"` (`"ban"` and `"unban"` unchanged).
- **Session-end reason (review fix).** `admin_update_user` evicts live sessions for both `Banned`
  and `Deleted`, but the `SessionEnded` reason was hardcoded `"user banned"`; it now reads
  `"user deleted"` for a delete.

## Tests

- New `bbs-core` test `list_visible_hides_deleted_users`: soft-deletes a user and asserts
  `list(None)` still includes it (internal callers unaffected), `list_visible(None)` excludes it,
  `list_visible(Some(Deleted))` is empty, and a non-deleted filter still works.
- Existing user-store tests (incl. `admin_update_user_ban_evicts_live_session`) still pass;
  frontend typechecks + builds.

Passes the repo pre-commit gate (fmt / clippy --all-features / test / docs). Build on Linux only.

## Manual test checklist

- Soft-delete a user → it vanishes from every filter and from the pending/verify-all counts.
- Delete button → confirm dialog → row gone; DB shows `status = 2`; live session terminated;
  audit log shows `delete_user`.
- Deleting your own Sysop row is rejected.
- `UPDATE users SET status = 0 WHERE username = 'x';` restores it to the list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
