### PR TITLE
perf(mesh): process commands on an off-loop worker

### DIFF
--- a/crates/bbs-mesh/src/transport.rs
+++ b/crates/bbs-mesh/src/transport.rs
@@ -77,9 +77,9 @@ const SAMPLE_TICK: Duration = Duration::from_secs(60);
 const HISTORY_SEED_SECS: u64 = 8 * 60 * 60;
 
 /// Depth of the queue feeding the command worker. Inbound LoRa traffic is slow
-/// (airtime-limited), so this is rarely above 1; the headroom only matters if a
-/// burst of queued messages drains faster than the host can process them, in
-/// which case the event loop applies backpressure rather than dropping work.
+/// (airtime-limited), so this is rarely above 1; the headroom only matters if
+/// frames arrive faster than the host can drain them, in which case the event
+/// loop blocks on `send` (backpressure) rather than dropping work.
 const COMMAND_QUEUE_DEPTH: usize = 64;
 
 /// Enqueue a plain-text reply to the companion client and, when retransmission
@@ -701,10 +701,11 @@ async fn event_loop(
     // (host DB I/O) never blocks the event loop from reading the next frame —
     // delivery confirmations, queued-message notifications, and the next
     // `SyncNextMessage` stay responsive. One worker preserves per-node ordering
-    // and the dedup check-and-record exactly as inline dispatch did. It drains
-    // and exits when `cmd_worker_tx` is dropped on event-loop exit.
+    // and the dedup check-and-record exactly as inline dispatch did. On
+    // shutdown the loop drops `cmd_worker_tx` and awaits the worker (bounded
+    // below) so any queued commands drain before the task exits.
     let (cmd_worker_tx, cmd_worker_rx) = mpsc::channel::<InboundCommand>(COMMAND_QUEUE_DEPTH);
-    tokio::spawn(command_worker(
+    let worker = tokio::spawn(command_worker(
         cmd_worker_rx,
         Arc::clone(&host),
         cmd_tx.clone(),
@@ -953,6 +954,13 @@ async fn event_loop(
             }
         }
     }
+
+    // Drain the command worker before the task ends: dropping the sender closes
+    // the channel, the worker finishes any queued commands, then `recv` returns
+    // `None` and it exits. Bounded so a stuck host command can't hang shutdown —
+    // on timeout the worker is left to finish (or be torn down with the runtime).
+    drop(cmd_worker_tx);
+    let _ = tokio::time::timeout(Duration::from_secs(5), worker).await;
 }
 
 /// Dispatch a single inbound frame from the radio bridge.
@@ -1361,7 +1369,8 @@ async fn dispatch_message(
     // ── Get or create a session for this node ─────────────────────────────────
     let Some((session, is_new)) = get_or_create_session(sender_prefix, host, state).await else {
         // Session creation failed; the error was already logged inside
-        // get_or_create_session.  Skip this message â the event loop continues.
+        // get_or_create_session.  Skip this message â the command worker continues
+        // with the next queued command.
         return;
     };
 
@@ -1724,13 +1733,13 @@ async fn get_or_create_session(
                 return Some((sid, false));
             }
             // We cannot proceed without a session, but we must NOT panic here.
-            // This function is called from a detached tokio::spawn event-loop
-            // task; a panic would kill the task permanently and silently, causing
-            // the BBS to stop responding to all mesh nodes with no visible error.
-            // Instead, log the failure and return None so the caller can skip
-            // this message and keep the event loop alive for future messages.
+            // This runs on the detached command_worker task; a panic would kill
+            // it permanently and silently, halting all mesh command processing
+            // with no visible error. Instead, log the failure and return None so
+            // the caller skips this message and the worker stays alive for the
+            // next queued command.
             error!(
-                "mesh: host.create_session failed and no fallback: {e}                  skipping this message to keep the event loop alive"
+                "mesh: host.create_session failed and no fallback: {e} — skipping this message to keep the command worker alive"
             );
             return None;
         }

--- a/crates/bbs-mesh/src/transport.rs
+++ b/crates/bbs-mesh/src/transport.rs
@@ -76,6 +76,12 @@ const SAMPLE_TICK: Duration = Duration::from_secs(60);
 /// (matches the in-memory ring's ~8h capacity).
 const HISTORY_SEED_SECS: u64 = 8 * 60 * 60;
 
+/// Depth of the queue feeding the command worker. Inbound LoRa traffic is slow
+/// (airtime-limited), so this is rarely above 1; the headroom only matters if a
+/// burst of queued messages drains faster than the host can process them, in
+/// which case the event loop applies backpressure rather than dropping work.
+const COMMAND_QUEUE_DEPTH: usize = 64;
+
 /// Enqueue a plain-text reply to the companion client and, when retransmission
 /// is enabled, record it in `tracker` for delivery tracking.
 ///
@@ -691,6 +697,26 @@ async fn event_loop(
         Err(e) => debug!("mesh: loading delivery history failed: {e}"),
     }
 
+    // Offload command processing to a single FIFO worker so handling a command
+    // (host DB I/O) never blocks the event loop from reading the next frame —
+    // delivery confirmations, queued-message notifications, and the next
+    // `SyncNextMessage` stay responsive. One worker preserves per-node ordering
+    // and the dedup check-and-record exactly as inline dispatch did. It drains
+    // and exits when `cmd_worker_tx` is dropped on event-loop exit.
+    let (cmd_worker_tx, cmd_worker_rx) = mpsc::channel::<InboundCommand>(COMMAND_QUEUE_DEPTH);
+    tokio::spawn(command_worker(
+        cmd_worker_rx,
+        Arc::clone(&host),
+        cmd_tx.clone(),
+        Arc::clone(&state),
+        command_prefix,
+        welcome_message,
+        node_credential_ttl_days,
+        flood_after_send,
+        Arc::clone(&send_tracker),
+        Arc::clone(&delivery_stats),
+    ));
+
     loop {
         tokio::select! {
             event = client.recv() => {
@@ -866,7 +892,7 @@ async fn event_loop(
                             _ => false,
                         };
                         if !consumed {
-                            handle_frame(frame, &host, &cmd_tx, &state, command_prefix, &welcome_message, node_credential_ttl_days, &draining, flood_after_send, &send_tracker, &delivery_stats).await;
+                            handle_frame(frame, &host, &cmd_tx, &state, &draining, &send_tracker, &delivery_stats, &cmd_worker_tx).await;
                         }
                     }
                 }
@@ -936,13 +962,10 @@ async fn handle_frame(
     host: &Arc<dyn Host>,
     cmd_tx: &mpsc::Sender<OutboundFrame>,
     state: &Arc<Mutex<SessionState>>,
-    command_prefix: Option<char>,
-    welcome_message: &str,
-    node_credential_ttl_days: u32,
     draining: &Arc<AtomicBool>,
-    flood_after_send: bool,
     send_tracker: &Arc<Mutex<SendTracker>>,
     delivery_stats: &Arc<DeliveryStats>,
+    cmd_worker_tx: &mpsc::Sender<InboundCommand>,
 ) {
     use meshcore_companion::frame::InboundFrame;
 
@@ -983,21 +1006,21 @@ async fn handle_frame(
                 len = msg.text.len(),
                 "mesh: inbound message received"
             );
-            dispatch_message(
-                msg.sender_key_prefix,
-                msg.timestamp,
-                &msg.text,
-                host,
-                cmd_tx,
-                state,
-                command_prefix,
-                welcome_message,
-                node_credential_ttl_days,
-                flood_after_send,
-                send_tracker,
-                delivery_stats,
-            )
-            .await;
+            // Hand the message to the command worker and return immediately so
+            // the event loop stays free to read the next frame instead of
+            // blocking on host I/O. The bounded channel applies backpressure
+            // (rarely reached at LoRa rates) rather than dropping a message.
+            if cmd_worker_tx
+                .send(InboundCommand {
+                    sender_prefix: msg.sender_key_prefix,
+                    timestamp: msg.timestamp,
+                    text: msg.text,
+                })
+                .await
+                .is_err()
+            {
+                warn!("mesh: command worker stopped — dropping inbound message");
+            }
         }
 
         // ── Queued message notification ───────────────────────────────────────
@@ -1262,6 +1285,57 @@ async fn handle_frame(
             debug!("mesh: ignoring frame {other:?}");
         }
     }
+}
+
+/// A plain-text direct message handed off from the event loop to the command
+/// worker for processing. Carries everything [`dispatch_message`] needs that is
+/// specific to one inbound message; the rest of its context is owned by the
+/// worker.
+struct InboundCommand {
+    sender_prefix: [u8; 6],
+    timestamp: u32,
+    text: String,
+}
+
+/// Process inbound commands off the event loop, one at a time, in arrival order.
+///
+/// The event loop forwards each plain-text DM here and immediately returns to
+/// reading frames, so handling a command (which awaits host DB I/O) never
+/// blocks delivery-confirmation handling or the next queued-message fetch. A
+/// single worker keeps per-node ordering — and the dedup check-and-record —
+/// identical to the previous inline dispatch. Exits when the event loop drops
+/// the sender and the queue drains.
+#[allow(clippy::too_many_arguments)]
+async fn command_worker(
+    mut rx: mpsc::Receiver<InboundCommand>,
+    host: Arc<dyn Host>,
+    cmd_tx: mpsc::Sender<OutboundFrame>,
+    state: Arc<Mutex<SessionState>>,
+    command_prefix: Option<char>,
+    welcome_message: String,
+    node_credential_ttl_days: u32,
+    flood_after_send: bool,
+    send_tracker: Arc<Mutex<SendTracker>>,
+    delivery_stats: Arc<DeliveryStats>,
+) {
+    while let Some(cmd) = rx.recv().await {
+        dispatch_message(
+            cmd.sender_prefix,
+            cmd.timestamp,
+            &cmd.text,
+            &host,
+            &cmd_tx,
+            &state,
+            command_prefix,
+            &welcome_message,
+            node_credential_ttl_days,
+            flood_after_send,
+            &send_tracker,
+            &delivery_stats,
+        )
+        .await;
+    }
+    debug!("mesh: command worker stopped (queue closed)");
 }
 
 /// Parse a direct message text, route it through the host, and send the reply.

--- a/crates/bbs-mesh/tests/transport.rs
+++ b/crates/bbs-mesh/tests/transport.rs
@@ -426,6 +426,48 @@ async fn retransmitted_command_with_same_timestamp_reaches_host_once() {
     transport.stop().await.unwrap();
 }
 
+/// Dispatch runs on a single off-loop command worker; this guards the invariant
+/// the offload relies on — a node's messages reach the host in arrival order. A
+/// per-message spawn instead of one FIFO worker would let workflow input race
+/// and reorder.
+#[tokio::test]
+async fn commands_from_same_node_processed_in_order() {
+    let host = Arc::new(MockHost::new());
+    // Every command returns a Prompt, so the session stays in awaiting-reply
+    // mode and each later message is delivered verbatim as a WorkflowReply.
+    host.set_default_response(Response::Prompt {
+        text: "?".to_owned(),
+        hide_input: false,
+    });
+
+    let (transport, mut bridge) = make_transport(Arc::clone(&host), None).await;
+    bridge.complete_handshake("Node").await;
+
+    let sender = [0x44u8; 6];
+    bridge.send(&contact_msg_frame(sender, "help")).await; // enters awaiting-reply
+    for reply in ["one", "two", "three"] {
+        tokio::time::sleep(Duration::from_millis(30)).await;
+        bridge.send(&contact_msg_frame(sender, reply)).await;
+    }
+    tokio::time::sleep(Duration::from_millis(60)).await;
+
+    let replies: Vec<String> = host
+        .commands_received()
+        .iter()
+        .filter_map(|(_, c)| match c {
+            Command::WorkflowReply { reply } => Some(reply.clone()),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(
+        replies,
+        vec!["one", "two", "three"],
+        "messages must reach the host in arrival order"
+    );
+
+    transport.stop().await.unwrap();
+}
+
 /// After a prompt, the next message must reach the host as a `WorkflowReply` —
 /// it must NOT be re-parsed as a standalone command at the transport layer. The
 /// host owns the decision of how to interpret a reply (including whether a

--- a/crates/bbs-mesh/tests/transport.rs
+++ b/crates/bbs-mesh/tests/transport.rs
@@ -468,6 +468,101 @@ async fn commands_from_same_node_processed_in_order() {
     transport.stop().await.unwrap();
 }
 
+/// Two different nodes interleaving through the single FIFO worker: each node's
+/// messages reach the host in that node's own arrival order, and the per-node
+/// dedup rings don't cross-contaminate.
+#[tokio::test]
+async fn two_nodes_interleaved_preserve_per_node_order() {
+    let host = Arc::new(MockHost::new());
+    host.set_default_response(Response::Prompt {
+        text: "?".to_owned(),
+        hide_input: false,
+    });
+
+    let (transport, mut bridge) = make_transport(Arc::clone(&host), None).await;
+    bridge.complete_handshake("Node").await;
+
+    let a = [0xA1u8; 6];
+    let b = [0xB2u8; 6];
+    // Each node enters awaiting-reply, then sends ordered replies, interleaved.
+    bridge.send(&contact_msg_frame(a, "help")).await;
+    bridge.send(&contact_msg_frame(b, "help")).await;
+    for (ra, rb) in [("a1", "b1"), ("a2", "b2"), ("a3", "b3")] {
+        tokio::time::sleep(Duration::from_millis(20)).await;
+        bridge.send(&contact_msg_frame(a, ra)).await;
+        bridge.send(&contact_msg_frame(b, rb)).await;
+    }
+    tokio::time::sleep(Duration::from_millis(80)).await;
+
+    let replies: Vec<String> = host
+        .commands_received()
+        .iter()
+        .filter_map(|(_, c)| match c {
+            Command::WorkflowReply { reply } => Some(reply.clone()),
+            _ => None,
+        })
+        .collect();
+    let a_order: Vec<&str> = replies
+        .iter()
+        .filter(|r| r.starts_with('a'))
+        .map(String::as_str)
+        .collect();
+    let b_order: Vec<&str> = replies
+        .iter()
+        .filter(|r| r.starts_with('b'))
+        .map(String::as_str)
+        .collect();
+    assert_eq!(a_order, vec!["a1", "a2", "a3"], "node A in arrival order");
+    assert_eq!(b_order, vec!["b1", "b2", "b3"], "node B in arrival order");
+
+    transport.stop().await.unwrap();
+}
+
+/// A burst larger than the worker queue depth applies backpressure (the event
+/// loop blocks on `send`) rather than dropping work: with a deliberately slow
+/// host, every message still reaches the host exactly once, in order.
+#[tokio::test]
+async fn burst_beyond_queue_depth_is_not_dropped_and_stays_ordered() {
+    let host = Arc::new(MockHost::new());
+    host.set_default_response(Response::Prompt {
+        text: "?".to_owned(),
+        hide_input: false,
+    });
+    // Slow host so the worker drains slower than the burst arrives, forcing the
+    // bounded channel (COMMAND_QUEUE_DEPTH = 64) to fill and backpressure.
+    host.set_process_delay(Duration::from_millis(10));
+
+    let (transport, mut bridge) = make_transport(Arc::clone(&host), None).await;
+    bridge.complete_handshake("Node").await;
+
+    let sender = [0xCCu8; 6];
+    bridge.send(&contact_msg_frame(sender, "help")).await; // enters awaiting-reply
+    let n = 80usize; // > COMMAND_QUEUE_DEPTH
+    for i in 0..n {
+        bridge
+            .send(&contact_msg_frame(sender, &format!("m{i}")))
+            .await;
+    }
+    // Wait for the slow host to drain the whole burst (~n * delay + margin).
+    tokio::time::sleep(Duration::from_millis(n as u64 * 10 + 800)).await;
+
+    let replies: Vec<String> = host
+        .commands_received()
+        .iter()
+        .filter_map(|(_, c)| match c {
+            Command::WorkflowReply { reply } => Some(reply.clone()),
+            _ => None,
+        })
+        .collect();
+    let expected: Vec<String> = (0..n).map(|i| format!("m{i}")).collect();
+    assert_eq!(
+        replies, expected,
+        "every burst message must reach the host once, in order, with none dropped"
+    );
+
+    transport.stop().await.unwrap();
+}
+
 /// A sender that supplies no per-message timestamp (`timestamp == 0`) still gets
 /// retransmission dedup via the text-only fallback window — the path that guards
 /// legacy/no-clock devices. Exercises the `timestamp == 0` branch end-to-end.

--- a/crates/bbs-plugin-api/src/testing.rs
+++ b/crates/bbs-plugin-api/src/testing.rs
@@ -30,6 +30,7 @@
 
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
+use std::time::Duration;
 
 use async_trait::async_trait;
 use tokio::sync::broadcast;
@@ -73,6 +74,9 @@ struct MockHostState {
     default_response: Response,
     /// Every command that has been dispatched, in order.
     commands_received: Vec<(SessionId, Command)>,
+    /// Artificial delay applied inside `process_command` before recording and
+    /// responding, to exercise slow-host / backpressure paths. Zero by default.
+    process_delay: Duration,
 }
 
 #[derive(Debug, Clone)]
@@ -112,6 +116,7 @@ impl MockHost {
                 responses: Vec::new(),
                 default_response: Response::Text("(unscripted)".to_owned()),
                 commands_received: Vec::new(),
+                process_delay: Duration::ZERO,
             }),
             events: tx,
             advert_bus: Arc::new(AdvertBus::new()),
@@ -158,6 +163,13 @@ impl MockHost {
         state.default_response = response;
     }
 
+    /// Make `process_command` sleep `delay` before recording and responding.
+    /// Lets tests model a slow host to exercise the transport's command-queue
+    /// backpressure without dropping or reordering. Defaults to zero (no delay).
+    pub fn set_process_delay(&self, delay: Duration) {
+        self.state.lock().expect("mock poisoned").process_delay = delay;
+    }
+
     /// Inspect the commands that have been dispatched, in order.
     /// Returns owned clones — the mock keeps its own record.
     #[must_use]
@@ -192,6 +204,13 @@ impl Host for MockHost {
         session: SessionId,
         cmd: Command,
     ) -> Result<Response, HostError> {
+        // Read the configured delay without holding the lock across the await,
+        // then sleep to model a slow host (used by backpressure tests).
+        let delay = self.state.lock().expect("mock poisoned").process_delay;
+        if !delay.is_zero() {
+            tokio::time::sleep(delay).await;
+        }
+
         let mut state = self.state.lock().expect("mock poisoned");
 
         // Verify the session is known.


### PR DESCRIPTION
Closes #163

> **Stacked on #160** — base is `fix/mesh-harden-inbound-dedup`. Merge #160 first; this PR's base retargets to `main` once #160 lands. The diff shown is this PR's incremental change only.

## Summary

Moves mesh command processing off the event loop onto a single FIFO worker, so handling a command (host DB I/O) no longer blocks the loop from reading the next frame. Item (5) on the multi-hop reliability list.

## Problem

`dispatch_message` ran inline on the event loop's `select!`. While a command awaited the host, the loop couldn't read the next frame — so delivery confirmations (`PUSH_CODE_SEND_CONFIRMED`), `MsgWaiting` notifications, and the next `SyncNextMessage` all waited behind it. On a busy node that serializes traffic and adds self-congestion.

## Fix

Hand each inbound plain-text DM to a single FIFO `command_worker` task over a bounded channel and return to the loop immediately.

- **Ordering preserved** — one worker consumes the queue in arrival order, so per-node ordering (and the dedup check-and-record) is identical to inline dispatch. A per-message spawn would risk reordering workflow input — guarded by a test.
- **No new `send_tracker` race** — `enqueue_text` already holds the tracker lock across both the send and the record, so the event loop's `on_sent` correlation is unaffected by the added concurrency.
- **Clean shutdown** — the event loop captures the worker `JoinHandle` and awaits it (bounded 5 s) so queued commands drain before the task exits.
- **Backpressure, not drops** — bounded channel (`COMMAND_QUEUE_DEPTH = 64`).

`handle_frame` no longer carries the dispatch-only context (`command_prefix`, `welcome_message`, `node_credential_ttl_days`, `flood_after_send`) — the worker owns it.

## Tests

Per-node FIFO ordering; two-node interleaving (per-node order + no cross-node dedup leakage); a burst beyond `COMMAND_QUEUE_DEPTH` applies backpressure and is neither dropped nor reordered (via a new `MockHost::set_process_delay` slow-host seam).

## Verification

Full Linux gate green: `cargo fmt --check`, `cargo clippy --workspace -D warnings`, `cargo test --workspace`, `cargo doc`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
