### PR TITLE
feat(mesh): instrument inbound deliverability and harden message fetch

### DIFF
--- a/crates/bbs-mesh/examples/deliverability_repro.rs
+++ b/crates/bbs-mesh/examples/deliverability_repro.rs
@@ -1,0 +1,221 @@
+//! Deliverability repro harness.
+//!
+//! Stands up a fake pyMC-style companion bridge on TCP loopback, runs the real
+//! MeshCore [`MeshTransport`] against it, feeds crafted frames, and prints the
+//! inbound delivery counters after each scenario — so you can watch them move
+//! without a radio or a real user.
+//!
+//! ```text
+//! cargo run -p bbs-mesh --example deliverability_repro
+//! ```
+//!
+//! It exercises the three inbound signatures this instrumentation surfaces:
+//!   1. a normal DM → `inbound_received`.
+//!   2. a same-timestamp resend → `dedup_dropped_timestamp` (a coarse-clock bridge like pyMC collides two same-second sends).
+//!   3. a reconnect backlog → fresh processed, clearly-stale → `reconnect_discarded`.
+//!
+//! This is a diagnostic/demo harness, not a test — it prints, it doesn't assert.
+//! The equivalent assertions live in `tests/transport.rs`.
+
+use std::sync::Arc;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use bbs_mesh::{MeshConfig, MeshTransport};
+use bbs_plugin_api::{plugin::Plugin, testing::MockHost, Response};
+use meshcore_companion::constants::*;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpStream;
+
+// ── companion-frame builders (mirror crates/bbs-mesh/tests/transport.rs) ────────
+
+fn radio_frame(payload: &[u8]) -> Vec<u8> {
+    let mut v = vec![FRAME_OUTBOUND_PREFIX];
+    v.extend_from_slice(&(payload.len() as u16).to_le_bytes());
+    v.extend_from_slice(payload);
+    v
+}
+
+fn self_info_frame(name: &str) -> Vec<u8> {
+    let mut body = Vec::new();
+    body.push(ADV_TYPE_CHAT);
+    body.push(20u8);
+    body.push(22u8);
+    body.extend_from_slice(&[0xAAu8; 32]);
+    body.extend_from_slice(&0i32.to_le_bytes());
+    body.extend_from_slice(&0i32.to_le_bytes());
+    body.push(0u8);
+    body.push(ADVERT_LOC_NONE);
+    body.push(0u8);
+    body.push(0u8);
+    body.extend_from_slice(&915_000u32.to_le_bytes());
+    body.extend_from_slice(&125_000u32.to_le_bytes());
+    body.push(10u8);
+    body.push(5u8);
+    body.extend_from_slice(name.as_bytes());
+
+    let mut payload = vec![RESP_CODE_SELF_INFO];
+    payload.extend_from_slice(&body);
+    radio_frame(&payload)
+}
+
+fn contact_msg_frame_ts(sender_prefix: [u8; 6], text: &str, timestamp: u32) -> Vec<u8> {
+    let mut payload = vec![RESP_CODE_CONTACT_MSG_RECV];
+    payload.extend_from_slice(&sender_prefix);
+    payload.push(0u8); // path_len
+    payload.push(TXT_TYPE_PLAIN);
+    payload.extend_from_slice(&timestamp.to_le_bytes());
+    payload.extend_from_slice(text.as_bytes());
+    radio_frame(&payload)
+}
+
+/// The fake bridge: the TCP peer the transport connects to.
+struct Bridge {
+    stream: TcpStream,
+}
+
+impl Bridge {
+    async fn send(&mut self, bytes: &[u8]) {
+        self.stream.write_all(bytes).await.unwrap();
+    }
+
+    async fn recv_n(&mut self, n: usize) -> Vec<u8> {
+        let mut buf = vec![0u8; n];
+        self.stream.read_exact(&mut buf).await.unwrap();
+        buf
+    }
+
+    /// Read one outbound frame payload (strips the 3-byte wire header).
+    async fn read_command(&mut self) -> Vec<u8> {
+        let header = self.recv_n(3).await;
+        let len = u16::from_le_bytes([header[1], header[2]]) as usize;
+        self.recv_n(len).await
+    }
+
+    /// Read outbound frames until a `CMD_SYNC_NEXT_MESSAGE` appears, skipping
+    /// replies, path resets, and connect-time bookkeeping.
+    async fn read_until_sync(&mut self) {
+        loop {
+            if self.read_command().await[0] == CMD_SYNC_NEXT_MESSAGE {
+                return;
+            }
+        }
+    }
+
+    /// The normal on-connect handshake: AppStart → SelfInfo, answer the drain
+    /// with NoMoreMessages, then GET_CONTACTS / GET_AUTOADD_CONFIG.
+    async fn complete_handshake(&mut self, name: &str) {
+        let _app_start = self.recv_n(11).await;
+        self.send(&self_info_frame(name)).await;
+        self.read_until_sync().await;
+        self.send(&radio_frame(&[RESP_CODE_NO_MORE_MESSAGES])).await;
+        // GET_CONTACTS, then GET_AUTOADD_CONFIG (reply: already enabled).
+        let _get_contacts = self.read_command().await;
+        let _get_autoadd = self.read_command().await;
+        self.send(&radio_frame(&[RESP_CODE_AUTOADD_CONFIG, 1]))
+            .await;
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+}
+
+fn now_secs() -> u32 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_secs() as u32
+}
+
+fn print_counters(label: &str, transport: &MeshTransport) {
+    let s = transport.delivery_stats().snapshot();
+    println!(
+        "    {label:<26} inbound_received={}  dedup_dropped_timestamp={}  dedup_dropped_text={}  reconnect_discarded={}  sends_total={}",
+        s.inbound_received,
+        s.dedup_dropped_timestamp,
+        s.dedup_dropped_text,
+        s.reconnect_discarded,
+        s.sends_total,
+    );
+}
+
+#[tokio::main]
+async fn main() {
+    let host = Arc::new(MockHost::new());
+    host.set_default_response(Response::Text("ok".to_owned()));
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let config = MeshConfig {
+        addr,
+        welcome_message: String::new(),
+        reconnect_delay_initial_ms: 20,
+        reconnect_delay_max_ms: 50,
+        ..MeshConfig::default()
+    };
+    let transport = MeshTransport::init(config, host).await.unwrap();
+    transport.start().await.unwrap();
+
+    let (stream, _) = listener.accept().await.unwrap();
+    let mut bridge = Bridge { stream };
+    bridge.complete_handshake("ReproBridge").await;
+
+    println!("\n=== Deliverability repro — watch the inbound counters move ===\n");
+    print_counters("baseline", &transport);
+
+    let user = [0x42u8; 6];
+
+    // ── Scenario 1: a normal DM ────────────────────────────────────────────────
+    println!("\n[1] normal DM  →  expect inbound_received +1");
+    bridge
+        .send(&contact_msg_frame_ts(user, "hello", 1_700_000_100))
+        .await;
+    tokio::time::sleep(Duration::from_millis(200)).await;
+    print_counters("after normal DM", &transport);
+
+    // ── Scenario 2: a resend reusing the SAME timestamp ─────────────────────────
+    // This is the coarse-clock collision: a whole-second bridge (pyMC) stamps two
+    // sends in the same second identically, so the second collides on the
+    // (timestamp, text) key and is dropped. Note `inbound_received` counts
+    // *pre-dedup*, so it also increments — net-processed is
+    // `inbound_received - dedup_dropped_*`, and `dedup_dropped / inbound_received`
+    // is the drop ratio the OPERATIONS.md triage table reads.
+    println!("\n[2] resend with the SAME timestamp  →  expect dedup_dropped_timestamp +1 (and inbound_received +1, counted pre-dedup)");
+    bridge
+        .send(&contact_msg_frame_ts(user, "hello", 1_700_000_100))
+        .await;
+    tokio::time::sleep(Duration::from_millis(200)).await;
+    print_counters("after same-ts resend", &transport);
+
+    // ── Scenario 3: a reconnect backlog (fresh processed, stale discarded) ──────
+    println!("\n[3] reconnect with a FRESH and a STALE queued message  →  expect inbound_received +1, reconnect_discarded +1");
+    drop(bridge); // close the link → the transport reconnects
+    let (stream2, _) = listener.accept().await.unwrap();
+    let mut bridge = Bridge { stream: stream2 };
+
+    // Manual drain handshake so we can inject the backlog during the drain.
+    let _app_start = bridge.recv_n(11).await;
+    bridge.send(&self_info_frame("ReproBridge")).await;
+    let now = now_secs();
+
+    bridge.read_until_sync().await;
+    bridge
+        .send(&contact_msg_frame_ts(user, "reconnect-fresh", now))
+        .await;
+
+    bridge.read_until_sync().await;
+    bridge
+        .send(&contact_msg_frame_ts(
+            user,
+            "reconnect-stale",
+            now.saturating_sub(3600),
+        ))
+        .await;
+
+    bridge.read_until_sync().await;
+    bridge
+        .send(&radio_frame(&[RESP_CODE_NO_MORE_MESSAGES]))
+        .await;
+    tokio::time::sleep(Duration::from_millis(200)).await;
+    print_counters("after reconnect drain", &transport);
+
+    println!("\n=== done ===\n");
+    let _ = transport.stop().await;
+}

