### PR TITLE
fix(mesh): dedup inbound retransmissions by sender timestamp

### DIFF
--- a/crates/bbs-mesh/src/session.rs
+++ b/crates/bbs-mesh/src/session.rs
@@ -242,6 +242,19 @@ impl SessionState {
     /// distinct messages that happen to share a one-second timestamp are not
     /// conflated.  No-op (returns `false`) if `prefix` has no session.
     pub fn dedup_by_timestamp(&mut self, prefix: &[u8; 6], timestamp: u32, text: &str) -> bool {
+        self.dedup_by_timestamp_at(prefix, timestamp, text, Instant::now())
+    }
+
+    /// [`Self::dedup_by_timestamp`] with an injectable `now`, so the window and
+    /// cap eviction are unit-testable without sleeping. `now` must be monotonic
+    /// across calls (it is when threaded from `Instant::now`).
+    fn dedup_by_timestamp_at(
+        &mut self,
+        prefix: &[u8; 6],
+        timestamp: u32,
+        text: &str,
+        now: Instant,
+    ) -> bool {
         if timestamp == 0 {
             return false;
         }
@@ -254,7 +267,7 @@ impl SessionState {
         while entry
             .recent_msgs
             .front()
-            .is_some_and(|(_, _, seen)| seen.elapsed() >= window)
+            .is_some_and(|(_, _, seen)| now.saturating_duration_since(*seen) >= window)
         {
             entry.recent_msgs.pop_front();
         }
@@ -267,7 +280,11 @@ impl SessionState {
         }
         entry
             .recent_msgs
-            .push_back((timestamp, text.to_owned(), Instant::now()));
+            .push_back((timestamp, text.to_owned(), now));
+        // Bound memory. Note the cap can evict a still-in-window identity under a
+        // burst of >RECENT_MSG_CAP distinct messages, so the effective dedup
+        // horizon is min(TIMESTAMP_DEDUP_SECS, last RECENT_MSG_CAP messages) — at
+        // airtime-limited LoRa rates this many distinct messages in 120s is rare.
         if entry.recent_msgs.len() > RECENT_MSG_CAP {
             entry.recent_msgs.pop_front();
         }
@@ -278,7 +295,10 @@ impl SessionState {
     /// within the deduplication window.  If it does not match, record `text`
     /// as the new last message and return `false`.
     ///
-    /// Used to silently drop radio retransmissions of regular commands.
+    /// This is the **fallback** dedup path, used only when the sender supplies no
+    /// per-message timestamp (`timestamp == 0`); when a timestamp is present
+    /// [`Self::dedup_by_timestamp`] handles dedup instead. Silently drops radio
+    /// retransmissions of regular commands.
     pub fn dedup_message(&mut self, prefix: &[u8; 6], text: &str) -> bool {
         if let Some(entry) = self.by_prefix.get_mut(prefix) {
             if let Some((last, instant)) = &entry.last_message {
@@ -389,6 +409,55 @@ mod tests {
         assert!(
             !st.dedup_by_timestamp(&PREFIX, 0, "hello"),
             "a zero timestamp is never treated as a duplicate"
+        );
+    }
+
+    #[test]
+    fn timestamp_dedup_cap_evicts_oldest_identity() {
+        let mut st = state_with_session();
+        let now = Instant::now();
+        // Fill the ring with RECENT_MSG_CAP+1 distinct identities at one instant
+        // (within the window, so only the cap — not the window — evicts).
+        for i in 0..=RECENT_MSG_CAP as u32 {
+            assert!(
+                !st.dedup_by_timestamp_at(&PREFIX, 1_000 + i, "cmd", now),
+                "each distinct timestamp is a new message"
+            );
+        }
+        assert!(
+            st.by_prefix.get(&PREFIX).unwrap().recent_msgs.len() <= RECENT_MSG_CAP,
+            "the ring stays bounded by RECENT_MSG_CAP"
+        );
+        // The most-recent identity is still remembered → its resend is dropped.
+        assert!(
+            st.dedup_by_timestamp_at(&PREFIX, 1_000 + RECENT_MSG_CAP as u32, "cmd", now),
+            "a recent identity within the cap is still deduped"
+        );
+        // The oldest identity (ts 1_000) was evicted by the cap, so a resend of it
+        // is reprocessed even though it is within the 120s window — the documented
+        // cap-vs-window trade-off.
+        assert!(
+            !st.dedup_by_timestamp_at(&PREFIX, 1_000, "cmd", now),
+            "an identity evicted by the cap is no longer deduped"
+        );
+    }
+
+    #[test]
+    fn timestamp_dedup_window_expiry_treats_late_resend_as_new() {
+        let mut st = state_with_session();
+        let t0 = Instant::now();
+        assert!(!st.dedup_by_timestamp_at(&PREFIX, 1_000, "login bob", t0));
+        // A resend just inside the window is still dropped.
+        let inside = t0 + Duration::from_secs(TIMESTAMP_DEDUP_SECS - 1);
+        assert!(
+            st.dedup_by_timestamp_at(&PREFIX, 1_000, "login bob", inside),
+            "a resend within the window is deduped"
+        );
+        // Past the window the identity is evicted and the resend is processed anew.
+        let outside = t0 + Duration::from_secs(TIMESTAMP_DEDUP_SECS + 1);
+        assert!(
+            !st.dedup_by_timestamp_at(&PREFIX, 1_000, "login bob", outside),
+            "a resend after the window expires is processed as new"
         );
     }
 }

--- a/crates/bbs-mesh/src/session.rs
+++ b/crates/bbs-mesh/src/session.rs
@@ -23,7 +23,7 @@
 //! this flag so the command parser knows whether to emit
 //! `Command::WorkflowReply` instead of trying to parse a command keyword.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, VecDeque};
 use std::time::{Duration, Instant};
 
 use bbs_plugin_api::SessionId;
@@ -37,6 +37,23 @@ const WORKFLOW_REPLY_DEDUP_SECS: u64 = 10;
 /// How long any inbound message is remembered for deduplication.
 /// Covers radio retransmissions of regular commands (non-workflow).
 const MESSAGE_DEDUP_SECS: u64 = 10;
+
+/// How long a message identity (sender timestamp + text) is remembered for the
+/// timestamp-based dedup in [`SessionState::dedup_by_timestamp`].
+///
+/// A genuine retransmission reuses the sender's per-message timestamp, so this
+/// window can be far more generous than [`MESSAGE_DEDUP_SECS`] without risking
+/// false-positive drops of legitimately repeated text (a real new message
+/// carries a new timestamp). It only has to outlast a retransmission train and
+/// the sender's own ACK-retry timeout — the gap that let the text-only window
+/// miss a delayed resend and reprocess it (the "Error: Already logged in"
+/// symptom).
+const TIMESTAMP_DEDUP_SECS: u64 = 120;
+
+/// Maximum number of recent message identities remembered per node for
+/// timestamp-based dedup. Bounds memory; comfortably covers an interleaved
+/// retransmission train.
+const RECENT_MSG_CAP: usize = 16;
 
 /// Per-node state tracked inside [`SessionState`].
 #[derive(Debug)]
@@ -57,8 +74,19 @@ pub struct SessionEntry {
     pub last_workflow_reply: Option<(String, Instant)>,
 
     /// The last inbound message text and the time it was processed.
-    /// Used to silently drop radio retransmissions of regular commands.
+    /// Used to silently drop radio retransmissions of regular commands when the
+    /// sender supplies no per-message timestamp (the `dedup_by_timestamp`
+    /// fallback).
     pub last_message: Option<(String, Instant)>,
+
+    /// Recently-seen `(sender timestamp, text, processed-at)` identities,
+    /// oldest first. A retransmitted message reuses the sender's timestamp, so
+    /// matching on `(timestamp, text)` drops resends robustly — even ones that
+    /// arrive long after the original or after the workflow state changed,
+    /// unlike the text-only [`Self::last_message`] window. Only populated for
+    /// messages whose sender timestamp is non-zero. Bounded by
+    /// `RECENT_MSG_CAP`.
+    pub recent_msgs: VecDeque<(u32, String, Instant)>,
 
     /// Full 32-byte public key for this node, populated the first time a
     /// `NewAdvert` frame arrives from this node.  `None` until that happens.
@@ -110,6 +138,7 @@ impl SessionState {
                 awaiting_reply: false,
                 last_workflow_reply: None,
                 last_message: None,
+                recent_msgs: VecDeque::new(),
                 full_pubkey: None,
             },
         );
@@ -199,6 +228,52 @@ impl SessionState {
         }
     }
 
+    /// Deduplicate an inbound message by the sender's per-message `timestamp`.
+    ///
+    /// Returns `true` (drop it) if this node already sent a message with the
+    /// same `(timestamp, text)` within `TIMESTAMP_DEDUP_SECS`; otherwise
+    /// records the identity and returns `false`. A `timestamp` of `0` means the
+    /// sender supplied none, so this records nothing and returns `false` — the
+    /// caller falls back to [`Self::dedup_message`].
+    ///
+    /// This is the robust path: a retransmission reuses the sender's timestamp,
+    /// so a resend is dropped even when it arrives past the text-only window or
+    /// after the workflow state changed. `text` is part of the key so two
+    /// distinct messages that happen to share a one-second timestamp are not
+    /// conflated.  No-op (returns `false`) if `prefix` has no session.
+    pub fn dedup_by_timestamp(&mut self, prefix: &[u8; 6], timestamp: u32, text: &str) -> bool {
+        if timestamp == 0 {
+            return false;
+        }
+        let Some(entry) = self.by_prefix.get_mut(prefix) else {
+            return false;
+        };
+        // Evict identities older than the window. Entries are pushed in time
+        // order, so the oldest are always at the front.
+        let window = Duration::from_secs(TIMESTAMP_DEDUP_SECS);
+        while entry
+            .recent_msgs
+            .front()
+            .is_some_and(|(_, _, seen)| seen.elapsed() >= window)
+        {
+            entry.recent_msgs.pop_front();
+        }
+        if entry
+            .recent_msgs
+            .iter()
+            .any(|(ts, t, _)| *ts == timestamp && t == text)
+        {
+            return true;
+        }
+        entry
+            .recent_msgs
+            .push_back((timestamp, text.to_owned(), Instant::now()));
+        if entry.recent_msgs.len() > RECENT_MSG_CAP {
+            entry.recent_msgs.pop_front();
+        }
+        false
+    }
+
     /// Return `true` if `text` matches the last processed message for `prefix`
     /// within the deduplication window.  If it does not match, record `text`
     /// as the new last message and return `false`.
@@ -263,6 +338,57 @@ mod tests {
         assert!(
             st.dedup_message(&PREFIX, "pw"),
             "a retransmission of the confirmation is still deduped"
+        );
+    }
+
+    #[test]
+    fn timestamp_dedup_drops_resend_with_same_timestamp() {
+        let mut st = state_with_session();
+        assert!(
+            !st.dedup_by_timestamp(&PREFIX, 1_000, "login bob"),
+            "first copy is processed"
+        );
+        assert!(
+            st.dedup_by_timestamp(&PREFIX, 1_000, "login bob"),
+            "a resend reusing the sender timestamp is dropped"
+        );
+    }
+
+    #[test]
+    fn timestamp_dedup_allows_new_message_with_new_timestamp() {
+        let mut st = state_with_session();
+        // Same text, but a genuinely new message carries a new timestamp — it
+        // must be processed (this is the issue #104 password/confirmation case).
+        assert!(!st.dedup_by_timestamp(&PREFIX, 1_000, "secret"));
+        assert!(
+            !st.dedup_by_timestamp(&PREFIX, 1_001, "secret"),
+            "identical text with a fresh timestamp is a new message, not a resend"
+        );
+    }
+
+    #[test]
+    fn timestamp_dedup_distinguishes_text_within_one_timestamp() {
+        let mut st = state_with_session();
+        // Two distinct messages that happen to share a one-second timestamp must
+        // both be processed — the text is part of the identity.
+        assert!(!st.dedup_by_timestamp(&PREFIX, 1_000, "rooms"));
+        assert!(
+            !st.dedup_by_timestamp(&PREFIX, 1_000, "read"),
+            "different text under the same timestamp is not a resend"
+        );
+        // ...but a true resend of either is still dropped.
+        assert!(st.dedup_by_timestamp(&PREFIX, 1_000, "rooms"));
+    }
+
+    #[test]
+    fn timestamp_dedup_skips_zero_timestamp() {
+        let mut st = state_with_session();
+        // A zero timestamp means "not supplied" — never dedup on it, so the
+        // caller falls back to the text-only window instead.
+        assert!(!st.dedup_by_timestamp(&PREFIX, 0, "hello"));
+        assert!(
+            !st.dedup_by_timestamp(&PREFIX, 0, "hello"),
+            "a zero timestamp is never treated as a duplicate"
         );
     }
 }

--- a/crates/bbs-mesh/src/transport.rs
+++ b/crates/bbs-mesh/src/transport.rs
@@ -980,6 +980,10 @@ async fn handle_frame(
             debug!(
                 prefix = msg.sender_key_prefix[0],
                 txt_type = msg.txt_type,
+                // The sender's per-message timestamp drives retransmission dedup;
+                // logging it lets an operator confirm two distinct sends carry
+                // distinct timestamps (e.g. a password and its confirmation).
+                timestamp = msg.timestamp,
                 len = msg.text.len(),
                 "mesh: inbound message received"
             );
@@ -1524,6 +1528,15 @@ async fn dispatch_message(
         // the message-dedup baseline so the general retransmission dedup can't
         // silently drop, for example, the matching password entered again at
         // "Confirm your password:". (#104)
+        //
+        // This only matters for the timestamp==0 fallback path. On the timestamp
+        // path, #104 is handled naturally: the re-typed confirmation is a new
+        // send with a new per-message timestamp, so dedup_by_timestamp's
+        // (timestamp, text) key already treats it as distinct — the dedup hinges
+        // on the client stamping each distinct send with a distinct timestamp.
+        // Do NOT also clear `recent_msgs` here: that would let a delayed
+        // retransmission of the previous reply through after a prompt, re-opening
+        // the very "Error: Already logged in" reprocessing this dedup prevents.
         if is_prompt {
             state.clear_last_message(&sender_prefix);
         }

--- a/crates/bbs-mesh/src/transport.rs
+++ b/crates/bbs-mesh/src/transport.rs
@@ -985,6 +985,7 @@ async fn handle_frame(
             );
             dispatch_message(
                 msg.sender_key_prefix,
+                msg.timestamp,
                 &msg.text,
                 host,
                 cmd_tx,
@@ -1267,6 +1268,7 @@ async fn handle_frame(
 #[allow(clippy::too_many_arguments)]
 async fn dispatch_message(
     sender_prefix: [u8; 6],
+    timestamp: u32,
     text: &str,
     host: &Arc<dyn Host>,
     cmd_tx: &mpsc::Sender<OutboundFrame>,
@@ -1367,30 +1369,44 @@ async fn dispatch_message(
         None
     };
 
-    // ── Dedup radio retransmissions of all inbound messages ──────────────────
-    // The radio layer retransmits packets; process only the first copy within
-    // the dedup window. This covers both regular commands and workflow replies.
-    if state
-        .lock()
-        .expect("state mutex poisoned")
-        .dedup_message(&sender_prefix, text)
-    {
-        debug!("mesh: dropping retransmitted message (dedup)");
-        return;
-    }
-
-    // ── Dedup mesh retransmissions of workflow replies ────────────────────────
-    // A retransmitted password can arrive after login completes
-    // (awaiting_reply=false). Drop it silently if it matches the most recently
-    // processed WorkflowReply within the dedup window.
-    if !awaiting_reply
-        && state
+    // ── Deduplicate retransmissions ───────────────────────────────────────────
+    // Prefer the sender's per-message timestamp: a retransmission reuses it, so
+    // matching on (timestamp, text) drops resends robustly — even ones delayed
+    // past the text-only window or arriving after the workflow state changed
+    // (the "Error: Already logged in" symptom). When the sender supplies no
+    // timestamp (0), fall back to the text-only window, which additionally
+    // guards mesh retransmissions of a workflow reply that land after the
+    // workflow has completed.
+    if timestamp != 0 {
+        if state
             .lock()
             .expect("state mutex poisoned")
-            .is_recent_workflow_reply(&sender_prefix, text)
-    {
-        debug!("mesh: dropping retransmitted workflow reply (dedup)");
-        return;
+            .dedup_by_timestamp(&sender_prefix, timestamp, text)
+        {
+            debug!(
+                timestamp,
+                "mesh: dropping retransmitted message (timestamp dedup)"
+            );
+            return;
+        }
+    } else {
+        if state
+            .lock()
+            .expect("state mutex poisoned")
+            .dedup_message(&sender_prefix, text)
+        {
+            debug!("mesh: dropping retransmitted message (text dedup)");
+            return;
+        }
+        if !awaiting_reply
+            && state
+                .lock()
+                .expect("state mutex poisoned")
+                .is_recent_workflow_reply(&sender_prefix, text)
+        {
+            debug!("mesh: dropping retransmitted workflow reply (text dedup)");
+            return;
+        }
     }
 
     // ── Parse the command ─────────────────────────────────────────────────────

--- a/crates/bbs-mesh/tests/transport.rs
+++ b/crates/bbs-mesh/tests/transport.rs
@@ -426,6 +426,133 @@ async fn retransmitted_command_with_same_timestamp_reaches_host_once() {
     transport.stop().await.unwrap();
 }
 
+/// A sender that supplies no per-message timestamp (`timestamp == 0`) still gets
+/// retransmission dedup via the text-only fallback window — the path that guards
+/// legacy/no-clock devices. Exercises the `timestamp == 0` branch end-to-end.
+#[tokio::test]
+async fn zero_timestamp_retransmission_deduped_via_text_window() {
+    let host = Arc::new(MockHost::new());
+    host.set_default_response(Response::Text("ok".to_owned()));
+
+    let (transport, mut bridge) = make_transport(Arc::clone(&host), None).await;
+    bridge.complete_handshake("Node").await;
+
+    let sender = [0x91u8; 6];
+    // Same command twice with timestamp 0, inside the text-dedup window.
+    bridge.send(&contact_msg_frame_ts(sender, "help", 0)).await;
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    bridge.send(&contact_msg_frame_ts(sender, "help", 0)).await;
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    let help_count = host
+        .commands_received()
+        .iter()
+        .filter(|(_, c)| matches!(c, Command::Help { .. }))
+        .count();
+    assert_eq!(
+        help_count, 1,
+        "a zero-timestamp retransmission must be dropped by the text-only fallback"
+    );
+
+    transport.stop().await.unwrap();
+}
+
+/// With `timestamp == 0`, a retransmitted workflow reply that lands after the
+/// workflow completed is still dropped by the text-only fallback (the
+/// `dedup_message` / `is_recent_workflow_reply` guards), so the host never
+/// reprocesses it.
+#[tokio::test]
+async fn zero_timestamp_workflow_reply_retransmission_after_completion_dropped() {
+    let host = Arc::new(MockHost::new());
+    host.set_response_for(
+        |cmd| matches!(cmd, Command::Help { .. }),
+        Response::Prompt {
+            text: "enter code:".to_owned(),
+            hide_input: false,
+        },
+    );
+    host.set_response_for(
+        |cmd| matches!(cmd, Command::WorkflowReply { .. }),
+        Response::Text("done".to_owned()),
+    );
+
+    let (transport, mut bridge) = make_transport(Arc::clone(&host), None).await;
+    bridge.complete_handshake("Node").await;
+
+    let sender = [0x92u8; 6];
+    bridge.send(&contact_msg_frame_ts(sender, "help", 0)).await; // → Prompt
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    bridge.send(&contact_msg_frame_ts(sender, "1234", 0)).await; // reply → completes
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    bridge.send(&contact_msg_frame_ts(sender, "1234", 0)).await; // retransmit after completion
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    let reply_count = host
+        .commands_received()
+        .iter()
+        .filter(|(_, c)| matches!(c, Command::WorkflowReply { reply } if reply == "1234"))
+        .count();
+    assert_eq!(
+        reply_count, 1,
+        "a zero-timestamp workflow-reply retransmission after completion must be dropped"
+    );
+
+    transport.stop().await.unwrap();
+}
+
+/// Boundary/documentation test for the dedup invariant: two identical workflow
+/// replies that reuse ONE timestamp are treated as a retransmission, so the
+/// second is dropped. This is exactly why issue #104 (password + identical
+/// confirmation) relies on the client stamping each distinct send with a DISTINCT
+/// timestamp — see `identical_workflow_replies_after_prompt_both_reach_host` for
+/// the distinct-timestamp (real-client) path where both reach the host.
+#[tokio::test]
+async fn identical_workflow_replies_with_same_timestamp_dedup_second() {
+    let host = Arc::new(MockHost::new());
+    host.set_response_for(
+        |cmd| matches!(cmd, Command::Help { .. }),
+        Response::Prompt {
+            text: "Choose a password:".to_owned(),
+            hide_input: true,
+        },
+    );
+    host.set_response_for(
+        |cmd| matches!(cmd, Command::WorkflowReply { .. }),
+        Response::Prompt {
+            text: "Confirm your password:".to_owned(),
+            hide_input: true,
+        },
+    );
+
+    let (transport, mut bridge) = make_transport(Arc::clone(&host), None).await;
+    bridge.complete_handshake("Node").await;
+
+    let sender = [0x93u8; 6];
+    bridge.send(&contact_msg_frame(sender, "help")).await; // distinct ts, enters workflow
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    let pw_ts = 1_700_050_000u32;
+    bridge
+        .send(&contact_msg_frame_ts(sender, "hunter2pw", pw_ts))
+        .await;
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    bridge
+        .send(&contact_msg_frame_ts(sender, "hunter2pw", pw_ts))
+        .await; // SAME timestamp ⇒ a retransmission
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    let reply_count = host
+        .commands_received()
+        .iter()
+        .filter(|(_, c)| matches!(c, Command::WorkflowReply { reply } if reply == "hunter2pw"))
+        .count();
+    assert_eq!(
+        reply_count, 1,
+        "a confirmation reusing the same timestamp is a retransmission and is dropped"
+    );
+
+    transport.stop().await.unwrap();
+}
+
 /// After a prompt, the next message must reach the host as a `WorkflowReply` —
 /// it must NOT be re-parsed as a standalone command at the transport layer. The
 /// host owns the decision of how to interpret a reply (including whether a
@@ -1018,6 +1145,83 @@ async fn real_host_oneshot_login_after_logout_yields_live_session() {
         who_text.contains("Logged in as squashed"),
         "BUG: session squashed after one-shot login — whoami got: {who_text:?}"
     );
+
+    transport.stop().await.unwrap();
+}
+
+/// Regression guard for the literal "Already logged in" symptom on a real host: a
+/// retransmitted `login` (same sender timestamp) must be deduped before reaching
+/// the host, so it is never reprocessed and the host never replies "Already
+/// logged in." Dedup runs before command parsing, so this also exercises the
+/// `login`-specific path of the symptom that motivated the feature.
+#[tokio::test]
+async fn real_host_retransmitted_login_is_not_reprocessed() {
+    let dbfile = tempfile::NamedTempFile::new().unwrap();
+    let db = bbs_core::Database::open(&dbfile.path().to_string_lossy())
+        .await
+        .unwrap();
+    let host: Arc<dyn bbs_plugin_api::Host> = Arc::new(bbs_core::BbsHost::new(db));
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let config = MeshConfig {
+        addr,
+        command_prefix: None,
+        welcome_message: String::new(),
+        reconnect_delay_initial_ms: 20,
+        reconnect_delay_max_ms: 50,
+        reply_max_attempts: 1,
+        ..MeshConfig::default()
+    };
+    let transport = MeshTransport::init(config, host).await.unwrap();
+    transport.start().await.unwrap();
+    let (stream, _) = listener.accept().await.unwrap();
+    let mut bridge = Bridge { stream };
+    bridge.complete_handshake("Node").await;
+
+    async fn next_text(bridge: &mut Bridge) -> Option<String> {
+        tokio::time::timeout(Duration::from_secs(2), bridge.read_text_send())
+            .await
+            .ok()
+            .map(|f| String::from_utf8_lossy(&f[13..]).to_string())
+    }
+    async fn expect_text_containing(bridge: &mut Bridge, want: &str) -> String {
+        loop {
+            let t = next_text(bridge)
+                .await
+                .unwrap_or_else(|| panic!("expected a frame containing {want:?}; timed out"));
+            if t.to_lowercase().contains(&want.to_lowercase()) {
+                return t;
+            }
+        }
+    }
+
+    let node_a = [0x9Bu8; 6];
+    let node_b = [0x9Cu8; 6];
+
+    // Node A registers the account (first user → Sysop, auto-verified).
+    bridge
+        .send(&contact_msg_frame(node_a, "register alice secretpw1"))
+        .await;
+    expect_text_containing(&mut bridge, "welcome").await;
+
+    // Node B is a fresh node: its first message mints a live session, so the
+    // one-shot login is processed directly (no UnknownSession refresh, which
+    // would otherwise reset the dedup ring). Then the byte-identical
+    // retransmission (same sender timestamp) must be deduped before the host.
+    let login_frame = contact_msg_frame_ts(node_b, "login alice secretpw1", 1_700_060_000);
+    bridge.send(&login_frame).await;
+    expect_text_containing(&mut bridge, "welcome").await;
+    bridge.send(&login_frame).await; // retransmission — must be deduped
+
+    // Drain any frames produced after the retransmission; none may be the
+    // reprocessing error.
+    while let Some(t) = next_text(&mut bridge).await {
+        assert!(
+            !t.to_lowercase().contains("already logged in"),
+            "retransmitted login was reprocessed by the host: {t:?}"
+        );
+    }
 
     transport.stop().await.unwrap();
 }

--- a/crates/bbs-mesh/tests/transport.rs
+++ b/crates/bbs-mesh/tests/transport.rs
@@ -11,7 +11,13 @@
 //! entering the event loop.  The test bridge must read all 11 bytes before
 //! sending SelfInfo to avoid leaving stale bytes in the TCP buffer.
 
-use std::{sync::Arc, time::Duration};
+use std::{
+    sync::{
+        atomic::{AtomicU32, Ordering},
+        Arc,
+    },
+    time::Duration,
+};
 
 use bbs_mesh::{MeshConfig, MeshTransport};
 use bbs_plugin_api::{
@@ -61,12 +67,25 @@ fn err_frame(error_code: u8) -> Vec<u8> {
     radio_frame(&[RESP_CODE_ERR, error_code])
 }
 
+/// Monotonic source of distinct sender timestamps so each `contact_msg_frame`
+/// models a genuinely new message. A real retransmission reuses a timestamp —
+/// use [`contact_msg_frame_ts`] with a repeated value for that.
+static NEXT_TS: AtomicU32 = AtomicU32::new(1_700_000_000);
+
 fn contact_msg_frame(sender_prefix: [u8; 6], text: &str) -> Vec<u8> {
+    let ts = NEXT_TS.fetch_add(1, Ordering::Relaxed);
+    contact_msg_frame_ts(sender_prefix, text, ts)
+}
+
+/// Like [`contact_msg_frame`] but with an explicit sender timestamp. Reuse the
+/// same `timestamp` across two frames to model a retransmission of one message;
+/// use distinct values to model two separate messages.
+fn contact_msg_frame_ts(sender_prefix: [u8; 6], text: &str, timestamp: u32) -> Vec<u8> {
     let mut payload = vec![RESP_CODE_CONTACT_MSG_RECV];
     payload.extend_from_slice(&sender_prefix);
     payload.push(0u8); // path_len
     payload.push(TXT_TYPE_PLAIN);
-    payload.extend_from_slice(&1_700_000_000u32.to_le_bytes());
+    payload.extend_from_slice(&timestamp.to_le_bytes());
     payload.extend_from_slice(text.as_bytes());
     radio_frame(&payload)
 }
@@ -367,6 +386,41 @@ async fn identical_workflow_replies_after_prompt_both_reach_host() {
         2,
         "both identical confirmations must reach the host, got commands: {:?}",
         received.iter().map(|(_, c)| c).collect::<Vec<_>>()
+    );
+
+    transport.stop().await.unwrap();
+}
+
+/// A true retransmission — the same message re-sent by the radio or a client
+/// that did not hear its ACK, reusing the sender's per-message timestamp — must
+/// reach the host only once, even though the text and session state are
+/// unchanged. This is the "Error: Already logged in" hardening: a resend can no
+/// longer be reprocessed, including copies that arrive after the text-only
+/// window or out of step with the workflow state.
+#[tokio::test]
+async fn retransmitted_command_with_same_timestamp_reaches_host_once() {
+    let host = Arc::new(MockHost::new());
+    host.set_default_response(Response::Text("ok".to_owned()));
+
+    let (transport, mut bridge) = make_transport(Arc::clone(&host), None).await;
+    bridge.complete_handshake("Node").await;
+
+    let sender = [0x77u8; 6];
+    let ts = 1_700_000_900u32;
+    // The same message arrives three times reusing the sender's timestamp.
+    for _ in 0..3 {
+        bridge.send(&contact_msg_frame_ts(sender, "help", ts)).await;
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+
+    let help_count = host
+        .commands_received()
+        .iter()
+        .filter(|(_, c)| matches!(c, Command::Help { .. }))
+        .count();
+    assert_eq!(
+        help_count, 1,
+        "a retransmitted command (same sender timestamp) must be processed once"
     );
 
     transport.stop().await.unwrap();
@@ -751,15 +805,17 @@ async fn real_host_register_double_send_then_password() {
 
     let sender = [0x88u8; 6];
 
-    // The flaky client sends REGISTER twice in quick succession.
+    // The flaky client RE-SENDS the same REGISTER message: a true retransmit
+    // reuses the sender's timestamp, so both copies carry the same one.
+    let register_ts = 1_700_000_500u32;
     bridge
-        .send(&contact_msg_frame(sender, "register dupe"))
+        .send(&contact_msg_frame_ts(sender, "register dupe", register_ts))
         .await;
     let _ = tokio::time::timeout(Duration::from_secs(2), bridge.read_text_send())
         .await
         .expect("first register reply");
     bridge
-        .send(&contact_msg_frame(sender, "register dupe"))
+        .send(&contact_msg_frame_ts(sender, "register dupe", register_ts))
         .await;
     // Second copy may or may not produce a frame depending on dedup; drain with a
     // short timeout so we don't block.


### PR DESCRIPTION
Closes #162

## Summary

Hardens inbound command deduplication so a retransmitted message can't be reprocessed — fixing duplicate command effects and the "Already logged in" symptom when a node re-sends a command whose ACK it never heard. Item (4) on the multi-hop reliability list; the `process_command` offload (item 5) follows in #161.

## Problem

Dedup matched on `(sender prefix, exact text)` within a fixed 10 s window that did **not** slide. On a congested link the sender re-sends a command long after the original (its ACK was delayed), so the resend lands past the window and gets reprocessed — e.g. a retried `login` yields "Already logged in".

## Fix

Dedup on the sender's **per-message `timestamp`** — already on the wire in `ContactMsg`, but previously discarded at the `handle_frame → dispatch_message` boundary. A genuine retransmission reuses `(timestamp, text)`, so a resend is dropped robustly — even one delayed past the old window or arriving after the workflow state changed.

Because a real *new* message always carries a new timestamp, the window can be generous (**120 s**) without false-dropping legitimately repeated text (a password and its confirmation — issue #104). `text` is part of the key so two distinct messages sharing a one-second timestamp aren't conflated. When a sender supplies no timestamp (`0`), the existing text-only window is used unchanged.

## Changes

- **`session.rs`**: `SessionState::dedup_by_timestamp` + a bounded per-node `(timestamp, text, seen)` identity ring (`RECENT_MSG_CAP = 16`, `TIMESTAMP_DEDUP_SECS = 120`); an injectable-clock helper makes the window/cap eviction unit-testable.
- **`transport.rs`**: thread `ContactMsg.timestamp` through `dispatch_message` (prefer the timestamp path, fall back to text dedup only when `0`); log the inbound timestamp; document why `recent_msgs` is intentionally **not** cleared on a prompt.
- **Tests**: timestamp dedup (drop/allow/zero/text-disambiguation), cap + window eviction, `timestamp == 0` fallback end-to-end (command + post-workflow reply), the same-timestamp #104 boundary, and a real-host login-resend guard (no "Already logged in").

## Verification

Full Linux gate green: `cargo fmt --check`, `cargo clippy --workspace -D warnings`, `cargo test --workspace`, `cargo doc`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
