### PR TITLE
chore: add GitHub Sponsor button

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,2 @@
+# GitHub Sponsor button config: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/displaying-a-sponsor-button-in-your-repository
+custom: ["https://meshamerica.com/pitch-in/"]


### PR DESCRIPTION
## Summary
- Adds `.github/FUNDING.yml` with a custom link to https://meshamerica.com/pitch-in/ (verified live — Mesh America's own donation page).
- This puts a "Sponsor" button on the repo page next to Watch/Fork/Star, linking to that page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)