### PR TITLE
fix(mesh): repair offline-queue drain state machine + audit corrections

### DIFF
--- a/crates/bbs-mesh/examples/deliverability_repro.rs
+++ b/crates/bbs-mesh/examples/deliverability_repro.rs
@@ -12,7 +12,7 @@
 //! It exercises the three inbound signatures this instrumentation surfaces:
 //!   1. a normal DM → `inbound_received`.
 //!   2. a same-timestamp resend → `dedup_dropped_timestamp` (a coarse-clock bridge like pyMC collides two same-second sends).
-//!   3. a reconnect backlog → fresh processed, clearly-stale → `reconnect_discarded`.
+//!   3. a reconnect backlog → all queued messages processed (even old sender clocks).
 //!
 //! This is a diagnostic/demo harness, not a test — it prints, it doesn't assert.
 //! The equivalent assertions live in `tests/transport.rs`.
@@ -127,12 +127,8 @@ fn now_secs() -> u32 {
 fn print_counters(label: &str, transport: &MeshTransport) {
     let s = transport.delivery_stats().snapshot();
     println!(
-        "    {label:<26} inbound_received={}  dedup_dropped_timestamp={}  dedup_dropped_text={}  reconnect_discarded={}  sends_total={}",
-        s.inbound_received,
-        s.dedup_dropped_timestamp,
-        s.dedup_dropped_text,
-        s.reconnect_discarded,
-        s.sends_total,
+        "    {label:<26} inbound_received={}  dedup_dropped_timestamp={}  dedup_dropped_text={}  sends_total={}",
+        s.inbound_received, s.dedup_dropped_timestamp, s.dedup_dropped_text, s.sends_total,
     );
 }
 
@@ -171,8 +167,9 @@ async fn main() {
     print_counters("after normal DM", &transport);
 
     // ── Scenario 2: a resend reusing the SAME timestamp ─────────────────────────
-    // This is the coarse-clock collision: a whole-second bridge (pyMC) stamps two
-    // sends in the same second identically, so the second collides on the
+    // This is the coarse-clock collision: a SENDER bridged through pyMC is
+    // re-stamped whole-second `int(time.time())` at send time, so two sends in
+    // the same second arrive identical and the second collides on the
     // (timestamp, text) key and is dropped. Note `inbound_received` counts
     // *pre-dedup*, so it also increments — net-processed is
     // `inbound_received - dedup_dropped_*`, and `dedup_dropped / inbound_received`
@@ -184,8 +181,11 @@ async fn main() {
     tokio::time::sleep(Duration::from_millis(200)).await;
     print_counters("after same-ts resend", &transport);
 
-    // ── Scenario 3: a reconnect backlog (fresh processed, stale discarded) ──────
-    println!("\n[3] reconnect with a FRESH and a STALE queued message  →  expect inbound_received +1, reconnect_discarded +1");
+    // ── Scenario 3: a reconnect backlog (everything processed) ──────────────────
+    // Queued messages are the user's own commands sent while the BBS was offline;
+    // both are processed and answered, even one whose sender clock looks old (a
+    // never-synced RTC stamps a stale-looking epoch — not evidence of staleness).
+    println!("\n[3] reconnect with two queued messages (one with an old sender clock)  →  expect inbound_received +2");
     drop(bridge); // close the link → the transport reconnects
     let (stream2, _) = listener.accept().await.unwrap();
     let mut bridge = Bridge { stream: stream2 };
@@ -204,7 +204,7 @@ async fn main() {
     bridge
         .send(&contact_msg_frame_ts(
             user,
-            "reconnect-stale",
+            "reconnect-old-clock",
             now.saturating_sub(3600),
         ))
         .await;

--- a/crates/bbs-mesh/src/config.rs
+++ b/crates/bbs-mesh/src/config.rs
@@ -199,6 +199,15 @@ pub struct MeshConfig {
     /// destination regardless of whether the BBS's stored route is still
     /// valid.  Disabling this restores the previous direct-path-only
     /// behaviour.  Defaults to `true`.
+    ///
+    /// Note the reply itself is **not** flooded — it travels the device's
+    /// current stored path; the reset only affects the *next* outbound to that
+    /// node. The device also re-learns a path from the node's own inbound
+    /// traffic (`PathUpdated`), which bounds the flooding cost to occasional
+    /// unsolicited pushes. Purely single-hop deployments (every node in direct
+    /// range) may set this to `false`; multi-hop deployments should leave it
+    /// on — retransmission (when enabled) also relies on the reset to flood a
+    /// retried reply.
     #[serde(default = "default_flood_after_send")]
     pub flood_after_send: bool,
 

--- a/crates/bbs-mesh/src/metrics.rs
+++ b/crates/bbs-mesh/src/metrics.rs
@@ -128,10 +128,6 @@ pub struct DeliveryStats {
     /// Inbound messages dropped by the text-only dedup (workflow-reply input and
     /// the `timestamp == 0` fallback).
     dedup_dropped_text: AtomicU64,
-    /// Inbound messages discarded while draining the bridge queue on reconnect
-    /// because they were older than the freshness window (stale backlog). A
-    /// non-zero value means DMs sent while the BBS was disconnected were dropped.
-    reconnect_discarded: AtomicU64,
     /// Number of round-trip latency samples. A sample is recorded when a
     /// confirmation correlates to a tracked send, so this is only populated when
     /// retransmission tracking is enabled (`reply_max_attempts > 1`).
@@ -169,7 +165,6 @@ impl Default for DeliveryStats {
             inbound_received: AtomicU64::new(0),
             dedup_dropped_timestamp: AtomicU64::new(0),
             dedup_dropped_text: AtomicU64::new(0),
-            reconnect_discarded: AtomicU64::new(0),
             latency_count: AtomicU64::new(0),
             latency_sum_ms: AtomicU64::new(0),
             // Sentinel so the first recorded sample becomes the minimum.
@@ -309,12 +304,6 @@ impl DeliveryStats {
         self.dedup_dropped_text.fetch_add(1, Ordering::Relaxed);
     }
 
-    /// Record an inbound message discarded as stale backlog while draining on
-    /// reconnect.
-    pub fn on_reconnect_discard(&self) {
-        self.reconnect_discarded.fetch_add(1, Ordering::Relaxed);
-    }
-
     /// Append a history sample of the current cumulative counters, stamped with
     /// `ts` (Unix seconds). Called on a timer; the oldest sample is dropped once
     /// the buffer is full. Consumers diff consecutive samples for interval rates.
@@ -385,7 +374,6 @@ impl DeliveryStats {
         let inbound_received = self.inbound_received.load(Ordering::Relaxed);
         let dedup_dropped_timestamp = self.dedup_dropped_timestamp.load(Ordering::Relaxed);
         let dedup_dropped_text = self.dedup_dropped_text.load(Ordering::Relaxed);
-        let reconnect_discarded = self.reconnect_discarded.load(Ordering::Relaxed);
 
         // Confirm rate is PER REPLY, not per transmission: the denominator is
         // first sends (distinct replies), not `accepted` (which counts every
@@ -426,7 +414,6 @@ impl DeliveryStats {
             inbound_received,
             dedup_dropped_timestamp,
             dedup_dropped_text,
-            reconnect_discarded,
             confirm_rate,
             route_failure_rate,
             latency_count,
@@ -512,8 +499,6 @@ pub struct DeliveryStatsSnapshot {
     /// Inbound messages dropped by the text-only dedup (workflow-reply /
     /// `timestamp == 0` fallback).
     pub dedup_dropped_text: u64,
-    /// Inbound messages discarded as stale backlog while draining on reconnect.
-    pub reconnect_discarded: u64,
     /// Per-reply confirm rate: `confirmed / first_sends` (clamped to ≤ 1.0), or
     /// `null` before any reply has been sent. Not per-transmission, so retries
     /// and floods don't deflate it.
@@ -701,19 +686,16 @@ mod tests {
         assert_eq!(snap.inbound_received, 0);
         assert_eq!(snap.dedup_dropped_timestamp, 0);
         assert_eq!(snap.dedup_dropped_text, 0);
-        assert_eq!(snap.reconnect_discarded, 0);
 
         s.on_inbound_received();
         s.on_inbound_received();
         s.on_dedup_drop_timestamp();
         s.on_dedup_drop_text();
         s.on_dedup_drop_text();
-        s.on_reconnect_discard();
         let snap = s.snapshot();
         assert_eq!(snap.inbound_received, 2);
         assert_eq!(snap.dedup_dropped_timestamp, 1);
         assert_eq!(snap.dedup_dropped_text, 2);
-        assert_eq!(snap.reconnect_discarded, 1);
     }
 
     #[test]

--- a/crates/bbs-mesh/src/transport.rs
+++ b/crates/bbs-mesh/src/transport.rs
@@ -82,25 +82,20 @@ const HISTORY_SEED_SECS: u64 = 8 * 60 * 60;
 /// loop blocks on `send` (backpressure) rather than dropping work.
 const COMMAND_QUEUE_DEPTH: usize = 64;
 
-/// How fresh a queued message must be to be processed when draining the bridge
-/// backlog on reconnect. Messages whose sender timestamp is older than this are
-/// discarded rather than acted on, so recovering from a long outage does not
-/// unleash a burst of replies to DMs the user sent long ago. Sized generously
-/// (10 minutes) so it cleanly separates a brief link blip (process the backlog)
-/// from a real outage (drop it), tolerating modest sender/BBS clock skew. A
-/// message with no sender timestamp (0) is treated as fresh — we cannot prove it
-/// stale, and dropping a real DM is worse than a late reply.
-const DRAIN_STALE_AFTER_SECS: u32 = 600;
-
 /// Enqueue a plain-text reply to the companion client and, when retransmission
 /// is enabled, record it in `tracker` for delivery tracking.
 ///
-/// Record + enqueue happen together under the tracker lock with a *non-blocking*
-/// `try_send`, so the tracker's send-order FIFO matches the wire order even when
-/// called from several tasks (the event loop, `notify`, domain-event pushes).
-/// No `.await` is held across the lock. A full command channel drops the reply
-/// (logged) rather than blocking the caller; depth is generous and this is rare.
-fn enqueue_text(
+/// Channel capacity is reserved with `reserve().await` BEFORE the tracker lock
+/// is taken; the frame is then recorded and placed with the synchronous
+/// [`mpsc::Permit::send`] under the lock. This keeps two invariants at once: no
+/// `.await` is ever held across the (std) tracker lock, and the tracker's
+/// send-order FIFO matches the wire order even when called from several tasks
+/// (the command worker, `notify`, domain-event pushes, the retry tick) — that
+/// FIFO is what correlates each `RESP_CODE_SENT` CRC back to its reply. A
+/// transiently full channel now waits (backpressure) instead of preferentially
+/// dropping the user-visible reply — the drain syncs already block the same
+/// way. Only a closed channel (shutdown) drops the reply, and that is counted.
+async fn enqueue_text(
     tracker: &Mutex<SendTracker>,
     stats: &DeliveryStats,
     cmd_tx: &mpsc::Sender<OutboundFrame>,
@@ -108,40 +103,44 @@ fn enqueue_text(
     text: String,
     attempt: u8,
 ) {
+    // Reserve a slot first — never await while holding the tracker lock.
+    let permit = match cmd_tx.reserve().await {
+        Ok(p) => p,
+        Err(e) => {
+            stats.on_dropped();
+            warn!(error = %e, "mesh: command channel closed — reply dropped");
+            return;
+        }
+    };
     let frame = OutboundFrame::SendTxtMsg {
         txt_type: TXT_TYPE_PLAIN,
         // The wire `attempt` field is 0-based (0 = first send); the tracker
         // counts transmissions 1-based.
         attempt: attempt.saturating_sub(1),
-        // Unique per send so two distinct replies to the same node in the same
-        // second aren't collapsed into one byte-identical frame by the radio's
-        // outbound dedup. See next_outbound_timestamp.
+        // Unique per send: two same-second identical replies would otherwise be
+        // byte-identical packets, and the first RECEIVING mesh node's seen-
+        // packet-hash table (the sending radio transmits both copies) drops the
+        // duplicate before it is decrypted or ACKed. See next_outbound_timestamp.
         timestamp: next_outbound_timestamp(),
         pubkey_prefix: prefix,
         text: text.clone(),
     };
     let mut t = tracker.lock().expect("send tracker mutex poisoned");
-    match cmd_tx.try_send(frame) {
-        Ok(()) => {
-            // Count every frame that reaches the wire, independent of whether
-            // retransmission (and hence the tracker's record) is enabled.
-            stats.on_send(prefix, attempt);
-            if t.retries_enabled() {
-                t.record(prefix, text, TXT_TYPE_PLAIN, attempt, Instant::now());
-            }
-        }
-        Err(e) => {
-            stats.on_dropped();
-            warn!(error = %e, "mesh: command channel full/closed — reply dropped");
-        }
+    // Count every frame that reaches the wire, independent of whether
+    // retransmission (and hence the tracker's record) is enabled.
+    stats.on_send(prefix, attempt);
+    if t.retries_enabled() {
+        t.record(prefix, text, TXT_TYPE_PLAIN, attempt, Instant::now());
     }
+    // Synchronous send: wire order equals record order, no await under the lock.
+    permit.send(frame);
 }
 
 /// Retransmit any replies whose end-to-end ACK deadline has passed, and log the
 /// ones that have exhausted their attempt budget. Called on the retry tick from
 /// the event loop. On retry the node's stored path is reset first (when flooding
 /// is enabled) so a stale direct route doesn't keep failing the same way.
-fn retransmit_due_replies(
+async fn retransmit_due_replies(
     cmd_tx: &mpsc::Sender<OutboundFrame>,
     state: &Arc<Mutex<SessionState>>,
     tracker: &Arc<Mutex<SendTracker>>,
@@ -184,7 +183,8 @@ fn retransmit_due_replies(
             rec.prefix,
             rec.text,
             rec.attempt + 1,
-        );
+        )
+        .await;
     }
 }
 
@@ -209,11 +209,17 @@ static NEXT_OUTBOUND_TS: AtomicU32 = AtomicU32::new(0);
 /// firmware's own `getCurrentTimeUnique()`. Two distinct replies to the same node
 /// in the same second would otherwise stamp byte-identical `(dest, timestamp,
 /// text)` frames — e.g. the identical "Welcome" banner an unauthenticated node
-/// gets for every message — which the radio firmware deduplicates, silently
-/// dropping the second reply so the user sees no response. A per-send unique
-/// stamp keeps each reply a distinct packet. Under a burst the stamp can run a
-/// few seconds ahead of real time (harmless; real time catches up when traffic
-/// quiets).
+/// gets for every message. The firmware passes the app timestamp through
+/// unchanged for plain text and encrypts deterministically (AES-ECB), so the two
+/// packets are byte-identical on air; the sending radio transmits BOTH, and the
+/// FIRST RECEIVING mesh node's seen-packet-hash table (the recipient itself at
+/// close range, or any repeater) drops the second before it is decrypted or
+/// ACKed — the user sees one reply and the BBS sees one confirmation. Distinct
+/// stamps also give each in-flight reply a distinct ACK CRC, which the
+/// send-tracker needs to correlate `SendConfirmed` per reply (identical stamps
+/// made two sends share a CRC and silently overwrite each other's record). Under
+/// a burst the stamp can run a few seconds ahead of real time (harmless; real
+/// time catches up when traffic quiets).
 fn next_outbound_timestamp() -> u32 {
     let now = now_unix_secs();
     let mut last = NEXT_OUTBOUND_TS.load(Ordering::Relaxed);
@@ -570,7 +576,8 @@ impl TransportEngine for MeshTransport {
             pubkey_prefix,
             text,
             1,
-        );
+        )
+        .await;
 
         if self.flood_after_send {
             let full_pubkey = self
@@ -634,7 +641,8 @@ async fn push_domain_notification(
                         "Your account has been validated. You now have full access. Type 'H'."
                             .to_owned(),
                         1,
-                    );
+                    )
+                    .await;
                     if flood_after_send {
                         let pubkey = state
                             .lock()
@@ -672,7 +680,8 @@ async fn push_domain_notification(
                             user.as_str()
                         ),
                         1,
-                    );
+                    )
+                    .await;
                     if flood_after_send {
                         let pubkey = state
                             .lock()
@@ -783,9 +792,12 @@ async fn event_loop(
                         break;
                     }
                     Some(ClientEvent::Connected { self_info }) => {
-                        // Drain any messages that queued while we were offline so
-                        // they don't corrupt in-progress workflows.  Always done
-                        // regardless of whether SelfInfo is available.
+                        // Drain the bridge's offline queue on connect so any
+                        // messages that queued while we were offline are handled
+                        // promptly (they are processed like live traffic — see
+                        // the ContactMsgRecv arm). Always done regardless of
+                        // whether SelfInfo is available; the flag's main job is
+                        // the Err fallback for firmware without SYNC support.
                         draining.store(true, Ordering::Relaxed);
                         let _ = cmd_tx.send(OutboundFrame::SyncNextMessage).await;
 
@@ -794,7 +806,7 @@ async fn event_loop(
                                 node = %info.node_name,
                                 freq_khz = info.frequency_khz,
                                 adv_type = info.adv_type,
-                                "mesh: radio bridge connected — draining stale queue"
+                                "mesh: radio bridge connected — draining offline queue"
                             );
                             // Register the BBS node in the advert bus so it appears in
                             // the web UI immediately (using whatever GPS the radio reports).
@@ -955,7 +967,7 @@ async fn event_loop(
                 }
             }
             _ = retry_tick.tick() => {
-                retransmit_due_replies(&cmd_tx, &state, &send_tracker, &delivery_stats, flood_after_send);
+                retransmit_due_replies(&cmd_tx, &state, &send_tracker, &delivery_stats, flood_after_send).await;
             }
             _ = sample_tick.tick() => {
                 let s = delivery_stats.sample(now_unix_secs() as u64);
@@ -1038,64 +1050,27 @@ async fn handle_frame(
         // Bridge has no more queued messages; resume normal processing.
         InboundFrame::NoMoreMessages if draining.load(Ordering::Relaxed) => {
             draining.store(false, Ordering::Relaxed);
-            info!("mesh: stale queue drained — resuming normal processing");
+            info!("mesh: offline queue drained — resuming normal processing");
         }
 
         // ── Direct text messages (v1/v2 and v3 with SNR) ─────────────────────
+        // Live pushes and offline-queue pops (reconnect backlog included) take
+        // the same path: process the message and continue the sync chain. The
+        // backlog is the user's own commands sent while we were offline — they
+        // get replies like live traffic. No age-based discard: the timestamp is
+        // stamped by the SENDER, whose clock may be unset (firmware's unsynced
+        // RTC defaults to a 2024 epoch), so "old-looking" does not mean stale;
+        // and the firmware offline queue holds at most 16 frames, so the worst
+        // reconnect burst is small and bounded.
         InboundFrame::ContactMsgRecv(msg) | InboundFrame::ContactMsgRecvV3(msg) => {
-            let is_draining = draining.load(Ordering::Relaxed);
-
             // Only handle plain-text messages; CLI data and signed frames are
-            // not BBS commands. Keep draining past a non-command frame so the
-            // backlog still flushes to NoMoreMessages.
+            // not BBS commands. Still continue the sync chain unconditionally:
+            // this frame may be a queue pop with more backlog behind it.
             if msg.txt_type != meshcore_companion::constants::TXT_TYPE_PLAIN {
                 debug!(
                     txt_type = msg.txt_type,
                     "mesh: ignoring non-plain-text ContactMsg"
                 );
-                if is_draining {
-                    let _ = cmd_tx.send(OutboundFrame::SyncNextMessage).await;
-                }
-                return;
-            }
-
-            // On reconnect we drain whatever queued while we were offline. Unlike
-            // before — when the whole backlog was discarded — we now *process*
-            // fresh messages so a DM sent during a brief blip still gets a reply.
-            // Clearly-stale backlog (older than DRAIN_STALE_AFTER_SECS, judged by
-            // the sender's timestamp) is still discarded so recovering from a long
-            // outage doesn't unleash a burst of replies to long-dead messages.
-            if is_draining {
-                let age = now_unix_secs().saturating_sub(msg.timestamp);
-                if msg.timestamp != 0 && age > DRAIN_STALE_AFTER_SECS {
-                    debug!(
-                        prefix = msg.sender_key_prefix[0],
-                        age_secs = age,
-                        "mesh: discarding stale queued message (draining)"
-                    );
-                    delivery_stats.on_reconnect_discard();
-                    let _ = cmd_tx.send(OutboundFrame::SyncNextMessage).await;
-                    return;
-                }
-                debug!(
-                    prefix = msg.sender_key_prefix[0],
-                    timestamp = msg.timestamp,
-                    age_secs = age,
-                    "mesh: processing queued message from reconnect backlog"
-                );
-                delivery_stats.on_inbound_received();
-                if cmd_worker_tx
-                    .send(InboundCommand {
-                        sender_prefix: msg.sender_key_prefix,
-                        timestamp: msg.timestamp,
-                        text: msg.text,
-                    })
-                    .await
-                    .is_err()
-                {
-                    warn!("mesh: command worker stopped — dropping inbound message");
-                }
-                // Keep pulling the rest of the backlog.
                 let _ = cmd_tx.send(OutboundFrame::SyncNextMessage).await;
                 return;
             }
@@ -1140,6 +1115,32 @@ async fn handle_frame(
             if cmd_tx.send(OutboundFrame::SyncNextMessage).await.is_err() {
                 warn!("mesh: could not enqueue drain SyncNextMessage — cmd channel closed");
             }
+        }
+
+        // ── Channel (group) traffic — not BBS commands, but queue-poppable ───
+        // The BBS ignores channel messages, but the device stores them in the
+        // SAME offline queue as DMs (firmware `addToOfflineQueue`; pyMC
+        // `message_queue`), so a `CMD_SYNC_NEXT_MESSAGE` pop can return one.
+        // The sync chain MUST continue past them, unconditionally: without this,
+        // a channel message popped during the reconnect drain pinned
+        // `draining = true` until the next MsgWaiting tickle (indefinitely on a
+        // quiet mesh), and in normal mode it broke the drain-to-NoMoreMessages
+        // recovery, stranding a DM queued behind it. Only queue-poppable frame
+        // families get this continuation — re-syncing on non-queue frames
+        // (Sent, Advert, PathUpdated, …) would let a spurious NoMoreMessages
+        // clear `draining` prematurely while real backlog pops are in flight.
+        // Cost: one SyncNextMessage → NoMoreMessages round-trip per channel
+        // frame; the chain always terminates because a non-draining
+        // NoMoreMessages is a no-op.
+        InboundFrame::ChannelMsgRecv(_) | InboundFrame::ChannelMsgRecvV3(_) => {
+            debug!("mesh: ignoring channel message — continuing queue sync");
+            let _ = cmd_tx.send(OutboundFrame::SyncNextMessage).await;
+        }
+        // RESP_CODE_CHANNEL_DATA_RECV (27): queued by firmware like channel
+        // messages but not parsed by the codec, so it surfaces as Unknown.
+        InboundFrame::Unknown { type_byte: 27, .. } => {
+            debug!("mesh: ignoring channel data frame — continuing queue sync");
+            let _ = cmd_tx.send(OutboundFrame::SyncNextMessage).await;
         }
 
         // ── Queued message notification ───────────────────────────────────────
@@ -1638,17 +1639,26 @@ async fn dispatch_message(
     //
     // The `on_dedup_drop_*` counters here are DIAGNOSTIC ONLY — they do not
     // change behaviour. They let an operator see, from the field, how often the
-    // dedup fires on a given node's traffic. This matters because a coarse-clock
-    // bridge (the pyMC bridge stamps whole-second `int(time.time())` and discards
-    // the client's own timestamp) makes two distinct sends in the same second
-    // collide on the (timestamp, text) key. Whether that ever drops *legitimate*
-    // traffic in practice is what these counters measure; the behavioural fix (if
-    // the data shows one is warranted) is deliberately deferred, because a
-    // same-second confirmation is on-the-wire indistinguishable from a stale
-    // retransmission of the command that triggered the prompt, so no
-    // transport-layer rule can tell them apart (see the tests
-    // `identical_workflow_replies_with_same_timestamp_dedup_second` and
-    // `real_host_register_double_send_then_password`, which demand opposite
+    // dedup fires on a given node's traffic. The timestamp we key on is whatever
+    // the ORIGIN stamped: both bridge implementations preserve the packet's
+    // embedded sender timestamp on receive (firmware `queueMessage` copies
+    // `sender_timestamp` verbatim; pyMC's text handler extracts it from the
+    // decrypted payload), so collision risk is set by the SENDING side. Senders
+    // attached to real firmware get the app-supplied stamp passed through
+    // unchanged (apps observed in the field stamp distinct sends distinctly, and
+    // firmware stamps CLI data with strictly-increasing `getCurrentTimeUnique`).
+    // Senders bridged through pyMC, however, are RE-stamped whole-second
+    // `int(time.time())` at send time — pyMC's CMD_SEND_TXT_MSG handler discards
+    // the client's own timestamp bytes — so two distinct, byte-identical sends
+    // from such a sender in the same second collide on the (timestamp, text) key
+    // and the second is dropped here. That is a property of the sender's bridge,
+    // not of ours. Whether it ever drops *legitimate* traffic in practice is
+    // what these counters measure; the behavioural fix (if the data shows one is
+    // warranted) is deliberately deferred, because a same-second confirmation is
+    // on-the-wire indistinguishable from a stale retransmission of the command
+    // that triggered the prompt, so no transport-layer rule can tell them apart
+    // (see the tests `identical_workflow_replies_with_same_timestamp_dedup_second`
+    // and `real_host_register_double_send_then_password`, which demand opposite
     // outcomes for byte-identical input).
     if timestamp != 0 {
         if state
@@ -1810,11 +1820,15 @@ async fn dispatch_message(
         // "Confirm your password:". (#104)
         //
         // This only matters for the timestamp==0 fallback path. On the timestamp
-        // path, #104 is handled naturally: the re-typed confirmation is a new
-        // send with a new per-message timestamp, so dedup_by_timestamp's
-        // (timestamp, text) key already treats it as distinct — the dedup hinges
-        // on the client stamping each distinct send with a distinct timestamp.
-        // Do NOT also clear `recent_msgs` here: that would let a delayed
+        // path, #104 is handled naturally whenever the origin stamps each send
+        // distinctly: the re-typed confirmation carries a new per-message
+        // timestamp, so dedup_by_timestamp's (timestamp, text) key already
+        // treats it as distinct. Caveat: a sender bridged through pyMC is
+        // re-stamped whole-second `int(time.time())` at send time, so a
+        // confirmation byte-identical to the previous reply and sent within the
+        // same second (e.g. a pasted password) still collides and is dropped —
+        // a real, narrow false-drop for that sender population, independent of
+        // our own bridge. Do NOT also clear `recent_msgs` here: that would let a delayed
         // retransmission of the previous reply through after a prompt, re-opening
         // the very "Error: Already logged in" reprocessing this dedup prevents.
         if prompt_text.is_some() {
@@ -1890,7 +1904,8 @@ async fn dispatch_message(
             sender_prefix,
             reply_text,
             1,
-        );
+        )
+        .await;
         // Reset path only after the last frame so intermediate frames travel
         // the same (possibly direct) route as the first.
         if is_last && flood_after_send {

--- a/crates/bbs-mesh/tests/transport.rs
+++ b/crates/bbs-mesh/tests/transport.rs
@@ -90,6 +90,20 @@ fn contact_msg_frame_ts(sender_prefix: [u8; 6], text: &str, timestamp: u32) -> V
     radio_frame(&payload)
 }
 
+/// RESP_CODE_CHANNEL_MSG_RECV: a channel (group) message popped from the device's
+/// offline queue — the same queue that holds DMs, so the sync chain must be able
+/// to continue past one. Layout: [code][channel_idx][path_len][txt_type][ts×4][text].
+fn channel_msg_frame(channel_idx: u8, text: &str) -> Vec<u8> {
+    let ts = NEXT_TS.fetch_add(1, Ordering::Relaxed);
+    let mut payload = vec![RESP_CODE_CHANNEL_MSG_RECV];
+    payload.push(channel_idx);
+    payload.push(0u8); // path_len
+    payload.push(TXT_TYPE_PLAIN);
+    payload.extend_from_slice(&ts.to_le_bytes());
+    payload.extend_from_slice(text.as_bytes());
+    radio_frame(&payload)
+}
+
 /// RESP_CODE_SENT: the device's reply to a send. `send_type` 0=failed, 1=flood,
 /// 2=direct; `crc` is the expected-ack identifier; `timeout_ms` the delivery hint.
 fn sent_frame(send_type: u8, crc: u32, timeout_ms: u32) -> Vec<u8> {
@@ -1118,13 +1132,15 @@ async fn processed_message_emits_followup_sync() {
     transport.stop().await.unwrap();
 }
 
-/// On reconnect the transport drains the bridge's queued backlog. A FRESH queued
-/// message (recent sender timestamp) is now processed — a DM sent during a brief
-/// disconnect still gets a reply — while a clearly-STALE one (older than the
-/// freshness window) is discarded so recovering from a long outage does not
-/// unleash a burst of replies to long-dead messages.
+/// On reconnect the transport drains the bridge's queued backlog and processes
+/// EVERY message — including one whose sender clock looks old. The timestamp is
+/// stamped by the sender, whose RTC may never have been synced (firmware's
+/// unsynced default is a 2024 epoch), so an old-looking stamp is not evidence of
+/// staleness; age-based discarding silently ate real commands from clockless
+/// nodes. The backlog is bounded (the firmware offline queue holds 16 frames),
+/// so processing everything cannot burst-reply meaningfully.
 #[tokio::test]
-async fn reconnect_drain_processes_fresh_and_discards_stale() {
+async fn reconnect_drain_processes_entire_backlog() {
     let host = Arc::new(MockHost::new());
     host.set_default_response(Response::Text("ok".to_owned()));
     let (transport, mut bridge) = make_transport(Arc::clone(&host), None).await;
@@ -1141,19 +1157,20 @@ async fn reconnect_drain_processes_fresh_and_discards_stale() {
         .as_secs() as u32;
     let sender = [0x31u8; 6];
 
-    // First drain sync → feed a FRESH queued message (age ~0, within the window).
+    // First drain sync → feed a FRESH queued message (age ~0).
     let drain1 = bridge.read_command().await;
     assert_eq!(drain1[0], CMD_SYNC_NEXT_MESSAGE);
     bridge
         .send(&contact_msg_frame_ts(sender, "fresh", now))
         .await;
 
-    // Next drain sync → feed a STALE queued message (an hour old, past the window).
+    // Next drain sync → feed a message whose sender clock reads an hour behind
+    // (a never-synced RTC can be years behind — must still be processed).
     bridge.read_until_sync().await;
     bridge
         .send(&contact_msg_frame_ts(
             sender,
-            "stale",
+            "oldclock",
             now.saturating_sub(3600),
         ))
         .await;
@@ -1178,8 +1195,101 @@ async fn reconnect_drain_processes_fresh_and_discards_stale() {
         received.iter().map(|(_, c)| c).collect::<Vec<_>>()
     );
     assert!(
-        !has("stale"),
-        "a stale queued message must be discarded on reconnect"
+        has("oldclock"),
+        "a queued message with an old sender clock must be processed too, got: {:?}",
+        received.iter().map(|(_, c)| c).collect::<Vec<_>>()
+    );
+
+    transport.stop().await.unwrap();
+}
+
+/// Channel (group) messages share the device's offline queue with DMs, so a
+/// `CMD_SYNC_NEXT_MESSAGE` pop can return one. The drain chain must continue
+/// past it: without the fix, a channel message popped during the reconnect
+/// drain pinned `draining=true` and stranded any DM queued behind it.
+#[tokio::test]
+async fn channel_message_during_drain_does_not_stall_the_chain() {
+    let host = Arc::new(MockHost::new());
+    host.set_default_response(Response::Text("ok".to_owned()));
+    let (transport, mut bridge) = make_transport(Arc::clone(&host), None).await;
+
+    // Manual handshake so queue pops can be injected during the on-connect drain.
+    let app_start = bridge.recv_n(11).await;
+    assert_eq!(app_start[3], CMD_APP_START);
+    bridge.send(&self_info_frame("Node")).await;
+
+    let sender = [0x35u8; 6];
+
+    // First drain sync → the queue pop returns a CHANNEL message.
+    let drain1 = bridge.read_command().await;
+    assert_eq!(drain1[0], CMD_SYNC_NEXT_MESSAGE);
+    bridge.send(&channel_msg_frame(0, "group chatter")).await;
+
+    // The chain must continue: another sync pops the DM queued BEHIND it.
+    bridge.read_until_sync().await;
+    bridge.send(&contact_msg_frame(sender, "behind-chan")).await;
+
+    // And on to the end of the queue.
+    bridge.read_until_sync().await;
+    bridge
+        .send(&radio_frame(&[RESP_CODE_NO_MORE_MESSAGES]))
+        .await;
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    let received = host.commands_received();
+    assert!(
+        received
+            .iter()
+            .any(|(_, c)| matches!(c, Command::Unknown { raw } if raw == "behind-chan")),
+        "a DM queued behind a channel message must still be drained and processed, got: {:?}",
+        received.iter().map(|(_, c)| c).collect::<Vec<_>>()
+    );
+
+    // Draining must have cleared: a LIVE message is processed normally.
+    bridge.send(&contact_msg_frame(sender, "live-after")).await;
+    let _ = tokio::time::timeout(Duration::from_secs(2), bridge.read_text_send())
+        .await
+        .expect("live message after drain must be answered (draining stuck?)");
+
+    transport.stop().await.unwrap();
+}
+
+/// In NORMAL mode the drain-to-NoMoreMessages recovery must also continue past a
+/// channel message: a DM whose MsgWaiting tickle was lost can sit queued behind
+/// one, and only the continued sync chain recovers it.
+#[tokio::test]
+async fn channel_message_in_normal_mode_continues_queue_sync() {
+    let host = Arc::new(MockHost::new());
+    host.set_default_response(Response::Text("ok".to_owned()));
+    let (transport, mut bridge) = make_transport(Arc::clone(&host), None).await;
+    bridge.complete_handshake("Node").await;
+
+    let sender = [0x36u8; 6];
+
+    // A MsgWaiting tickle whose pop returns a CHANNEL message; the DM behind it
+    // never got a tickle (dropped). The continued chain must recover it.
+    bridge.send(&radio_frame(&[PUSH_CODE_MSG_WAITING])).await;
+    bridge.read_until_sync().await;
+    bridge.send(&channel_msg_frame(0, "group chatter")).await;
+
+    // Continuation sync → pops the tickle-less DM.
+    bridge.read_until_sync().await;
+    bridge
+        .send(&contact_msg_frame(sender, "tickleless-dm"))
+        .await;
+
+    // The DM's own continuation → queue is empty.
+    bridge.read_until_sync().await;
+    bridge
+        .send(&radio_frame(&[RESP_CODE_NO_MORE_MESSAGES]))
+        .await;
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    assert!(
+        host.commands_received()
+            .iter()
+            .any(|(_, c)| matches!(c, Command::Unknown { raw } if raw == "tickleless-dm")),
+        "a tickle-less DM behind a channel message must be recovered by the sync chain"
     );
 
     transport.stop().await.unwrap();

--- a/crates/bbs-web/web/src/pages/MetricsPage.vue
+++ b/crates/bbs-web/web/src/pages/MetricsPage.vue
@@ -62,7 +62,6 @@ interface DeliveryStats {
   inbound_received: number
   dedup_dropped_timestamp: number
   dedup_dropped_text: number
-  reconnect_discarded: number
   confirm_rate: number | null
   route_failure_rate: number | null
   latency_count: number
@@ -377,11 +376,6 @@ onUnmounted(() => {
           <div class="big-num">{{ ratePct(dedupDropRate) }}</div>
           <div class="bar-track"><div class="bar-fill" :style="{ width: rateWidth(dedupDropRate) + '%' }" :class="failBarClass(dedupDropRate)"></div></div>
           <div class="card-sub muted">{{ delivery.dedup_dropped_timestamp }} timestamp / {{ delivery.dedup_dropped_text }} text — retransmissions dropped</div>
-        </div>
-        <div class="card">
-          <div class="card-label">Reconnect discards</div>
-          <div class="big-num">{{ delivery.reconnect_discarded }}</div>
-          <div class="card-sub muted">stale backlog dropped while draining on reconnect</div>
         </div>
       </div>
     </section>

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -762,27 +762,27 @@ When users report that DMs to the BBS are "less reliable than normal messaging"
 or that "the BBS didn't respond", the stats snapshot
 (`GET /api/v1/transports/meshcore/stats`) carries **inbound** counters alongside
 the outbound reply metrics above. Together they localize *where* a message is
-being lost — the radio return path, the BBS's own dedup, or a reconnect:
+being lost — the radio return path or the BBS's own dedup:
 
 - `inbound_received` — plain-text DMs the BBS accepted for processing.
 - `dedup_dropped_timestamp` / `dedup_dropped_text` — inbound messages the BBS
   dropped as retransmissions before acting on them.
-- `reconnect_discarded` — messages discarded as stale backlog while draining the
-  bridge queue after a reconnect.
+
+(Messages queued at the bridge while the BBS was offline are all processed on
+reconnect — they get replies like live traffic — so there is no separate
+reconnect-loss counter.)
 
 Read them against the outbound `sends_total` / `confirm_rate` / `failed_no_route`
-to tell the three failure modes apart:
+to tell the failure modes apart:
 
 | Symptom | What the numbers show | Likely cause |
 |---------|-----------------------|--------------|
 | BBS replies, user never sees them | `sends_total` climbs, `confirm_rate ≈ 0`, `failed_no_route ≈ 0` | **Outbound return-path loss.** The device accepts every send but no end-to-end ACK returns — a lossy multi-hop reverse path. Replies are not retried by default (`reply_max_attempts = 1`). |
-| BBS "ignores" repeated commands | `dedup_dropped_timestamp` rises against `inbound_received` for that node | **Inbound dedup.** A bridge that stamps coarse whole-second timestamps (the pyMC bridge does) makes two identical sends in the same second collide and the second is dropped. Confirm with a `DEBUG` log line `dropping retransmitted message (timestamp dedup)`. |
-| DMs sent during an outage vanish | `reconnect_discarded` is non-zero | **Reconnect backlog.** Messages older than the freshness window are discarded on reconnect; fresh ones are now processed. |
+| BBS "ignores" repeated commands | `dedup_dropped_timestamp` rises against `inbound_received` for that node | **Inbound dedup.** The dedup keys on the timestamp the *sender* stamped. Senders bridged through pyMC are re-stamped whole-second `int(time.time())` at send time, so two identical sends from such a sender in the same second collide and the second is dropped. Senders on real firmware carry their app's stamp, which is normally distinct per send. Confirm with a `DEBUG` log line `dropping retransmitted message (timestamp dedup)`. |
 
 For a live trace, raise the log level to `DEBUG` (Settings page or `[logging]
-level = "DEBUG"`) and watch for `mesh: inbound message received`,
-`mesh: dropping retransmitted message …`, and
-`mesh: discarding stale queued message (draining)`.
+level = "DEBUG"`) and watch for `mesh: inbound message received` and
+`mesh: dropping retransmitted message …`.
 
 > Note: retrying lost **outbound** replies is not as simple as raising
 > `reply_max_attempts` — on a link that never confirms, the tracker would


### PR DESCRIPTION
> **Stacked on #171** (base `fix/mesh-workflow-timeout-and-flood-unblock`). Merge order: #170 → #171 → this.

## Why

The operator sits 2 ft from the BBS radio (serial → real MeshCore firmware) and still saw dropped/inconsistent replies — a code issue, not RF. A three-pass comparative audit checked our companion code byte-by-byte against **both** references (pyMC_core and the MeshCore C++ firmware); every audit claim was then **adversarially re-verified against the primary sources** before implementation (6-verifier workflow). The re-verification mattered: it corrected the fix shapes on 4 of 6 claims, reversed one "finding", and caught a fix that wouldn't compile.

Codec verdict for the record: **byte-exact** — every frame constant, framing, `RESP_CODE_SENT`, `SEND_CONFIRMED`, SelfInfo, and both message variants match the firmware. The primary 2-ft collapse (same-second identical replies dedup-dropped by the first receiving node) is fixed by `267ab97` in #171; this PR fixes what the audit found beyond it.

## Drain state machine (the real inbound bugs)

- **Channel frames stalled the sync chain.** The device stores channel (group) messages in the **same offline queue** as DMs (`MyMesh.cpp` `addToOfflineQueue`; pyMC `message_queue`), so a `SYNC_NEXT_MESSAGE` pop can return one. Our handler ignored them with no follow-up sync → after a reconnect this pinned `draining=true` (indefinitely on a quiet mesh), and in normal mode it broke the drain-to-NoMoreMessages recovery, stranding a DM queued behind a channel message. New arms for `ChannelMsgRecv(_V3)` + `Unknown{27}` (`RESP_CODE_CHANNEL_DATA_RECV`, unparsed by the codec) continue the chain unconditionally. Scoped to queue-poppable frames only — re-syncing on `Sent`/`Advert`/`PathUpdated` would clear `draining` prematurely (re-verification catch).
- **The reconnect age-discard was unsound — removed.** `DRAIN_STALE_AFTER_SECS=600` (a #170 addition) discarded "old" messages by sender timestamp. But the timestamp is stamped by the **sender**, and firmware's never-synced RTC defaults to a **May 2024 epoch** (`ArduinoHelpers.h` `1715770351`) — above any plausible sanity floor, so clockless nodes' *fresh* commands read as years old and were silently eaten. The firmware itself annotates the field "by sender's RTC clock — **which could be wrong**". The firmware offline queue holds ≤16 frames, so processing the whole backlog is bounded. The draining/live paths now converge; the dead `reconnect_discarded` counter is retired (metrics, web UI, docs, repro example).

## Backpressure hardening (latent)

`enqueue_text` try_send-dropped the **user-visible reply** on a full channel while drain syncs blocked. The naive fix (blocking `send().await`) does not compile — it would hold the `std::sync::Mutex` tracker guard across an await (re-verification catch). Implemented instead: `reserve().await` **before** the tracker lock, then synchronous `Permit::send` under it — no await across the lock, and the tracker's record-order==wire-order FIFO (which correlates `RESP_CODE_SENT` CRCs) is preserved across concurrent callers. Field metrics show `dropped=0`, so this is hardening that matters chiefly once retransmission is enabled.

## Comment corrections (audit-verified, one reversal)

- The first audit pass called our "pyMC re-stamps whole-second" comment a false premise. Re-verification showed it **conflated pyMC's send path with its receive path**: both bridges *preserve* the origin timestamp on **receive**, but pyMC **re-stamps whole-second `int(time.time())` on its send path** (discards the client's stamp bytes) — so same-second identical sends from pyMC-bridged senders (the jc1 population) genuinely collide in our dedup. Comments now state the verified split instead of either wrong absolute.
- `next_outbound_timestamp` docs now name the real dedup locus: the sending radio transmits *both* byte-identical packets; the **first receiving node's** seen-packet-hash table drops the duplicate. Bonus documented: identical stamps also gave two in-flight replies the same ACK CRC, silently overwriting each other's tracker record — unique stamps fix that correlation too.
- `flood_after_send` rustdoc: the reply itself is never flooded; guidance for single-hop deployments.

## Deliberately deferred

- **DeviceQuery/V3 negotiation** (real firmware stays at V1; we lose only SNR, which nothing consumes): `parse_device_info`'s `need!(81)` would decode-fail pre-v9 firmware's 79-byte reply → io::Error → permanent reconnect loop. Needs the parser relaxed first; zero benefit today.
- 
## Testing

Linux/WSL full gate green (fmt, clippy `-D warnings`, `test --workspace`, doc). New/updated tests:
- `channel_message_during_drain_does_not_stall_the_chain` — DM behind a channel message is drained; draining clears; live traffic flows.
- `channel_message_in_normal_mode_continues_queue_sync` — a tickle-less DM behind a channel message is recovered.
- `reconnect_drain_processes_entire_backlog` (was `…discards_stale`) — old-sender-clock messages are processed, not discarded.
