### PR TITLE
fix(install): grant serial-port access across distros (dialout vs plugdev) (#167)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -105,6 +105,7 @@ jobs:
           mkdir -p "${PKG}/DEBIAN"
           mkdir -p "${PKG}/usr/local/bin"
           mkdir -p "${PKG}/lib/systemd/system"
+          mkdir -p "${PKG}/lib/udev/rules.d"
           mkdir -p "${PKG}/etc/supply-drop-bbs"
           mkdir -p "${PKG}/var/lib/supply-drop-bbs"
 
@@ -116,6 +117,10 @@ jobs:
           # Systemd service unit
           cp supply-drop-bbs.service \
              "${PKG}/lib/systemd/system/supply-drop-bbs.service"
+
+          # udev rule — grants the service serial-port access across distros
+          cp packaging/70-supply-drop-bbs.rules \
+             "${PKG}/lib/udev/rules.d/70-supply-drop-bbs.rules"
 
           # control — dpkg extended description continuation lines need exactly
           # one leading space, which is produced here by the YAML indentation.

--- a/crates/bbs-meshtastic/src/stream.rs
+++ b/crates/bbs-meshtastic/src/stream.rs
@@ -137,6 +137,31 @@ async fn run_serial_worker(
         .await;
 }
 
+/// Map a serial-open error to an `io::Error`, upgrading a permission-denied
+/// failure to an actionable message. Access-denied on the radio's tty is a
+/// common Pi/Debian gotcha: the device is group-owned by `plugdev` (or
+/// `dialout`, depending on the distro) and the `supply-drop` service user is
+/// not in that group.
+fn serial_open_error(port: &str, e: tokio_serial::Error) -> io::Error {
+    if matches!(
+        e.kind(),
+        tokio_serial::ErrorKind::Io(io::ErrorKind::PermissionDenied)
+    ) {
+        io::Error::new(
+            io::ErrorKind::PermissionDenied,
+            format!(
+                "permission denied opening serial port {port}: the service user is not in the \
+                 group that owns the device. Run `ls -l {port}` to find the owning group \
+                 (commonly `dialout` or `plugdev`), add the user to it \
+                 (`sudo usermod -aG <group> supply-drop`), then restart the service. \
+                 See docs/OPERATIONS.md — \"Serial port: Permission denied\"."
+            ),
+        )
+    } else {
+        io::Error::other(format!("could not open serial port {port}: {e}"))
+    }
+}
+
 async fn attempt_serial_session(
     config: &SerialConfig,
     cmd_rx: &mut mpsc::Receiver<ToRadio>,
@@ -145,10 +170,7 @@ async fn attempt_serial_session(
     let stream = match tokio_serial::new(&config.port, config.baud_rate).open_native_async() {
         Ok(s) => s,
         Err(e) => {
-            return SessionOutcome::IoError(io::Error::other(format!(
-                "could not open serial port {}: {e}",
-                config.port
-            )));
+            return SessionOutcome::IoError(serial_open_error(&config.port, e));
         }
     };
     info!(port = %config.port, baud = config.baud_rate, "meshtastic/serial: opened");
@@ -364,5 +386,25 @@ mod tests {
         tx.write_all(&bytes).await.unwrap();
         let decoded = read_from_radio(&mut rx).await.unwrap();
         assert_eq!(decoded.id, 1);
+    }
+
+    #[test]
+    fn permission_denied_serial_error_is_actionable() {
+        let e = tokio_serial::Error::new(
+            tokio_serial::ErrorKind::Io(io::ErrorKind::PermissionDenied),
+            "permission denied",
+        );
+        let mapped = serial_open_error("/dev/ttyACM0", e);
+        assert_eq!(mapped.kind(), io::ErrorKind::PermissionDenied);
+        assert!(mapped.to_string().contains("usermod"));
+        assert!(mapped.to_string().contains("ls -l"));
+    }
+
+    #[test]
+    fn other_serial_error_keeps_generic_message() {
+        let e = tokio_serial::Error::new(tokio_serial::ErrorKind::NoDevice, "nope");
+        let mapped = serial_open_error("/dev/ttyACM0", e);
+        assert_ne!(mapped.kind(), io::ErrorKind::PermissionDenied);
+        assert!(mapped.to_string().contains("could not open serial port"));
     }
 }

--- a/crates/meshcore-companion/src/client.rs
+++ b/crates/meshcore-companion/src/client.rs
@@ -362,6 +362,31 @@ async fn run_serial_worker(
         .await;
 }
 
+/// Map a serial-open error to an `io::Error`, upgrading a permission-denied
+/// failure to an actionable message. Access-denied on the radio's tty is a
+/// common Pi/Debian gotcha: the device is group-owned by `plugdev` (or
+/// `dialout`, depending on the distro) and the `supply-drop` service user is
+/// not in that group.
+fn serial_open_error(port: &str, e: tokio_serial::Error) -> io::Error {
+    if matches!(
+        e.kind(),
+        tokio_serial::ErrorKind::Io(io::ErrorKind::PermissionDenied)
+    ) {
+        io::Error::new(
+            io::ErrorKind::PermissionDenied,
+            format!(
+                "permission denied opening serial port {port}: the service user is not in the \
+                 group that owns the device. Run `ls -l {port}` to find the owning group \
+                 (commonly `dialout` or `plugdev`), add the user to it \
+                 (`sudo usermod -aG <group> supply-drop`), then restart the service. \
+                 See docs/OPERATIONS.md — \"Serial port: Permission denied\"."
+            ),
+        )
+    } else {
+        io::Error::other(format!("could not open serial port {port}: {e}"))
+    }
+}
+
 async fn attempt_serial_session(
     config: &SerialConfig,
     cmd_rx: &mut mpsc::Receiver<OutboundFrame>,
@@ -370,10 +395,7 @@ async fn attempt_serial_session(
     let stream = match tokio_serial::new(&config.port, config.baud_rate).open_native_async() {
         Ok(s) => s,
         Err(e) => {
-            return SessionOutcome::IoError(
-                io::Error::other(format!("could not open serial port {}: {e}", config.port)),
-                false,
-            );
+            return SessionOutcome::IoError(serial_open_error(&config.port, e), false);
         }
     };
     info!(port = %config.port, baud = config.baud_rate, "companion/serial: port opened");
@@ -630,4 +652,29 @@ async fn read_frame<R: AsyncRead + Unpin>(reader: &mut R) -> io::Result<InboundF
 
     decode_inbound(&payload)
         .map_err(|e: FrameDecodeError| io::Error::new(io::ErrorKind::InvalidData, e.to_string()))
+}
+
+#[cfg(test)]
+mod serial_open_error_tests {
+    use super::*;
+
+    #[test]
+    fn permission_denied_serial_error_is_actionable() {
+        let e = tokio_serial::Error::new(
+            tokio_serial::ErrorKind::Io(io::ErrorKind::PermissionDenied),
+            "permission denied",
+        );
+        let mapped = serial_open_error("/dev/ttyACM0", e);
+        assert_eq!(mapped.kind(), io::ErrorKind::PermissionDenied);
+        assert!(mapped.to_string().contains("usermod"));
+        assert!(mapped.to_string().contains("ls -l"));
+    }
+
+    #[test]
+    fn other_serial_error_keeps_generic_message() {
+        let e = tokio_serial::Error::new(tokio_serial::ErrorKind::NoDevice, "nope");
+        let mapped = serial_open_error("/dev/ttyACM0", e);
+        assert_ne!(mapped.kind(), io::ErrorKind::PermissionDenied);
+        assert!(mapped.to_string().contains("could not open serial port"));
+    }
 }

--- a/docs/DUAL_TRANSPORT.md
+++ b/docs/DUAL_TRANSPORT.md
@@ -185,7 +185,7 @@ If the MeshCore HAT transport logs a connection error, check that `pymc_core` is
 systemctl status pymc-core
 ```
 
-If either transport logs a serial error, confirm the port name with `dmesg | grep tty` and update `serial_port` in the config.
+If either transport logs a serial error, confirm the port name with `dmesg | grep tty` and update `serial_port` in the config. If the error is `Permission denied (os error 13)`, the service user lacks access to the port's group — see [OPERATIONS.md → Serial port: Permission denied](OPERATIONS.md#serial-port-permission-denied).
 
 To turn on verbose logging for just one transport without making everything noisy:
 

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -812,8 +812,9 @@ ls -la /dev/ttyACM* /dev/ttyUSB*
 sudo journalctl -u supply-drop-bbs -f
 ```
 
-Common causes: wrong `serial_port` in config; device not in `dialout` group
-(`sudo usermod -aG dialout supply-drop`); firmware crashed (unplug and replug).
+Common causes: wrong `serial_port` in config; **permission denied** on the port
+(see [Serial port: Permission denied](#serial-port-permission-denied) below);
+firmware crashed (unplug and replug).
 
 **Pi HAT:**
 
@@ -828,6 +829,51 @@ Common causes:
 - `supply-drop` user not in `spi`/`gpio` groups (installer adds these; a reboot may be needed)
 - Missing Python dependency - `sudo /opt/pymc-companion/venv/bin/pip install spidev lgpio`
 - Wrong HAT selected - edit `/etc/supply-drop-bbs/pymc-companion.yaml` and restart pymc-companion
+
+### Serial port: Permission denied
+
+Symptom — the log repeats:
+
+```
+could not open serial port /dev/ttyACM0: Permission denied (os error 13)
+```
+
+The service (running as the `supply-drop` user) is not in the group that owns the
+serial device. Check the owning group:
+
+```sh
+ls -l /dev/ttyACM* /dev/ttyUSB*
+```
+
+```
+crw-rw----+ 1 root plugdev 166, 0 … /dev/ttyACM0
+```
+
+The **owning group varies by distro** — `dialout` on many systems, but `plugdev`
+on current Raspberry Pi OS / Debian 13 "Trixie". The trailing `+` is a POSIX ACL
+that grants the interactive desktop (seat) user; a headless system service never
+receives it, so access depends on group membership.
+
+**Packaged installs** (`.deb` / `install.sh`) ship a udev rule
+(`/lib/udev/rules.d/70-supply-drop-bbs.rules`) that re-owns the radio's tty to the
+`supply-drop` group automatically. If it has not taken effect, reapply it:
+
+```sh
+sudo udevadm control --reload-rules && sudo udevadm trigger --subsystem-match=tty
+sudo systemctl restart supply-drop-bbs
+```
+
+**Manual / raw-binary installs** — add the service user to the owning group, then
+restart:
+
+```sh
+sudo usermod -aG <owning-group> supply-drop   # e.g. plugdev or dialout
+sudo systemctl restart supply-drop-bbs
+```
+
+`udevadm trigger` re-applies device ownership without unplugging the radio, but a
+**group-membership change takes effect only after the service restarts** (a reboot
+always works).
 
 ### Database locked
 

--- a/install.sh
+++ b/install.sh
@@ -97,6 +97,13 @@ if [[ "${1:-}" == "--uninstall" ]]; then
             success "Removed $_unit"
         fi
     done
+
+    # Remove the serial-port udev rule.
+    if [[ -f /lib/udev/rules.d/70-supply-drop-bbs.rules ]]; then
+        rm -f /lib/udev/rules.d/70-supply-drop-bbs.rules
+        success "Removed /lib/udev/rules.d/70-supply-drop-bbs.rules"
+        command -v udevadm &>/dev/null && udevadm control --reload-rules || true
+    fi
     systemctl daemon-reload
 
     # Remove sudoers rule.
@@ -407,6 +414,17 @@ fi
 
 # Add service user to dialout for serial port access.
 usermod -aG dialout "$SERVICE_USER"
+
+# Install the udev rule so the service can open the radio's serial port
+# regardless of the distro's default tty group (dialout on some systems,
+# plugdev on current Raspberry Pi OS / Debian Trixie). It re-owns ttyACM*/
+# ttyUSB* to the `supply-drop` group (created above).
+install -m 644 "$SRC_DIR/packaging/70-supply-drop-bbs.rules" \
+    /lib/udev/rules.d/70-supply-drop-bbs.rules
+if command -v udevadm &>/dev/null; then
+    udevadm control --reload-rules || true
+    udevadm trigger --subsystem-match=tty --action=add || true
+fi
 
 # ── Directories ───────────────────────────────────────────────────────────────
 

--- a/packaging/70-supply-drop-bbs.rules
+++ b/packaging/70-supply-drop-bbs.rules
@@ -1,0 +1,9 @@
+# Supply Drop BBS — grant the service account access to USB serial radios
+# regardless of the distro's default tty group (dialout on some systems,
+# plugdev on current Raspberry Pi OS / Debian Trixie).
+#
+# Runs after 50-udev-default.rules so this GROUP= assignment wins. The device
+# node is re-owned to the service's own primary group (`supply-drop`), which
+# exists because the package/installer creates the user before udev is applied.
+SUBSYSTEM=="tty", KERNEL=="ttyACM[0-9]*", GROUP="supply-drop", MODE="0660"
+SUBSYSTEM=="tty", KERNEL=="ttyUSB[0-9]*", GROUP="supply-drop", MODE="0660"

--- a/packaging/postinst
+++ b/packaging/postinst
@@ -26,6 +26,17 @@ case "$1" in
     # ── Config directory — populated by the setup wizard ────────────────────
     mkdir -p /etc/supply-drop-bbs
 
+    # ── Serial-port access — apply the packaged udev rule ───────────────────
+    # 70-supply-drop-bbs.rules re-owns the radio's tty to the `supply-drop`
+    # group so the service can open it regardless of the distro's default tty
+    # group (dialout vs plugdev). The `supply-drop` group exists by now
+    # (created above). Reload + trigger so an already-connected radio picks up
+    # the new ownership without needing a replug. Idempotent on upgrades.
+    if command -v udevadm >/dev/null 2>&1; then
+      udevadm control --reload-rules || true
+      udevadm trigger --subsystem-match=tty --action=add || true
+    fi
+
     if command -v systemctl >/dev/null 2>&1; then
       systemctl daemon-reload || true
 

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -2096,17 +2096,23 @@ fn print_next_steps(
         println!();
     }
 
-    let needs_dialout = cfg!(target_os = "linux")
+    let needs_serial_access = cfg!(target_os = "linux")
         && ((use_mesh && mesh_conn_type == "serial")
             || (use_meshtastic && matches!(meshtastic_conn_type, "serial" | "hat")));
 
-    if needs_dialout {
-        println!("To allow Supply Drop BBS to access serial ports, your user must");
-        println!("be in the 'dialout' group:");
+    if needs_serial_access {
+        println!("Serial port access:");
         println!();
-        println!("  sudo usermod -aG dialout $USER");
-        println!("  # then log out and back in, or run:");
-        println!("  newgrp dialout");
+        println!("The .deb package and install.sh ship a udev rule that grants the");
+        println!("'supply-drop' service user access to the radio automatically, so no");
+        println!("group change is usually needed.");
+        println!();
+        println!("If you installed the binary manually and hit 'Permission denied' on");
+        println!("the port, add the service user to the group that owns the device");
+        println!("(it varies by distro — 'dialout' or 'plugdev'):");
+        println!();
+        println!("  ls -l <port>                          # shows the owning group");
+        println!("  sudo usermod -aG <group> supply-drop  # then restart the service");
         println!();
         if use_mesh && mesh_conn_type == "serial" {
             if let Some(port) = mesh_serial_port {


### PR DESCRIPTION
Closes #167

## Summary

On current Raspberry Pi OS / Debian 13 "Trixie", the USB radio's tty node is group **`plugdev`**, not `dialout` (the trailing `+` is a uaccess ACL that only covers the interactive seat user — a headless service never gets it). The `supply-drop` service is only ever added to `dialout`, so it hits `Permission denied (os error 13)` opening the port. The reporter confirmed adding to `plugdev` fixes it — the owning group varies by distro and the install hard-codes one scheme.

## Fix — distro-agnostic udev rule

New `packaging/70-supply-drop-bbs.rules` re-owns `ttyACM*`/`ttyUSB*` to the service's own primary group `supply-drop`, so access works regardless of whether the distro puts serial in `dialout` or `plugdev` — no dependency on a group existing, no new package dependency.

- **`.deb`:** packaged via `release.yml`; `postinst` runs `udevadm control --reload-rules && udevadm trigger` so an already-connected radio picks up the new ownership without a replug.
- **`install.sh`:** installs the rule + reloads/triggers; the uninstall path removes it.
- **systemd unit left unchanged** — deliberately *not* adding `plugdev` to `SupplementaryGroups=` (systemd fails the whole unit if a supplementary group can't be resolved, which would regress minimal/headless images that lack `plugdev`).

## Make the failure self-explanatory

- Both serial-open sites (`bbs-meshtastic/src/stream.rs`, `meshcore-companion/src/client.rs`) now upgrade an EACCES to an actionable message (which group owns the port, `ls -l <port>`, `sudo usermod -aG <group> supply-drop`, restart), with unit tests. Non-permission errors are byte-for-byte unchanged.
- The setup-wizard hint is group-agnostic, targets the `supply-drop` **service** user (not `$USER`, which is `root` under `sudo`), and notes the udev rule handles it automatically.
- New `docs/OPERATIONS.md` → **"Serial port: Permission denied"** troubleshooting entry; `docs/DUAL_TRANSPORT.md` cross-links it.

## Verification

Full Linux gate green (`cargo fmt --check`, `cargo clippy --workspace -D warnings`, `cargo test --workspace`, `cargo doc`); `sh -n packaging/postinst` and `bash -n install.sh` pass. New unit tests cover the EACCES-vs-other message split in both crates.

Note: the udev rule ships with the **next release**. Existing installs can apply the reporter's workaround (`sudo usermod -aG plugdev supply-drop`) or drop the rule in manually per the new docs entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