--- a/crates/bbs-mesh/src/metrics.rs
+++ b/crates/bbs-mesh/src/metrics.rs
@@ -117,6 +117,21 @@ pub struct DeliveryStats {
     /// Replies abandoned after exhausting the retransmission budget without a
     /// confirmation.
     gave_up: AtomicU64,
+    /// Inbound plain-text DMs accepted for processing (after the `TXT_TYPE_PLAIN`
+    /// gate, before dedup). The denominator for "how much of what the bridge
+    /// delivered did we actually act on".
+    inbound_received: AtomicU64,
+    /// Inbound messages dropped by the `(timestamp, text)` retransmission dedup.
+    /// A high ratio against `inbound_received` for a node that repeats commands is
+    /// the signature of the dedup over-dropping legitimate traffic.
+    dedup_dropped_timestamp: AtomicU64,
+    /// Inbound messages dropped by the text-only dedup (workflow-reply input and
+    /// the `timestamp == 0` fallback).
+    dedup_dropped_text: AtomicU64,
+    /// Inbound messages discarded while draining the bridge queue on reconnect
+    /// because they were older than the freshness window (stale backlog). A
+    /// non-zero value means DMs sent while the BBS was disconnected were dropped.
+    reconnect_discarded: AtomicU64,
     /// Number of round-trip latency samples. A sample is recorded when a
     /// confirmation correlates to a tracked send, so this is only populated when
     /// retransmission tracking is enabled (`reply_max_attempts > 1`).
@@ -151,6 +166,10 @@ impl Default for DeliveryStats {
             failed_no_route: AtomicU64::new(0),
             confirmed: AtomicU64::new(0),
             gave_up: AtomicU64::new(0),
+            inbound_received: AtomicU64::new(0),
+            dedup_dropped_timestamp: AtomicU64::new(0),
+            dedup_dropped_text: AtomicU64::new(0),
+            reconnect_discarded: AtomicU64::new(0),
             latency_count: AtomicU64::new(0),
             latency_sum_ms: AtomicU64::new(0),
             // Sentinel so the first recorded sample becomes the minimum.
@@ -273,6 +292,29 @@ impl DeliveryStats {
         self.with_node(prefix, |c| c.gave_up += 1);
     }
 
+    /// Record an inbound plain-text DM accepted for processing (post-`TXT_TYPE_PLAIN`,
+    /// pre-dedup).
+    pub fn on_inbound_received(&self) {
+        self.inbound_received.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Record an inbound message dropped by the `(timestamp, text)` dedup.
+    pub fn on_dedup_drop_timestamp(&self) {
+        self.dedup_dropped_timestamp.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Record an inbound message dropped by the text-only dedup (workflow-reply or
+    /// `timestamp == 0` fallback).
+    pub fn on_dedup_drop_text(&self) {
+        self.dedup_dropped_text.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Record an inbound message discarded as stale backlog while draining on
+    /// reconnect.
+    pub fn on_reconnect_discard(&self) {
+        self.reconnect_discarded.fetch_add(1, Ordering::Relaxed);
+    }
+
     /// Append a history sample of the current cumulative counters, stamped with
     /// `ts` (Unix seconds). Called on a timer; the oldest sample is dropped once
     /// the buffer is full. Consumers diff consecutive samples for interval rates.
@@ -340,6 +382,10 @@ impl DeliveryStats {
         let failed_no_route = self.failed_no_route.load(Ordering::Relaxed);
         let confirmed = self.confirmed.load(Ordering::Relaxed);
         let gave_up = self.gave_up.load(Ordering::Relaxed);
+        let inbound_received = self.inbound_received.load(Ordering::Relaxed);
+        let dedup_dropped_timestamp = self.dedup_dropped_timestamp.load(Ordering::Relaxed);
+        let dedup_dropped_text = self.dedup_dropped_text.load(Ordering::Relaxed);
+        let reconnect_discarded = self.reconnect_discarded.load(Ordering::Relaxed);
 
         // Confirm rate is PER REPLY, not per transmission: the denominator is
         // first sends (distinct replies), not `accepted` (which counts every
@@ -377,6 +423,10 @@ impl DeliveryStats {
             failed_no_route,
             confirmed,
             gave_up,
+            inbound_received,
+            dedup_dropped_timestamp,
+            dedup_dropped_text,
+            reconnect_discarded,
             confirm_rate,
             route_failure_rate,
             latency_count,
@@ -454,6 +504,16 @@ pub struct DeliveryStatsSnapshot {
     pub confirmed: u64,
     /// Replies abandoned after exhausting all retransmission attempts.
     pub gave_up: u64,
+    /// Inbound plain-text DMs accepted for processing (post-`TXT_TYPE_PLAIN`,
+    /// pre-dedup).
+    pub inbound_received: u64,
+    /// Inbound messages dropped by the `(timestamp, text)` retransmission dedup.
+    pub dedup_dropped_timestamp: u64,
+    /// Inbound messages dropped by the text-only dedup (workflow-reply /
+    /// `timestamp == 0` fallback).
+    pub dedup_dropped_text: u64,
+    /// Inbound messages discarded as stale backlog while draining on reconnect.
+    pub reconnect_discarded: u64,
     /// Per-reply confirm rate: `confirmed / first_sends` (clamped to ≤ 1.0), or
     /// `null` before any reply has been sent. Not per-transmission, so retries
     /// and floods don't deflate it.
@@ -631,6 +691,29 @@ mod tests {
         let snap = s.snapshot();
         assert_eq!(snap.dropped, 1);
         assert_eq!(snap.gave_up, 2);
+    }
+
+    #[test]
+    fn inbound_counters_are_counted() {
+        let s = DeliveryStats::default();
+        let snap = s.snapshot();
+        // Default is zero across the board.
+        assert_eq!(snap.inbound_received, 0);
+        assert_eq!(snap.dedup_dropped_timestamp, 0);
+        assert_eq!(snap.dedup_dropped_text, 0);
+        assert_eq!(snap.reconnect_discarded, 0);
+
+        s.on_inbound_received();
+        s.on_inbound_received();
+        s.on_dedup_drop_timestamp();
+        s.on_dedup_drop_text();
+        s.on_dedup_drop_text();
+        s.on_reconnect_discard();
+        let snap = s.snapshot();
+        assert_eq!(snap.inbound_received, 2);
+        assert_eq!(snap.dedup_dropped_timestamp, 1);
+        assert_eq!(snap.dedup_dropped_text, 2);
+        assert_eq!(snap.reconnect_discarded, 1);
     }
 
     #[test]

--- a/crates/bbs-mesh/src/transport.rs
+++ b/crates/bbs-mesh/src/transport.rs
@@ -82,6 +82,16 @@ const HISTORY_SEED_SECS: u64 = 8 * 60 * 60;
 /// loop blocks on `send` (backpressure) rather than dropping work.
 const COMMAND_QUEUE_DEPTH: usize = 64;
 
+/// How fresh a queued message must be to be processed when draining the bridge
+/// backlog on reconnect. Messages whose sender timestamp is older than this are
+/// discarded rather than acted on, so recovering from a long outage does not
+/// unleash a burst of replies to DMs the user sent long ago. Sized generously
+/// (10 minutes) so it cleanly separates a brief link blip (process the backlog)
+/// from a real outage (drop it), tolerating modest sender/BBS clock skew. A
+/// message with no sender timestamp (0) is treated as fresh — we cannot prove it
+/// stale, and dropping a real DM is worse than a late reply.
+const DRAIN_STALE_AFTER_SECS: u32 = 600;
+
 /// Enqueue a plain-text reply to the companion client and, when retransmission
 /// is enabled, record it in `tracker` for delivery tracking.
 ///
@@ -987,24 +997,60 @@ async fn handle_frame(
 
         // ── Direct text messages (v1/v2 and v3 with SNR) ─────────────────────
         InboundFrame::ContactMsgRecv(msg) | InboundFrame::ContactMsgRecvV3(msg) => {
-            // While draining, discard queued messages and request the next one
-            // so we flush the entire backlog before serving live traffic.
-            if draining.load(Ordering::Relaxed) {
-                debug!(
-                    prefix = msg.sender_key_prefix[0],
-                    "mesh: discarding stale queued message (draining)"
-                );
-                let _ = cmd_tx.send(OutboundFrame::SyncNextMessage).await;
-                return;
-            }
+            let is_draining = draining.load(Ordering::Relaxed);
 
             // Only handle plain-text messages; CLI data and signed frames are
-            // not BBS commands.
+            // not BBS commands. Keep draining past a non-command frame so the
+            // backlog still flushes to NoMoreMessages.
             if msg.txt_type != meshcore_companion::constants::TXT_TYPE_PLAIN {
                 debug!(
                     txt_type = msg.txt_type,
                     "mesh: ignoring non-plain-text ContactMsg"
                 );
+                if is_draining {
+                    let _ = cmd_tx.send(OutboundFrame::SyncNextMessage).await;
+                }
+                return;
+            }
+
+            // On reconnect we drain whatever queued while we were offline. Unlike
+            // before — when the whole backlog was discarded — we now *process*
+            // fresh messages so a DM sent during a brief blip still gets a reply.
+            // Clearly-stale backlog (older than DRAIN_STALE_AFTER_SECS, judged by
+            // the sender's timestamp) is still discarded so recovering from a long
+            // outage doesn't unleash a burst of replies to long-dead messages.
+            if is_draining {
+                let age = now_unix_secs().saturating_sub(msg.timestamp);
+                if msg.timestamp != 0 && age > DRAIN_STALE_AFTER_SECS {
+                    debug!(
+                        prefix = msg.sender_key_prefix[0],
+                        age_secs = age,
+                        "mesh: discarding stale queued message (draining)"
+                    );
+                    delivery_stats.on_reconnect_discard();
+                    let _ = cmd_tx.send(OutboundFrame::SyncNextMessage).await;
+                    return;
+                }
+                debug!(
+                    prefix = msg.sender_key_prefix[0],
+                    timestamp = msg.timestamp,
+                    age_secs = age,
+                    "mesh: processing queued message from reconnect backlog"
+                );
+                delivery_stats.on_inbound_received();
+                if cmd_worker_tx
+                    .send(InboundCommand {
+                        sender_prefix: msg.sender_key_prefix,
+                        timestamp: msg.timestamp,
+                        text: msg.text,
+                    })
+                    .await
+                    .is_err()
+                {
+                    warn!("mesh: command worker stopped — dropping inbound message");
+                }
+                // Keep pulling the rest of the backlog.
+                let _ = cmd_tx.send(OutboundFrame::SyncNextMessage).await;
                 return;
             }
 
@@ -1018,6 +1064,7 @@ async fn handle_frame(
                 len = msg.text.len(),
                 "mesh: inbound message received"
             );
+            delivery_stats.on_inbound_received();
             // Hand the message to the command worker and return immediately so
             // the event loop stays free to read the next frame instead of
             // blocking on host I/O. The bounded channel applies backpressure
@@ -1032,6 +1079,20 @@ async fn handle_frame(
                 .is_err()
             {
                 warn!("mesh: command worker stopped — dropping inbound message");
+            }
+            // Drain-to-NoMoreMessages: keep fetching until the bridge reports the
+            // queue empty, so message delivery no longer depends on a perfect 1:1
+            // MsgWaiting↔message correspondence. This recovers a message whose
+            // MsgWaiting push was dropped (e.g. under bridge write-queue
+            // backpressure) and is robust to a bridge/firmware that notifies once
+            // per empty→non-empty transition rather than per message. The
+            // follow-up sync uses a blocking send so a transiently full command
+            // channel backpressures the event loop rather than dropping the sync
+            // (a dropped sync would re-open the stranding gap). When the queue is
+            // empty the bridge replies NoMoreMessages, which — while not draining —
+            // falls through to a harmless no-op and stops the loop.
+            if cmd_tx.send(OutboundFrame::SyncNextMessage).await.is_err() {
+                warn!("mesh: could not enqueue drain SyncNextMessage — cmd channel closed");
             }
         }
 
@@ -1464,6 +1525,21 @@ async fn dispatch_message(
     // timestamp (0), fall back to the text-only window, which additionally
     // guards mesh retransmissions of a workflow reply that land after the
     // workflow has completed.
+    //
+    // The `on_dedup_drop_*` counters here are DIAGNOSTIC ONLY — they do not
+    // change behaviour. They let an operator see, from the field, how often the
+    // dedup fires on a given node's traffic. This matters because a coarse-clock
+    // bridge (the pyMC bridge stamps whole-second `int(time.time())` and discards
+    // the client's own timestamp) makes two distinct sends in the same second
+    // collide on the (timestamp, text) key. Whether that ever drops *legitimate*
+    // traffic in practice is what these counters measure; the behavioural fix (if
+    // the data shows one is warranted) is deliberately deferred, because a
+    // same-second confirmation is on-the-wire indistinguishable from a stale
+    // retransmission of the command that triggered the prompt, so no
+    // transport-layer rule can tell them apart (see the tests
+    // `identical_workflow_replies_with_same_timestamp_dedup_second` and
+    // `real_host_register_double_send_then_password`, which demand opposite
+    // outcomes for byte-identical input).
     if timestamp != 0 {
         if state
             .lock()
@@ -1474,6 +1550,7 @@ async fn dispatch_message(
                 timestamp,
                 "mesh: dropping retransmitted message (timestamp dedup)"
             );
+            delivery_stats.on_dedup_drop_timestamp();
             return;
         }
     } else {
@@ -1483,6 +1560,7 @@ async fn dispatch_message(
             .dedup_message(&sender_prefix, text)
         {
             debug!("mesh: dropping retransmitted message (text dedup)");
+            delivery_stats.on_dedup_drop_text();
             return;
         }
         if !awaiting_reply
@@ -1492,6 +1570,7 @@ async fn dispatch_message(
                 .is_recent_workflow_reply(&sender_prefix, text)
         {
             debug!("mesh: dropping retransmitted workflow reply (text dedup)");
+            delivery_stats.on_dedup_drop_text();
             return;
         }
     }

--- a/crates/bbs-mesh/tests/transport.rs
+++ b/crates/bbs-mesh/tests/transport.rs
@@ -215,6 +215,18 @@ impl Bridge {
             }
         }
     }
+
+    /// Read outbound frames until a `CMD_SYNC_NEXT_MESSAGE` appears, skipping
+    /// replies, path resets, and connect-time bookkeeping (GET_CONTACTS /
+    /// GET_AUTOADD_CONFIG).
+    async fn read_until_sync(&mut self) {
+        loop {
+            let cmd = self.read_command().await;
+            if cmd[0] == CMD_SYNC_NEXT_MESSAGE {
+                return;
+            }
+        }
+    }
 }
 
 /// Spin up a [`MeshTransport`] against an in-process loopback listener.
@@ -290,7 +302,9 @@ async fn response_text_returned_to_sender() {
     bridge.send(&contact_msg_frame(sender, "help")).await;
 
     // Payload layout: [CMD_SEND_TXT_MSG][txt_type][attempt][reserved×4][prefix×6][text…]
-    let cmd_payload = tokio::time::timeout(Duration::from_secs(2), bridge.read_command())
+    // read_text_send skips the drain SyncNextMessage the transport now emits after
+    // each processed inbound message (drain-to-NoMoreMessages hardening).
+    let cmd_payload = tokio::time::timeout(Duration::from_secs(2), bridge.read_text_send())
         .await
         .expect("timed out waiting for reply");
 
@@ -780,7 +794,8 @@ async fn notify_sends_text_to_node() {
     // Establish a session by sending a message first.
     let sender = [0x33u8; 6];
     bridge.send(&contact_msg_frame(sender, "whoami")).await;
-    let _ = tokio::time::timeout(Duration::from_secs(2), bridge.read_command())
+    // read_text_send skips the post-message drain SyncNextMessage.
+    let _ = tokio::time::timeout(Duration::from_secs(2), bridge.read_text_send())
         .await
         .expect("timed out waiting for whoami reply");
 
@@ -791,7 +806,7 @@ async fn notify_sends_text_to_node() {
         .unwrap();
     assert!(matches!(outcome, NotifyOutcome::Queued));
 
-    let cmd_payload = tokio::time::timeout(Duration::from_secs(2), bridge.read_command())
+    let cmd_payload = tokio::time::timeout(Duration::from_secs(2), bridge.read_text_send())
         .await
         .expect("timed out waiting for notification");
 
@@ -842,8 +857,9 @@ async fn unsupported_app_start_and_sync_still_processes_messages() {
     let sender = [0x55u8; 6];
     bridge.send(&contact_msg_frame(sender, "help")).await;
 
-    // The transport should send back a reply (from MockHost).
-    let cmd_payload = tokio::time::timeout(Duration::from_secs(2), bridge.read_command())
+    // The transport should send back a reply (from MockHost). read_text_send skips
+    // the post-message drain SyncNextMessage.
+    let cmd_payload = tokio::time::timeout(Duration::from_secs(2), bridge.read_text_send())
         .await
         .expect("timed out — drain flag was not cleared; message was silently dropped");
 
@@ -892,10 +908,119 @@ async fn unsupported_app_start_with_successful_drain_processes_messages() {
     let sender = [0x66u8; 6];
     bridge.send(&contact_msg_frame(sender, "whoami")).await;
 
-    let cmd_payload = tokio::time::timeout(Duration::from_secs(2), bridge.read_command())
+    // read_text_send skips the post-message drain SyncNextMessage.
+    let cmd_payload = tokio::time::timeout(Duration::from_secs(2), bridge.read_text_send())
         .await
         .expect("timed out waiting for reply");
     assert_eq!(cmd_payload[0], CMD_SEND_TXT_MSG);
+
+    transport.stop().await.unwrap();
+}
+
+/// Drain-to-NoMoreMessages: after processing a normal (non-draining) inbound
+/// message, the transport emits a follow-up `SyncNextMessage` so it keeps pulling
+/// until the bridge reports the queue empty. This makes delivery robust to a
+/// dropped `MsgWaiting` push (or a bridge/firmware that notifies once per
+/// empty→non-empty transition) instead of stranding a backlog until reconnect.
+#[tokio::test]
+async fn processed_message_emits_followup_sync() {
+    let host = Arc::new(MockHost::new());
+    host.set_default_response(Response::Text("ok".to_owned()));
+    let (transport, mut bridge) = make_transport(Arc::clone(&host), None).await;
+    bridge.complete_handshake("Node").await;
+
+    let sender = [0x21u8; 6];
+    bridge.send(&contact_msg_frame(sender, "help")).await;
+
+    // Collect outbound frames until we've seen BOTH the text reply and the drain
+    // SyncNextMessage (their relative order is not guaranteed).
+    let mut saw_sync = false;
+    let mut saw_reply = false;
+    for _ in 0..6 {
+        let cmd = tokio::time::timeout(Duration::from_secs(2), bridge.read_command())
+            .await
+            .expect("timed out waiting for outbound frames");
+        match cmd[0] {
+            CMD_SYNC_NEXT_MESSAGE => saw_sync = true,
+            CMD_SEND_TXT_MSG => saw_reply = true,
+            _ => {}
+        }
+        if saw_sync && saw_reply {
+            break;
+        }
+    }
+    assert!(saw_reply, "the text reply must be sent");
+    assert!(
+        saw_sync,
+        "a follow-up SyncNextMessage must be emitted to drain the bridge queue"
+    );
+
+    transport.stop().await.unwrap();
+}
+
+/// On reconnect the transport drains the bridge's queued backlog. A FRESH queued
+/// message (recent sender timestamp) is now processed — a DM sent during a brief
+/// disconnect still gets a reply — while a clearly-STALE one (older than the
+/// freshness window) is discarded so recovering from a long outage does not
+/// unleash a burst of replies to long-dead messages.
+#[tokio::test]
+async fn reconnect_drain_processes_fresh_and_discards_stale() {
+    let host = Arc::new(MockHost::new());
+    host.set_default_response(Response::Text("ok".to_owned()));
+    let (transport, mut bridge) = make_transport(Arc::clone(&host), None).await;
+
+    // Manual handshake so queued messages can be injected during the on-connect
+    // drain (before NoMoreMessages clears the draining flag).
+    let app_start = bridge.recv_n(11).await;
+    assert_eq!(app_start[3], CMD_APP_START);
+    bridge.send(&self_info_frame("Node")).await;
+
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_secs() as u32;
+    let sender = [0x31u8; 6];
+
+    // First drain sync → feed a FRESH queued message (age ~0, within the window).
+    let drain1 = bridge.read_command().await;
+    assert_eq!(drain1[0], CMD_SYNC_NEXT_MESSAGE);
+    bridge
+        .send(&contact_msg_frame_ts(sender, "fresh", now))
+        .await;
+
+    // Next drain sync → feed a STALE queued message (an hour old, past the window).
+    bridge.read_until_sync().await;
+    bridge
+        .send(&contact_msg_frame_ts(
+            sender,
+            "stale",
+            now.saturating_sub(3600),
+        ))
+        .await;
+
+    // Next drain sync → end the drain.
+    bridge.read_until_sync().await;
+    bridge
+        .send(&radio_frame(&[RESP_CODE_NO_MORE_MESSAGES]))
+        .await;
+
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    let received = host.commands_received();
+    let has = |t: &str| {
+        received
+            .iter()
+            .any(|(_, c)| matches!(c, Command::Unknown { raw } if raw == t))
+    };
+    assert!(
+        has("fresh"),
+        "a fresh queued message must be processed on reconnect, got: {:?}",
+        received.iter().map(|(_, c)| c).collect::<Vec<_>>()
+    );
+    assert!(
+        !has("stale"),
+        "a stale queued message must be discarded on reconnect"
+    );
 
     transport.stop().await.unwrap();
 }

--- a/crates/bbs-web/web/src/pages/MetricsPage.vue
+++ b/crates/bbs-web/web/src/pages/MetricsPage.vue
@@ -59,6 +59,10 @@ interface DeliveryStats {
   failed_no_route: number
   confirmed: number
   gave_up: number
+  inbound_received: number
+  dedup_dropped_timestamp: number
+  dedup_dropped_text: number
+  reconnect_discarded: number
   confirm_rate: number | null
   route_failure_rate: number | null
   latency_count: number
@@ -182,6 +186,15 @@ const trendStart = computed(() => (history.value.length ? sampleTime(history.val
 const trendEnd = computed(() =>
   history.value.length ? sampleTime(history.value[history.value.length - 1].ts) : ''
 )
+
+// Share of received inbound messages the dedup dropped as retransmissions, 0–1
+// (or null before any inbound traffic). A high ratio for a node that repeats
+// commands is the signature of the dedup over-dropping legitimate messages.
+const dedupDropRate = computed<number | null>(() => {
+  const d = delivery.value
+  if (!d || d.inbound_received === 0) return null
+  return (d.dedup_dropped_timestamp + d.dedup_dropped_text) / d.inbound_received
+})
 
 function ratePct(r: number | null): string {
   return r === null ? '—' : `${(r * 100).toFixed(1)}%`
@@ -342,6 +355,33 @@ onUnmounted(() => {
           <div class="card-label">Avg round-trip</div>
           <div class="big-num">{{ fmtMs(delivery.avg_latency_ms) }}</div>
           <div class="card-sub muted">min {{ fmtMs(delivery.min_latency_ms) }} / max {{ fmtMs(delivery.max_latency_ms) }}</div>
+        </div>
+      </div>
+    </section>
+
+    <!-- Inbound message health -->
+    <section v-if="delivery" class="section">
+      <h2 class="section-title">Inbound message health (cumulative since start)</h2>
+      <p class="muted">
+        Where inbound DMs are lost before the BBS acts on them — read alongside the confirm rate above
+        to tell an outbound return-path problem from an inbound one.
+      </p>
+      <div class="metrics-grid">
+        <div class="card">
+          <div class="card-label">Received</div>
+          <div class="big-num">{{ delivery.inbound_received }}</div>
+          <div class="card-sub muted">plain-text DMs accepted for processing (pre-dedup)</div>
+        </div>
+        <div class="card">
+          <div class="card-label">Dedup drops</div>
+          <div class="big-num">{{ ratePct(dedupDropRate) }}</div>
+          <div class="bar-track"><div class="bar-fill" :style="{ width: rateWidth(dedupDropRate) + '%' }" :class="failBarClass(dedupDropRate)"></div></div>
+          <div class="card-sub muted">{{ delivery.dedup_dropped_timestamp }} timestamp / {{ delivery.dedup_dropped_text }} text — retransmissions dropped</div>
+        </div>
+        <div class="card">
+          <div class="card-label">Reconnect discards</div>
+          <div class="big-num">{{ delivery.reconnect_discarded }}</div>
+          <div class="card-sub muted">stale backlog dropped while draining on reconnect</div>
         </div>
       </div>
     </section>

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -756,6 +756,39 @@ enable it only on a link with a non-zero confirm rate (see
 [CONFIG.md](CONFIG.md)). Samples are persisted in the database and pruned after
 7 days, so the trend survives a service restart or upgrade rather than resetting.
 
+### Diagnosing message deliverability
+
+When users report that DMs to the BBS are "less reliable than normal messaging"
+or that "the BBS didn't respond", the stats snapshot
+(`GET /api/v1/transports/meshcore/stats`) carries **inbound** counters alongside
+the outbound reply metrics above. Together they localize *where* a message is
+being lost — the radio return path, the BBS's own dedup, or a reconnect:
+
+- `inbound_received` — plain-text DMs the BBS accepted for processing.
+- `dedup_dropped_timestamp` / `dedup_dropped_text` — inbound messages the BBS
+  dropped as retransmissions before acting on them.
+- `reconnect_discarded` — messages discarded as stale backlog while draining the
+  bridge queue after a reconnect.
+
+Read them against the outbound `sends_total` / `confirm_rate` / `failed_no_route`
+to tell the three failure modes apart:
+
+| Symptom | What the numbers show | Likely cause |
+|---------|-----------------------|--------------|
+| BBS replies, user never sees them | `sends_total` climbs, `confirm_rate ≈ 0`, `failed_no_route ≈ 0` | **Outbound return-path loss.** The device accepts every send but no end-to-end ACK returns — a lossy multi-hop reverse path. Replies are not retried by default (`reply_max_attempts = 1`). |
+| BBS "ignores" repeated commands | `dedup_dropped_timestamp` rises against `inbound_received` for that node | **Inbound dedup.** A bridge that stamps coarse whole-second timestamps (the pyMC bridge does) makes two identical sends in the same second collide and the second is dropped. Confirm with a `DEBUG` log line `dropping retransmitted message (timestamp dedup)`. |
+| DMs sent during an outage vanish | `reconnect_discarded` is non-zero | **Reconnect backlog.** Messages older than the freshness window are discarded on reconnect; fresh ones are now processed. |
+
+For a live trace, raise the log level to `DEBUG` (Settings page or `[logging]
+level = "DEBUG"`) and watch for `mesh: inbound message received`,
+`mesh: dropping retransmitted message …`, and
+`mesh: discarding stale queued message (draining)`.
+
+> Note: retrying lost **outbound** replies is not as simple as raising
+> `reply_max_attempts` — on a link that never confirms, the tracker would
+> retransmit every reply to exhaustion and flood the mesh with duplicates. A
+> confirm-gated retransmission strategy for far nodes is planned separately.
+
 ### Logs
 
 ```sh


### PR DESCRIPTION
## Why

Follows a deep-dive + three-pass adversarial review of the multi-hop
deliverability reports ("DMs to the BBS are far less reliable than normal
messaging"; "I see my traffic in the pymc logs but the BBS takes no action").

The review **refuted** the initial "inbound stranding via bridge backpressure"
hypothesis (pyMC never emits `LOG_RX_DATA` as shipped, and the BBS read path is
decoupled from DB I/O) and surfaced three better-grounded, BBS-specific causes,
each with a falsifiable log signature. The reviewers disagreed on which
dominates — and the discriminator is **measurable in logs**. So this PR is
*diagnose-first*: ship the measurement plus the fixes that are correct
regardless, and defer the riskier outbound rework until field data confirms it.

## What's in this PR

**Instrumentation (`DeliveryStats`)** — new inbound counters in the stats
snapshot, complementing the existing outbound `confirm_rate` / `sends_total`:
- `inbound_received`, `dedup_dropped_timestamp`, `dedup_dropped_text`,
  `reconnect_discarded`
- These localise loss to the outbound return path (A), the inbound dedup (B), or
  a reconnect (C). New OPERATIONS.md section maps the three signatures.

**Fixes:**
- **Stop discarding the reconnect backlog.** The connect-drain used to discard
  *every* queued message; a DM sent during a brief disconnect vanished. It now
  **processes fresh** messages (so they get a reply) and discards only
  clearly-stale ones (>10 min by sender timestamp) to avoid a reply burst after
  a long outage.
- **Drain-to-`NoMoreMessages`.** After each processed message the transport
  re-syncs until the bridge queue is empty, so a dropped `MsgWaiting` push (or a
  non-per-message bridge/firmware) can't strand a backlog until the next
  reconnect. Guarded per the review: blocking send, non-draining path only, no
  re-syncing `NoMoreMessages` arm (which would loop).

## What's deliberately NOT changed (and why)

**The `(timestamp, text)` dedup behaviour.** Implementing the planned "accept a
repeated prompted value" fix turned out to be **unsound**: a legitimate
same-second confirmation is byte-for-byte identical to a stale retransmission of
the command that triggered the prompt. Two existing tests
(`identical_workflow_replies_with_same_timestamp_dedup_second` and
`real_host_register_double_send_then_password`) demand **opposite** outcomes for
that identical input, so no transport-layer rule can satisfy both. The dedup is
therefore **instrumented only** — the counters will show whether it actually
drops legitimate traffic in the field before we touch behaviour (the real fix,
if warranted, belongs at the host/command layer as idempotent workflows).

## Deferred to a follow-up (gated on field data)

Outbound reply reliability — the *measured* 0%-confirm return-path loss. It
can't be fixed by simply raising `reply_max_attempts` (on a never-confirming
link the tracker would retransmit every reply to exhaustion and flood
duplicates — the exact storm that forced the `=1` default). The duplicate-free
fix is to flood/reset the path *before* the first reply for far nodes plus a
confirm-gated retransmission circuit-breaker.

## Testing

Linux/WSL, full pre-commit gate green: `cargo fmt --all --check`,
`cargo clippy --workspace --all-targets --all-features -- -D warnings`,
`cargo test --workspace`, `cargo doc --workspace --no-deps --all-features`.

New tests:
- `processed_message_emits_followup_sync` — a normal inbound message triggers a
  follow-up `SyncNextMessage`.
- `reconnect_drain_processes_fresh_and_discards_stale` — fresh backlog is
  processed, stale backlog is discarded.
- `metrics::tests::inbound_counters_are_counted`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
