### PR TITLE
chore: make next the integration/default branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches: [main, next]
   pull_request:
 
 env:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,7 +27,13 @@ Be certain to update documentation, where relevant.
 
 ## Branching and pull requests
 
-**Never commit directly to `main`.** All changes must go through a feature branch and a pull request, no matter how small.
+**`next` is the integration branch and the default branch.** All feature/fix work
+branches from `next` and PRs target `next`, not `main`. `main` tracks only what
+has actually been released — `next` is periodically merged into `main` via its
+own PR to cut a release.
+
+**Never commit directly to `next` or `main`.** All changes must go through a
+feature branch and a pull request, no matter how small.
 
 Branch naming follows the pattern `<type>/<short-description>`, e.g.:
 - `feat/guest-room-access`
@@ -36,10 +42,13 @@ Branch naming follows the pattern `<type>/<short-description>`, e.g.:
 - `chore/bump-v0-8-3`
 
 Workflow:
-1. Create a feature branch from `main`
+1. Create a feature branch from `next` (`git checkout -b <branch> next`, or
+   `git checkout -b <branch> origin/next` if `next` isn't checked out locally)
 2. Commit changes to the feature branch
-3. Push the branch and open a PR with `gh pr create --base main --head <branch>`
-4. Never push directly to `main`
+3. Push the branch and open a PR with `gh pr create --base next --head <branch>`
+4. Never push directly to `next` or `main`
+5. Periodically, `next` is merged into `main` via its own PR
+   (`gh pr create --base main --head next`) to cut a release.
 
 ## Commit style
 


### PR DESCRIPTION
## Summary

Establishes `next` as the integration branch going forward: feature/fix work branches from `next` and PRs target `next`; `next` is periodically merged into `main` (its own PR) to cut a release. `main` now tracks only what's actually been released.

- Updated CLAUDE.md's branching section accordingly.
- Added `next` to `ci.yml`'s `push` trigger, so merges/direct pushes to `next` also run the full gate. (`pull_request:` has no branch filter, so PR-triggered CI already covers PRs targeting `next`.)
- Left `docs.yml` (the public docs-site deploy) triggered on `main` only — the public docs should reflect the released state, not in-progress integration work. Flagging this choice in case that's not what you want.

## Follow-up (not in this PR)

- GitHub's repo-level default branch still needs to be flipped from `main` to `next` (a settings change) — will do once this merges, unless you'd rather do it yourself.
- PRs #175 and #176 currently target `main` but their content is already merged into `next` — I'll retarget or close them to avoid confusion once you confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)