### PR TITLE
docs: fix two broken rustdoc intra-doc links

### DIFF
--- a/crates/bbs-plugin-api/src/advert.rs
+++ b/crates/bbs-plugin-api/src/advert.rs
@@ -221,7 +221,7 @@ impl AdvertBus {
     /// whose key prefix (first 6 bytes) does not appear in `exclude_prefixes`.
     ///
     /// Used by the mesh transport to pick a stale contact for eviction when
-    /// the radio's contact table is full ([`ContactsFull`] push): the caller
+    /// the radio's contact table is full (`ContactsFull` push): the caller
     /// can then send `RemoveContact` for the returned key to free a table slot.
     ///
     /// Returns `None` if the bus is empty or all contacts match an excluded

--- a/crates/meshcore-companion/src/constants.rs
+++ b/crates/meshcore-companion/src/constants.rs
@@ -5,10 +5,9 @@ pub const FRAME_INBOUND_PREFIX: u8 = 0x3C;
 
 /// Maximum total frame size for frames we *send* (prefix + 2-byte length + payload).
 ///
-/// Used by the transport layer to compute [`MAX_REPLY_BYTES`] so that outgoing
-/// `SendTxtMsg` frames fit within the radio bridge's expected frame size.
-///
-/// [`MAX_REPLY_BYTES`]: bbs_mesh::transport::MAX_REPLY_BYTES
+/// Used by the transport layer to compute `MAX_REPLY_BYTES` in `bbs-mesh` so
+/// that outgoing `SendTxtMsg` frames fit within the radio bridge's expected
+/// frame size.
 pub const MAX_FRAME_SIZE: usize = 172;
 
 /// Maximum payload size for frames we *receive* from the radio bridge.


### PR DESCRIPTION
Closes #158

## What

Demote two unresolvable rustdoc intra-doc links to plain code spans so `cargo doc --workspace --no-deps --all-features` no longer emits `unresolved link` warnings.

| File | Link | Why it could never resolve | Fix |
|------|------|----------------------------|-----|
| `crates/meshcore-companion/src/constants.rs` | `[MAX_REPLY_BYTES]` → `bbs_mesh::transport::MAX_REPLY_BYTES` | `meshcore-companion` is a lower-level crate with no dependency on `bbs-mesh` (adding one would be a dependency cycle) | Dropped the link-ref; the doc now names `MAX_REPLY_BYTES` in `bbs-mesh` as a plain code span |
| `crates/bbs-plugin-api/src/advert.rs` | `[ContactsFull]` | `ContactsFull` is an `InboundFrame` variant in `meshcore-companion`; `bbs-plugin-api` is the minimal plugin contract and deliberately does not depend on it | Demoted to a plain code span, matching the adjacent `RemoveContact` span |

Both warnings were cosmetic — `cargo doc` still exited 0 and the doc gate does not treat doc warnings as errors — but this removes the recurring noise on every `cargo doc` run.

## Verification

Full pre-commit gate run on Linux (WSL, toolchain 1.96), all green:

- `cargo fmt --all --check`
- `cargo clippy --workspace -- -D warnings`
- `cargo test --workspace`
- `cargo doc --workspace --no-deps --all-features` — **0 warnings** (previously 2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
