### PR TITLE
docs: correct stale tracing-target examples to crate paths

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -104,7 +104,7 @@
 # specific subsystem without turning the whole BBS verbose.
 # Defaults clamp the noisy ones to WARN.
 # [logging.targets]
-# "supply_drop_bbs::transport::mesh" = "DEBUG"
+# "bbs_mesh" = "DEBUG"                  # MeshCore transport (whole crate)
 # "sqlx::query" = "INFO"
 # "meshcore_companion::frame" = "WARN"
 

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -210,10 +210,15 @@ Per-target overrides example:
 
 ```toml
 [logging.targets]
-"supply_drop_bbs::transport::mesh" = "DEBUG"
+"bbs_mesh" = "DEBUG"                  # MeshCore transport (whole crate)
 "sqlx::query" = "INFO"
 "meshcore_companion::frame" = "WARN"
 ```
+
+Targets are Rust module paths. First-party code lives in per-crate paths
+(`bbs_mesh`, `bbs_meshtastic`, `bbs_core`, `bbs_web`, `meshcore_companion`, and
+the `supply_drop_bbs` binary), so target the crate (or a module within it, e.g.
+`bbs_mesh::transport`) — not a single `supply_drop_bbs::*` prefix.
 
 See [ADR-0009](adr/0009-tracing-config-respected.md) for the
 no-silent-overrides rule.

--- a/docs/DUAL_TRANSPORT.md
+++ b/docs/DUAL_TRANSPORT.md
@@ -175,8 +175,8 @@ journalctl -u supply-drop-bbs -f
 You should see a connected line for each transport within a few seconds:
 
 ```
-INFO supply_drop_bbs::transport::mesh        connected
-INFO supply_drop_bbs::transport::meshtastic  connected
+INFO bbs_mesh::transport     connected
+INFO bbs_meshtastic           connected
 ```
 
 If the MeshCore HAT transport logs a connection error, check that `pymc_core` is running:
@@ -191,8 +191,8 @@ To turn on verbose logging for just one transport without making everything nois
 
 ```toml
 [logging.targets]
-"supply_drop_bbs::transport::mesh"       = "DEBUG"
-"supply_drop_bbs::transport::meshtastic" = "DEBUG"
+"bbs_mesh"       = "DEBUG"   # MeshCore transport crate
+"bbs_meshtastic" = "DEBUG"   # Meshtastic transport crate
 ```
 
 ---

--- a/docs/PLUGIN_API.md
+++ b/docs/PLUGIN_API.md
@@ -618,7 +618,8 @@ and not yet committed to backward compatibility.
   `pub(crate)`; only the `Plugin`-implementing struct is `pub`
 - Config struct is named `<Plugin>Config`
 - Errors: one enum per plugin, named `<Plugin>Error`
-- Logging: use `tracing` macros, target `supply_drop_bbs::<plugin-name>`
+- Logging: use `tracing` macros; events are tagged with the plugin crate's
+  module path (e.g. `bbs_mesh::transport`), which is what operators filter on
 
 ## Contributing a plugin
 

--- a/docs/adr/0009-tracing-config-respected.md
+++ b/docs/adr/0009-tracing-config-respected.md
@@ -145,7 +145,7 @@ The default per-target levels (clamped from root):
 
 | Target prefix              | Default | Notes                          |
 |----------------------------|---------|--------------------------------|
-| `supply_drop_bbs::*`       | inherit | Our own code; root level       |
+| `bbs_*`, `supply_drop_bbs` | inherit | Our own code (per-crate paths) |
 | `meshcore_companion::frame` | WARN   | Per-frame trace; very noisy   |
 | `sqlx::query`              | WARN    | Per-query trace; very noisy   |
 | `hyper`, `tower`, `axum`   | WARN    | Web framework internals       |
@@ -154,7 +154,7 @@ Operators override individual targets via:
 
 ```toml
 [logging.targets]
-"supply_drop_bbs::transport::mesh" = "DEBUG"
+"bbs_mesh" = "DEBUG"
 "sqlx::query" = "INFO"
 ```
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -323,7 +323,7 @@ pub struct LoggingConfig {
     /// Example in TOML:
     /// ```toml
     /// [logging.targets]
-    /// "supply_drop_bbs::transport::mesh" = "DEBUG"
+    /// "bbs_mesh" = "DEBUG"
     /// "sqlx::query" = "WARN"
     /// ```
     #[serde(default)]


### PR DESCRIPTION
## Summary

The mesh/meshtastic transports were extracted into their own crates (`bbs-mesh`, `bbs-meshtastic`), so their `tracing` targets are the crate module paths (`bbs_mesh`, `bbs_meshtastic`) — **not** the pre-refactor `supply_drop_bbs::transport::mesh`. An operator who copied the stale examples enabled a `[logging.targets]` key that matches nothing (e.g. trying to debug the mesh transport, or read the new inbound-message timestamp log).

## Changes

Corrected the `[logging.targets]` examples and log-output samples in:
- `config.example.toml`, `src/config.rs` (doc comment), `docs/CONFIG.md`
- `docs/DUAL_TRANSPORT.md` (config example + example log lines)
- `docs/adr/0009-tracing-config-respected.md`, `docs/PLUGIN_API.md`

Added a note that first-party code lives in per-crate paths (`bbs_mesh`, `bbs_meshtastic`, `bbs_core`, `bbs_web`, `meshcore_companion`, plus the `supply_drop_bbs` binary), so you target a crate (or a module within it) rather than a single `supply_drop_bbs::*` prefix. No code behavior change.

## Verification

Full Linux gate green (the only non-doc file is a doc-comment in `src/config.rs`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
