### PR TITLE
chore: promote FUNDING.yml to main

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,2 @@
+# GitHub Sponsor button config: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/displaying-a-sponsor-button-in-your-repository
+custom: ["https://meshamerica.com/pitch-in/"]


### PR DESCRIPTION
Promotes the GitHub Sponsor button (`.github/FUNDING.yml` → https://meshamerica.com/pitch-in/) from `next` to `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)