### PR TITLE
chore: promote docs Pitch In CTA to main

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,12 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "docs-preview",
+      "runtimeExecutable": "npx",
+      "runtimeArgs": ["vitepress", "preview", "--port", "5174"],
+      "port": 5174,
+      "cwd": "docs-site"
+    }
+  ]
+}

--- a/docs-site/.vitepress/config.ts
+++ b/docs-site/.vitepress/config.ts
@@ -42,6 +42,7 @@ export default defineConfig({
         link: 'https://github.com/Mesh-America/supply-drop-bbs',
       },
       { text: 'Mesh America', link: 'https://meshamerica.com' },
+      { text: '💚 Pitch In', link: 'https://meshamerica.com/pitch-in/' },
     ],
 
     sidebar: [

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,6 +15,9 @@ hero:
     - theme: alt
       text: View on GitHub
       link: https://github.com/Mesh-America/supply-drop-bbs
+    - theme: alt
+      text: 💚 Pitch In
+      link: https://meshamerica.com/pitch-in/
 
 features:
   - icon: 📻


### PR DESCRIPTION
Promotes the docs-site Pitch In CTA (nav link + hero button, both → https://meshamerica.com/pitch-in/) from `next` to `main`. Needed for the live site — `docs.yml` only deploys on push to `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)