### PR TITLE
fix(mesh): default reply_max_attempts to 1 (retransmission opt-in)

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -205,9 +205,12 @@
 # Reset the node's path after each send so the next message floods (more
 # reliable than a possibly-stale direct route).
 # flood_after_send = true
-# Total transmissions per reply, including the first. >1 retransmits a reply
-# the destination never confirms; 1 disables retransmission.
-# reply_max_attempts = 3
+# Total transmissions per reply, including the first. 1 (default) disables
+# retransmission. Raise above 1 ONLY on a link whose confirm rate is non-zero
+# (check the Mesh link health panel on the Metrics page): a link that never
+# confirms delivery resends EVERY reply reply_max_attempts times. See
+# docs/CONFIG.md §[plugins.mesh].
+# reply_max_attempts = 1
 
 
 # ─── Plugin: Meshtastic transport ─────────────────────────────────

--- a/crates/bbs-mesh/src/config.rs
+++ b/crates/bbs-mesh/src/config.rs
@@ -204,15 +204,26 @@ pub struct MeshConfig {
 
     /// Total transmissions for an outbound reply, including the first.
     ///
-    /// On a multi-hop mesh the return path is lossy, so a reply (or its
-    /// end-to-end ACK) is routinely dropped and the BBS appears unresponsive.
-    /// When this is greater than `1`, the transport tracks each reply's delivery
-    /// (via the device's `RESP_CODE_SENT` CRC and `PUSH_CODE_SEND_CONFIRMED`)
-    /// and retransmits if no confirmation arrives before the device's timeout
-    /// hint. `1` disables retransmission (record-and-forget). Defaults to `3`.
+    /// Defaults to `1` (retransmission disabled — record-and-forget). When set
+    /// greater than `1`, the transport tracks each reply's delivery (via the
+    /// device's `RESP_CODE_SENT` CRC and `PUSH_CODE_SEND_CONFIRMED`) and
+    /// retransmits — up to this many attempts — if no end-to-end confirmation
+    /// arrives before the device's timeout hint. On a multi-hop mesh the return
+    /// path is lossy, so a reply (or its ACK) can be dropped and the BBS appears
+    /// unresponsive; retransmission recovers those cases on links that actually
+    /// confirm delivery.
     ///
-    /// Trade-off: delivery becomes at-least-once, so a confirmation lost on the
-    /// return path can produce a duplicate reply — preferable to silence.
+    /// ⚠️ Only raise this above `1` on a link whose confirm rate is non-zero
+    /// (check the mesh "link health" metrics first). Retransmission depends on
+    /// the radio returning `PUSH_CODE_SEND_CONFIRMED`; a link that never does —
+    /// some multi-hop / bridge setups never surface one — cannot tell a
+    /// delivered reply from a lost one, so it retransmits *every* reply to
+    /// exhaustion, duplicating it `reply_max_attempts` times. That is why the
+    /// default is `1`.
+    ///
+    /// Even on a healthy link delivery is at-least-once: a confirmation lost on
+    /// the return path can produce one duplicate reply — preferable to silence,
+    /// and inbound commands are deduplicated separately.
     #[serde(default = "default_reply_max_attempts")]
     pub reply_max_attempts: u8,
 
@@ -299,9 +310,26 @@ fn default_flood_after_send() -> bool {
 }
 
 fn default_reply_max_attempts() -> u8 {
-    3
+    1
 }
 
 fn default_true() -> bool {
     true
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Reply retransmission is opt-in: the default must stay `1` so a link that
+    /// never returns an end-to-end delivery confirmation can't duplicate every
+    /// reply (see the `reply_max_attempts` field docs). Regression guard.
+    #[test]
+    fn reply_retransmission_is_off_by_default() {
+        assert_eq!(MeshConfig::default().reply_max_attempts, 1);
+
+        // An omitted key must resolve to the off default via the serde wiring.
+        let cfg: MeshConfig = serde_json::from_str("{}").unwrap();
+        assert_eq!(cfg.reply_max_attempts, 1);
+    }
 }

--- a/crates/bbs-mesh/tests/transport.rs
+++ b/crates/bbs-mesh/tests/transport.rs
@@ -202,17 +202,27 @@ impl Bridge {
 ///
 /// `host` is an `Arc<MockHost>` so the caller can keep a clone for inspection.
 async fn make_transport(host: Arc<MockHost>, prefix: Option<char>) -> (MeshTransport, Bridge) {
+    make_transport_with(host, |cfg| cfg.command_prefix = prefix).await
+}
+
+/// Like [`make_transport`] but lets the caller tweak the `MeshConfig` before the
+/// transport starts — e.g. to enable reply retransmission
+/// (`reply_max_attempts > 1`), which is off by default.
+async fn make_transport_with(
+    host: Arc<MockHost>,
+    customize: impl FnOnce(&mut MeshConfig),
+) -> (MeshTransport, Bridge) {
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
     let addr = listener.local_addr().unwrap();
 
-    let config = MeshConfig {
+    let mut config = MeshConfig {
         addr,
-        command_prefix: prefix,
         welcome_message: String::new(), // suppressed in tests
         reconnect_delay_initial_ms: 20,
         reconnect_delay_max_ms: 50,
         ..MeshConfig::default()
     };
+    customize(&mut config);
 
     // Arc<MockHost> coerces to Arc<dyn Host>.
     let transport = MeshTransport::init(config, host).await.unwrap();
@@ -580,7 +590,9 @@ async fn unacked_reply_is_retransmitted() {
     let host = Arc::new(MockHost::new());
     host.set_default_response(Response::Text("hi there".to_owned()));
 
-    let (transport, mut bridge) = make_transport(Arc::clone(&host), None).await;
+    // Retransmission is opt-in (default 1); this test exercises it.
+    let (transport, mut bridge) =
+        make_transport_with(Arc::clone(&host), |cfg| cfg.reply_max_attempts = 3).await;
     bridge.complete_handshake("Node").await;
 
     let sender = [0x55u8; 6];
@@ -615,7 +627,10 @@ async fn confirmed_reply_is_not_retransmitted() {
     let host = Arc::new(MockHost::new());
     host.set_default_response(Response::Text("hi there".to_owned()));
 
-    let (transport, mut bridge) = make_transport(Arc::clone(&host), None).await;
+    // Retransmission is opt-in (default 1); enable it so "confirmed ⇒ no retry"
+    // is actually under test.
+    let (transport, mut bridge) =
+        make_transport_with(Arc::clone(&host), |cfg| cfg.reply_max_attempts = 3).await;
     bridge.complete_handshake("Node").await;
 
     let sender = [0x56u8; 6];

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -529,7 +529,7 @@ binary via `rust-embed`. Speaks a JSON API documented as OpenAPI.
   (about once a minute, pruned after 7 days) and re-seeds the trend
   from it on startup so it survives a restart. Latency and the per-node
   breakdown populate only when reply retransmission is on
-  (`reply_max_attempts > 1`, the default).
+  (`reply_max_attempts > 1`; off by default).
 - Manage backups: list, trigger manual backup, download.
 - View logs: tail the structured-log feed live.
 - View audit log: read-only, append-only history of sysop actions.

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -268,13 +268,27 @@ arrive.
 | Key                 | Type    | Default | Required | Description                                     |
 |---------------------|---------|---------|----------|-------------------------------------------------|
 | `flood_after_send`  | bool    | `true`  | no       | Reset the node's stored path after each send so the next message floods (hop-by-hop) rather than using a possibly-stale direct route. |
-| `reply_max_attempts`| integer | `3`     | no       | Total transmissions per reply, including the first. When > 1, the transport tracks each reply's delivery via the device's send-result CRC and delivery confirmation and retransmits if no confirmation arrives in time. `1` disables retransmission. |
+| `reply_max_attempts`| integer | `1`     | no       | Total transmissions per reply, including the first. `1` (the default) disables retransmission. When > 1, the transport tracks each reply's delivery via the device's send-result CRC and delivery confirmation and retransmits — up to this many attempts — if no confirmation arrives in time. **Only raise this on a link that confirms deliveries — see the warning below.** |
 
-> **At-least-once delivery.** With `reply_max_attempts > 1`, a delivery
-> confirmation lost on the return path can cause the BBS to retransmit a reply
-> the user already received — a duplicate message is preferable to silence, and
-> inbound commands are deduplicated separately. The per-attempt wait is the
-> device's own timeout hint, clamped to the 4–30 s range.
+> **Check the confirm rate before enabling retransmission.** Retransmission
+> relies on the radio returning an end-to-end delivery confirmation
+> (`PUSH_CODE_SEND_CONFIRMED`). On a link that never confirms — some multi-hop
+> or bridge setups never surface one, giving a **0% confirm rate** — the
+> transport cannot distinguish a delivered reply from a lost one, so it
+> retransmits *every* reply to exhaustion and the user receives it
+> `reply_max_attempts` times. That is why the default is `1` (retransmission
+> off).
+>
+> Before raising it, open the **Mesh link health** panel on the Metrics page
+> (see [OPERATIONS.md](OPERATIONS.md)) and confirm the link's *confirm rate* is
+> non-zero. Latency and the per-node breakdown also populate only when
+> `reply_max_attempts > 1`.
+>
+> **At-least-once delivery.** Even on a healthy link, a confirmation lost on the
+> return path can cause the BBS to retransmit a reply the user already received
+> — a duplicate message is preferable to silence, and inbound commands are
+> deduplicated separately. The per-attempt wait is the device's own timeout
+> hint, clamped to the 4–30 s range.
 
 ### Serial mode (`connection_type = "serial"`)
 

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -751,7 +751,8 @@ GET /api/v1/transports/meshcore/history   # recent ~8h of samples
 ```
 
 Latency and the per-node breakdown are populated only when reply retransmission
-is active (`reply_max_attempts > 1`, the default — see
+is active (`reply_max_attempts > 1`). Retransmission is **off by default** —
+enable it only on a link with a non-zero confirm rate (see
 [CONFIG.md](CONFIG.md)). Samples are persisted in the database and pruned after
 7 days, so the trend survives a service restart or upgrade rather than resetting.
 


### PR DESCRIPTION
Closes #159

## Summary

Changes the default `reply_max_attempts` from **3 → 1**, making mesh reply **retransmission opt-in**, and rewrites the surrounding docs to warn about the failure mode the new link-health metrics exposed.

### Why

The reply-retransmission layer (shipped in v0.9.8) resends a reply until the radio returns an end-to-end delivery confirmation (`PUSH_CODE_SEND_CONFIRMED`). On links that **never** surface one — common on multi-hop / bridge setups, where the confirm rate sits at **0%** — it can't distinguish a delivered reply from a lost one, so it retransmits *every* reply to exhaustion. Users received each reply up to `reply_max_attempts` times (the duplicate-reply issue diagnosed via the v0.10.0 mesh metrics).

Defaulting to `1` disables retransmission unless an operator explicitly opts in on a link whose confirm rate is healthy.

## Changes

- **`bbs-mesh` config:** `default_reply_max_attempts()` 3 → 1; rewrote the field doc to explain the 0%-confirm failure mode and when it's safe to raise.
- **Docs:** `CONFIG.md` + `config.example.toml` — new warning to check the confirm rate (the **Mesh link health** panel) before enabling, at-least-once caveat retained. `OPERATIONS.md` + `ARCHITECTURE.md` — corrected text that called `reply_max_attempts > 1` "the default" (it no longer is).
- **Tests:** the two retransmission tests (`unacked_reply_is_retransmitted`, `confirmed_reply_is_not_retransmitted`) now opt into retransmission via a new `make_transport_with` config-customizer helper; added a regression guard (`reply_retransmission_is_off_by_default`) asserting the default — and the serde default path — stays `1`.

## Compatibility

Behavioral change for operators relying on the default. Anyone who needs retransmission (on a link that actually confirms delivery) can set `reply_max_attempts` explicitly in `[plugins.mesh]`. With the default, the per-node breakdown and latency metrics are empty (they require `> 1`) — documented.

## Verification

Full Linux gate green via the pre-commit hook: `cargo fmt --check`, `cargo clippy --workspace -D warnings`, `cargo test --workspace`, `cargo doc`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
