### PR TITLE
docs: add a Pitch In donate CTA to the docs site

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,12 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "docs-preview",
+      "runtimeExecutable": "npx",
+      "runtimeArgs": ["vitepress", "preview", "--port", "5174"],
+      "port": 5174,
+      "cwd": "docs-site"
+    }
+  ]
+}

--- a/docs-site/.vitepress/config.ts
+++ b/docs-site/.vitepress/config.ts
@@ -42,6 +42,7 @@ export default defineConfig({
         link: 'https://github.com/Mesh-America/supply-drop-bbs',
       },
       { text: 'Mesh America', link: 'https://meshamerica.com' },
+      { text: '💚 Pitch In', link: 'https://meshamerica.com/pitch-in/' },
     ],
 
     sidebar: [

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,6 +15,9 @@ hero:
     - theme: alt
       text: View on GitHub
       link: https://github.com/Mesh-America/supply-drop-bbs
+    - theme: alt
+      text: 💚 Pitch In
+      link: https://meshamerica.com/pitch-in/
 
 features:
   - icon: 📻


### PR DESCRIPTION
## Summary
- Nav bar link ("💚 Pitch In") — persistent on every docs page, next to the existing GitHub/Mesh America links.
- Homepage hero — a third action button alongside "Get Started" / "View on GitHub", same styling.
- Both point at https://meshamerica.com/pitch-in/ (verified live; same link used for the GitHub Sponsor button).

Also adds `.claude/launch.json` (`docs-preview`, `vitepress preview` on :5174) so future docs changes can be visually verified via the browser preview tool before shipping — used it here to confirm both the nav link and hero button render and link correctly.

## Test plan
- [x] `npm run docs:build` succeeds
- [x] Visually verified via `vitepress preview` — both links present with correct hrefs

🤖 Generated with [Claude Code](https://claude.com/claude-code)