### PR TITLE
feat: persist mesh contacts across repeater-advert eviction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -96,7 +96,7 @@ checksum = "3c3610892ee6e0cbce8ae2700349fcf8f98adb0dbfbee85aec3c9179d29cc072"
 dependencies = [
  "base64ct",
  "blake2",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "password-hash",
 ]
 
@@ -363,7 +363,7 @@ dependencies = [
  "tokio-stream",
  "toml",
  "toml_edit",
- "tower-http",
+ "tower-http 0.5.2",
  "tracing",
  "tracing-subscriber",
  "uuid",
@@ -465,6 +465,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "chacha20"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65c35e4b699c7e15ccbe7ee35c005e4fc0a278d22238a2857e6ce2dadeda1b06"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.1",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "clap"
 version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -550,6 +561,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "cookie_store"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15b2c103cf610ec6cae3da84a766285b42fd16aad564758459e6ecf128c75206"
+dependencies = [
+ "cookie",
+ "document-features",
+ "idna",
+ "log",
+ "publicsuffix",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "time",
+ "url",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -570,6 +599,15 @@ name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca28b0ae3115b884660db4118d803791fd6756b6e88f39c0f3f7859060d7566"
 dependencies = [
  "libc",
 ]
@@ -710,6 +748,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "document-features"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
+dependencies = [
+ "litrs",
 ]
 
 [[package]]
@@ -964,8 +1011,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -987,10 +1036,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 6.0.0",
+ "rand_core 0.10.1",
  "wasip2",
  "wasip3",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1121,6 +1173,23 @@ dependencies = [
  "pin-project-lite",
  "smallvec",
  "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -1129,13 +1198,21 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
+ "base64",
  "bytes",
+ "futures-channel",
+ "futures-util",
  "http",
  "http-body",
  "hyper",
+ "ipnet",
+ "libc",
+ "percent-encoding",
  "pin-project-lite",
+ "socket2",
  "tokio",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -1276,6 +1353,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ipnet"
+version = "2.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a756c3fac73139e83f14c2d742155dd2b78d3ee56597b419a0579b7bdd6dd78"
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1380,6 +1463,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
+name = "litrs"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
+
+[[package]]
 name = "lock_api"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1393,6 +1482,12 @@ name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "mach2"
@@ -1849,10 +1944,82 @@ dependencies = [
 ]
 
 [[package]]
+name = "psl-types"
+version = "2.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33cb294fe86a74cbcf50d4445b37da762029549ebeea341421c7c70370f86cac"
+
+[[package]]
+name = "publicsuffix"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f42ea446cab60335f76979ec15e12619a2165b5ae2c12166bef27d283a9fadf"
+dependencies = [
+ "idna",
+ "psl-types",
+]
+
+[[package]]
 name = "quick-error"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
+name = "quinn"
+version = "0.11.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c1a41e437b6bbd489372cd4971de128e85c855f56c57f283d20ff016cf7c0a8"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04759210543be93709136e28212294a659ef5001836ff4eab4d663e4529bba83"
+dependencies = [
+ "bytes",
+ "getrandom 0.4.2",
+ "lru-slab",
+ "rand 0.10.2",
+ "rand_pcg",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35a133f956daabe89a61a685c2649f13d82d5aa4bd5d12d1277e1072a21c0694"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "quote"
@@ -1897,6 +2064,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.2",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "rand_chacha"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1932,6 +2110,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
+name = "rand_pcg"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
+dependencies = [
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -1990,6 +2183,60 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
+name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64",
+ "bytes",
+ "cookie",
+ "cookie_store",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tower",
+ "tower-http 0.6.11",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "webpki-roots",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "rsa"
 version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2044,6 +2291,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc-hash"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
+
+[[package]]
 name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2054,6 +2307,41 @@ dependencies = [
  "libc",
  "linux-raw-sys",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0283386ce02abc0151e1761d08802dfe86c173b0b494af5cbc086574e453da06"
+dependencies = [
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f4925028c7eb5d1fcdaf196971378ed9d2c1c4efc7dc5d011256f76c99c0a96"
+dependencies = [
+ "web-time",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3c3cf1d8b1e7d4927e2d154c3fcb02979afb9939629c62cd9048d4f07b60ac2"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
@@ -2201,7 +2489,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 
@@ -2212,7 +2500,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 
@@ -2545,6 +2833,7 @@ dependencies = [
  "figment",
  "meshcore-companion",
  "mimalloc",
+ "reqwest",
  "serde",
  "sysinfo",
  "thiserror 1.0.69",
@@ -2573,6 +2862,9 @@ name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
+]
 
 [[package]]
 name = "synstructure"
@@ -2744,6 +3036,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-serial"
 version = "5.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2856,6 +3158,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "tower-http"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
+dependencies = [
+ "bitflags 2.11.1",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "pin-project-lite",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "url",
+]
+
+[[package]]
 name = "tower-layer"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2943,6 +3263,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
 name = "typenum"
 version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3018,6 +3344,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3091,6 +3423,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
+]
+
+[[package]]
 name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3131,6 +3472,16 @@ dependencies = [
  "rustversion",
  "wasm-bindgen-macro",
  "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.71"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96492d0d3ffba25305a7dc88720d250b1401d7edca02cc3bcd50633b424673b8"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -3197,6 +3548,35 @@ dependencies = [
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.98"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b572dff8bcf38bad0fa19729c89bb5748b2b9b1d8be70cf90df697e3a8f32aa"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dcd9d09a39985f5344844e66b0c530a33843579125f23e21e9f0f220850f22a"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,7 @@ sysinfo.workspace            = true
 dialoguer.workspace          = true
 tokio-serial.workspace       = true
 time.workspace               = true
+reqwest.workspace            = true
 
 [lints]
 workspace = true
@@ -113,6 +114,12 @@ tower-http  = { version = "0.5", features = ["cors", "set-header"] }
 rust-embed  = { version = "8" }
 mime_guess  = "2"
 tokio-stream = { version = "0.1", features = ["sync"] }
+# Minimal feature set (see specs/001-persist-mesh-contacts/research.md
+# Decision 13): JSON bodies + an automatic cookie jar for session auth
+# against a running bbs-web instance (the `contacts` CLI subcommand).
+# rustls-tls avoids an OpenSSL system dependency, consistent with this
+# project's portability goals.
+reqwest     = { version = "0.12", default-features = false, features = ["json", "cookies", "rustls-tls"] }
 zip         = { version = "2", default-features = false, features = ["deflate"] }
 toml_edit   = { version = "0.22", features = ["serde"] }
 sysinfo     = { version = "0.33", default-features = false, features = ["system", "disk", "network"] }

--- a/crates/bbs-core/src/host.rs
+++ b/crates/bbs-core/src/host.rs
@@ -737,6 +737,32 @@ impl Host for BbsHost {
             .map_err(bbs_plugin_api::HostError::Internal)
     }
 
+    async fn admin_remove_meshcore_contact(
+        &self,
+        pubkey: [u8; 32],
+    ) -> Result<(), bbs_plugin_api::HostError> {
+        let tx = self
+            .mesh_key_tx
+            .read()
+            .expect("mesh_key_tx poisoned")
+            .clone()
+            .ok_or_else(|| {
+                bbs_plugin_api::HostError::Internal("mesh transport not connected".into())
+            })?;
+        let (reply_tx, reply_rx) = tokio::sync::oneshot::channel();
+        tx.send(bbs_plugin_api::MeshKeyRequest::RemoveContact {
+            pubkey,
+            reply: reply_tx,
+        })
+        .await
+        .map_err(|_| bbs_plugin_api::HostError::Internal("mesh transport disconnected".into()))?;
+        tokio::time::timeout(std::time::Duration::from_secs(10), reply_rx)
+            .await
+            .map_err(|_| bbs_plugin_api::HostError::Internal("contact removal timed out".into()))?
+            .map_err(|_| bbs_plugin_api::HostError::Internal("contact removal cancelled".into()))?
+            .map_err(bbs_plugin_api::HostError::Internal)
+    }
+
     fn register_meshtastic_admin_ops(
         &self,
         sender: tokio::sync::mpsc::Sender<bbs_plugin_api::MeshtasticAdminRequest>,
@@ -948,6 +974,38 @@ impl Host for BbsHost {
             .await
             .map_err(|_| bbs_plugin_api::HostError::Internal("meshtastic reboot timed out".into()))?
             .map_err(|_| bbs_plugin_api::HostError::Internal("meshtastic reboot cancelled".into()))?
+            .map_err(bbs_plugin_api::HostError::Internal)
+    }
+
+    async fn admin_remove_meshtastic_favorite(
+        &self,
+        node_num: u32,
+    ) -> Result<(), bbs_plugin_api::HostError> {
+        let tx = self
+            .meshtastic_admin_tx
+            .read()
+            .expect("meshtastic_admin_tx poisoned")
+            .clone()
+            .ok_or_else(|| {
+                bbs_plugin_api::HostError::Internal("meshtastic transport not connected".into())
+            })?;
+        let (reply_tx, reply_rx) = tokio::sync::oneshot::channel();
+        tx.send(bbs_plugin_api::MeshtasticAdminRequest::RemoveFavoriteNode {
+            node_num,
+            reply: reply_tx,
+        })
+        .await
+        .map_err(|_| {
+            bbs_plugin_api::HostError::Internal("meshtastic transport disconnected".into())
+        })?;
+        tokio::time::timeout(std::time::Duration::from_secs(10), reply_rx)
+            .await
+            .map_err(|_| {
+                bbs_plugin_api::HostError::Internal("meshtastic favorite removal timed out".into())
+            })?
+            .map_err(|_| {
+                bbs_plugin_api::HostError::Internal("meshtastic favorite removal cancelled".into())
+            })?
             .map_err(bbs_plugin_api::HostError::Internal)
     }
 

--- a/crates/bbs-mesh/src/config.rs
+++ b/crates/bbs-mesh/src/config.rs
@@ -295,6 +295,26 @@ pub struct MeshConfig {
     /// ```
     #[serde(default)]
     pub radio: Option<RadioConfig>,
+
+    /// Maximum number of contacts that may be protected (favourited) at
+    /// once — see the "Persist Mesh Contacts" feature
+    /// (`specs/001-persist-mesh-contacts/research.md` Decision 5b).
+    ///
+    /// Once this many contacts are protected, a newly-eligible sender's
+    /// first DM evicts the oldest-protected, currently session-inactive
+    /// contact to make room, rather than growing the protected set further.
+    /// Set this to your device's real contact-table capacity (MeshCore's
+    /// `max_contacts` varies by hardware — check your device). Defaults to
+    /// `350`, a common companion-radio figure, but is not authoritative for
+    /// every board. `0` disables protection entirely on this transport (no
+    /// new contact is ever protected).
+    ///
+    /// Enforced in `dispatch_message`'s call to
+    /// `AdvertBus::mark_favourite_if_eligible`. (Meshtastic's equivalent
+    /// default is `100`, not `350` — the two are intentionally different,
+    /// not drifted; real device capacity varies by transport and hardware.)
+    #[serde(default = "default_protected_contact_cap")]
+    pub protected_contact_cap: usize,
 }
 
 impl MeshConfig {
@@ -336,6 +356,7 @@ impl Default for MeshConfig {
             workflow_timeout_secs: default_workflow_timeout_secs(),
             advert_on_connect: true,
             radio: None,
+            protected_contact_cap: default_protected_contact_cap(),
         }
     }
 }
@@ -388,6 +409,10 @@ fn default_workflow_timeout_secs() -> u64 {
 
 fn default_true() -> bool {
     true
+}
+
+fn default_protected_contact_cap() -> usize {
+    350
 }
 
 #[cfg(test)]

--- a/crates/bbs-mesh/src/session.rs
+++ b/crates/bbs-mesh/src/session.rs
@@ -36,6 +36,12 @@ use bbs_plugin_api::SessionId;
 /// entry is a few bytes; the sweep is what keeps this from growing forever).
 const PENDING_PROTECT_TTL_SECS: u64 = 86_400; // 24 hours
 
+/// Minimum gap between targeted `GetContacts` catch-up requests (see
+/// [`SessionState::should_request_contacts_catchup`]). Matches
+/// `MIN_ADVERT_SPACING` in transport.rs — the same "don't hammer the radio
+/// with a background maintenance request" scale, not a real-time retry.
+const CONTACTS_CATCHUP_COOLDOWN_SECS: u64 = 60;
+
 /// How long a workflow reply is remembered for deduplication.
 /// Meshtastic retransmissions happen within a few seconds; 10 s is generous.
 /// 60 s caused false-positive drops when a user typed a short string (e.g. "h")
@@ -110,8 +116,9 @@ pub struct SessionEntry {
     /// `RECENT_MSG_CAP`.
     pub recent_msgs: VecDeque<(u32, String, Instant)>,
 
-    /// Full 32-byte public key for this node, populated the first time a
-    /// `NewAdvert` frame arrives from this node.  `None` until that happens.
+    /// Full 32-byte public key for this node, populated the first time any
+    /// identity-bearing frame arrives from it — `NewAdvert`, `Contact`,
+    /// `PathUpdated`, or the lightweight `Advert`.  `None` until then.
     /// Used to send `ResetPath` after delivering a message so the next
     /// outbound message floods rather than using a potentially-stale path.
     pub full_pubkey: Option<[u8; 32]>,
@@ -145,6 +152,15 @@ pub struct SessionState {
     /// insertion time, used only for the TTL sweep in
     /// [`Self::mark_pending_protect`].
     pending_protect: HashMap<[u8; 6], Instant>,
+    /// The last time a targeted `GetContacts` catch-up request was sent —
+    /// see [`Self::should_request_contacts_catchup`]. A single cooldown
+    /// shared by every sender rather than one per sender, since `GetContacts`
+    /// fetches every contact the device knows about at once, not one contact
+    /// at a time. `SessionState` (and this field with it) lives for the
+    /// whole transport's lifetime, not just one physical connection — it is
+    /// never reset on reconnect, so the cooldown persists across reconnects
+    /// too.
+    contacts_catchup_requested_at: Option<Instant>,
 }
 
 impl SessionState {
@@ -407,6 +423,46 @@ impl SessionState {
     /// contact-protection decision.
     pub fn is_pending_protect(&self, prefix: &[u8; 6]) -> bool {
         self.pending_protect.contains_key(prefix)
+    }
+
+    /// True when a targeted `GetContacts` catch-up request should be sent —
+    /// more than `CONTACTS_CATCHUP_COOLDOWN_SECS` have passed since the last
+    /// one (or none has ever been sent for the lifetime of this transport).
+    ///
+    /// Why this exists: the one-time, connect-time `GetContacts` (see
+    /// `transport.rs`'s `event_loop` — its `ClientEvent::Connected` handler)
+    /// only captures contacts the device already knew about at that exact
+    /// moment. A sender who first DMs the BBS
+    /// afterward — the common case, since BBS uptime and a given user's
+    /// first contact are unrelated — gets a `NoRecordYet` protection outcome
+    /// forever: the device now knows this contact internally (it routed the
+    /// DM reply), but its own subsequent adverts for an already-known
+    /// contact come through as the lightweight, name/type-less kind, not a
+    /// full re-send. Nothing else in this transport re-asks the device for
+    /// full contact details once the initial connect-time sync has passed,
+    /// so without this, such a sender can never become eligible for
+    /// protection no matter how many times they advert.
+    pub fn should_request_contacts_catchup(&self) -> bool {
+        self.should_request_contacts_catchup_at(Instant::now())
+    }
+
+    /// [`Self::should_request_contacts_catchup`] with an injectable `now`,
+    /// so the cooldown is unit-testable without sleeping for real.
+    fn should_request_contacts_catchup_at(&self, now: Instant) -> bool {
+        let cooldown = Duration::from_secs(CONTACTS_CATCHUP_COOLDOWN_SECS);
+        self.contacts_catchup_requested_at
+            .is_none_or(|at| now.saturating_duration_since(at) >= cooldown)
+    }
+
+    /// Record that a `GetContacts` catch-up request was just sent, starting
+    /// the cooldown before another one will be considered.
+    pub fn mark_contacts_catchup_requested(&mut self) {
+        self.mark_contacts_catchup_requested_at(Instant::now());
+    }
+
+    /// [`Self::mark_contacts_catchup_requested`] with an injectable `now`.
+    fn mark_contacts_catchup_requested_at(&mut self, now: Instant) {
+        self.contacts_catchup_requested_at = Some(now);
     }
 }
 
@@ -684,6 +740,41 @@ mod tests {
         assert!(
             !st.is_pending_protect(&PREFIX),
             "an entry past its TTL must be swept by the next insert"
+        );
+    }
+
+    #[test]
+    fn contacts_catchup_is_allowed_before_any_request_and_blocked_right_after() {
+        let mut st = SessionState::default();
+        assert!(
+            st.should_request_contacts_catchup(),
+            "nothing sent yet — a first catch-up must be allowed"
+        );
+        let t0 = Instant::now();
+        st.mark_contacts_catchup_requested_at(t0);
+        assert!(
+            !st.should_request_contacts_catchup_at(t0),
+            "immediately after a request, the cooldown must block another"
+        );
+    }
+
+    #[test]
+    fn contacts_catchup_cooldown_boundary_is_at_least_not_strictly_greater() {
+        let mut st = SessionState::default();
+        let t0 = Instant::now();
+        st.mark_contacts_catchup_requested_at(t0);
+
+        let just_inside = t0 + Duration::from_secs(CONTACTS_CATCHUP_COOLDOWN_SECS - 1);
+        assert!(
+            !st.should_request_contacts_catchup_at(just_inside),
+            "still within the cooldown window must stay blocked"
+        );
+
+        // The real check is `>=`, not `>` — exactly at the boundary is allowed.
+        let at_boundary = t0 + Duration::from_secs(CONTACTS_CATCHUP_COOLDOWN_SECS);
+        assert!(
+            st.should_request_contacts_catchup_at(at_boundary),
+            "exactly at the cooldown boundary must be allowed again"
         );
     }
 }

--- a/crates/bbs-mesh/src/session.rs
+++ b/crates/bbs-mesh/src/session.rs
@@ -28,6 +28,14 @@ use std::time::{Duration, Instant};
 
 use bbs_plugin_api::SessionId;
 
+/// How long an unresolved pending-protect entry is remembered before being
+/// swept, per `specs/001-persist-mesh-contacts/research.md` Decision 3's
+/// round-21/26 fixes. Generous enough to comfortably outlast any commonly-
+/// configured advertising interval, while still bounding memory against a
+/// hostile peer manufacturing many never-resolving identities (each pending
+/// entry is a few bytes; the sweep is what keeps this from growing forever).
+const PENDING_PROTECT_TTL_SECS: u64 = 86_400; // 24 hours
+
 /// How long a workflow reply is remembered for deduplication.
 /// Meshtastic retransmissions happen within a few seconds; 10 s is generous.
 /// 60 s caused false-positive drops when a user typed a short string (e.g. "h")
@@ -131,6 +139,12 @@ pub struct SessionState {
     pub by_prefix: HashMap<[u8; 6], SessionEntry>,
     /// Session ID → pubkey prefix (6 bytes).
     pub by_session: HashMap<SessionId, [u8; 6]>,
+    /// Senders whose contact-protection decision is still pending more data
+    /// (an unresolved identity or an incomplete `AdvertBus` record) — see
+    /// `specs/001-persist-mesh-contacts/research.md` Decision 3. Value is
+    /// insertion time, used only for the TTL sweep in
+    /// [`Self::mark_pending_protect`].
+    pending_protect: HashMap<[u8; 6], Instant>,
 }
 
 impl SessionState {
@@ -170,6 +184,7 @@ impl SessionState {
     /// Remove the session for `prefix` (e.g. on explicit logout or expiry).
     /// Returns the removed `SessionId` if one existed.
     pub fn remove_by_prefix(&mut self, prefix: &[u8; 6]) -> Option<SessionId> {
+        self.pending_protect.remove(prefix);
         if let Some(entry) = self.by_prefix.remove(prefix) {
             self.by_session.remove(&entry.session_id);
             Some(entry.session_id)
@@ -359,6 +374,39 @@ impl SessionState {
             entry.last_message = Some((text.to_owned(), Instant::now()));
         }
         false
+    }
+
+    /// Mark `prefix` as pending a contact-protection decision — an
+    /// unconditional insert, idempotent regardless of whether it was already
+    /// pending (see research.md Decision 3's round-21 correction: this must
+    /// be a plain re-insert, not a conditional one, since a concurrent
+    /// resolver could have raced it in between). Sweeps entries older than
+    /// `PENDING_PROTECT_TTL_SECS` first — lazy, O(n) over the (small,
+    /// TTL-bounded) pending set, no separate timer needed.
+    pub fn mark_pending_protect(&mut self, prefix: [u8; 6]) {
+        self.mark_pending_protect_at(prefix, Instant::now());
+    }
+
+    /// [`Self::mark_pending_protect`] with an injectable `now`, so the TTL
+    /// sweep is unit-testable without sleeping for real hours.
+    fn mark_pending_protect_at(&mut self, prefix: [u8; 6], now: Instant) {
+        let ttl = Duration::from_secs(PENDING_PROTECT_TTL_SECS);
+        self.pending_protect
+            .retain(|_, inserted_at| now.saturating_duration_since(*inserted_at) < ttl);
+        self.pending_protect.insert(prefix, now);
+    }
+
+    /// Clear `prefix`'s pending-protect mark — called once a protection
+    /// attempt reaches a terminal outcome (`Protected`, `ProtectedWithEviction`,
+    /// `AlreadyProtected`, `Ineligible`, or `CapReached`).
+    pub fn clear_pending_protect(&mut self, prefix: &[u8; 6]) {
+        self.pending_protect.remove(prefix);
+    }
+
+    /// Return `true` if `prefix` is currently marked as pending a
+    /// contact-protection decision.
+    pub fn is_pending_protect(&self, prefix: &[u8; 6]) -> bool {
+        self.pending_protect.contains_key(prefix)
     }
 }
 
@@ -570,6 +618,72 @@ mod tests {
         assert!(
             !st.dedup_by_timestamp_at(&PREFIX, 1_000, "login bob", outside),
             "a resend after the window expires is processed as new"
+        );
+    }
+
+    #[test]
+    fn pending_protect_marks_and_clears() {
+        let mut st = SessionState::default();
+        assert!(!st.is_pending_protect(&PREFIX));
+        st.mark_pending_protect(PREFIX);
+        assert!(st.is_pending_protect(&PREFIX));
+        st.clear_pending_protect(&PREFIX);
+        assert!(!st.is_pending_protect(&PREFIX));
+    }
+
+    #[test]
+    fn pending_protect_mark_is_idempotent_and_reentrant() {
+        let mut st = SessionState::default();
+        // Re-marking an already-pending entry (round-21 fix: must be an
+        // unconditional re-insert, not a conditional one) must not error or
+        // clear it.
+        st.mark_pending_protect(PREFIX);
+        st.mark_pending_protect(PREFIX);
+        assert!(st.is_pending_protect(&PREFIX));
+        // Clearing an entry that was never marked is a no-op, not a panic.
+        let other: [u8; 6] = [9, 9, 9, 9, 9, 9];
+        st.clear_pending_protect(&other);
+        assert!(!st.is_pending_protect(&other));
+    }
+
+    /// Cross-transport audit regression (Phase 4 verifier): Meshtastic's
+    /// sibling `remove_by_node` clears `pending_protect` on removal; this
+    /// method didn't. Low impact (a stale mark self-heals via the 24h TTL
+    /// sweep), but the two transports' equivalent methods should behave the
+    /// same way rather than silently drift apart.
+    #[test]
+    fn remove_by_prefix_clears_pending_protect() {
+        let mut st = SessionState::default();
+        st.get_or_insert(PREFIX, SessionId::__internal_new(1));
+        st.mark_pending_protect(PREFIX);
+        assert!(st.is_pending_protect(&PREFIX));
+        st.remove_by_prefix(&PREFIX);
+        assert!(!st.is_pending_protect(&PREFIX));
+    }
+
+    #[test]
+    fn pending_protect_ttl_sweeps_stale_entries() {
+        let mut st = SessionState::default();
+        let t0 = Instant::now();
+        let other: [u8; 6] = [9, 9, 9, 9, 9, 9];
+        st.mark_pending_protect_at(PREFIX, t0);
+
+        // Still within the TTL: a later insert for a different prefix must
+        // not sweep the first one away.
+        let inside = t0 + Duration::from_secs(PENDING_PROTECT_TTL_SECS - 1);
+        st.mark_pending_protect_at(other, inside);
+        assert!(
+            st.is_pending_protect(&PREFIX),
+            "an entry still within its TTL must survive another insert's sweep"
+        );
+
+        // Past the TTL: the next insert's lazy sweep must evict the stale one.
+        let outside = t0 + Duration::from_secs(PENDING_PROTECT_TTL_SECS + 1);
+        let third: [u8; 6] = [7, 7, 7, 7, 7, 7];
+        st.mark_pending_protect_at(third, outside);
+        assert!(
+            !st.is_pending_protect(&PREFIX),
+            "an entry past its TTL must be swept by the next insert"
         );
     }
 }

--- a/crates/bbs-mesh/src/transport.rs
+++ b/crates/bbs-mesh/src/transport.rs
@@ -36,13 +36,13 @@ use bbs_plugin_api::{
     identity::SessionId,
     plugin::Plugin,
     transport::TransportEngine,
-    Command, Host, PermissionLevel, Response,
+    Command, FavouriteOutcome, FavouriteSnapshot, Host, PermissionLevel, Response,
 };
 use meshcore_companion::{
     client::{ClientConfig, ClientEvent, CompanionClient, SerialConfig},
-    constants::{MAX_FRAME_SIZE, TXT_TYPE_PLAIN},
+    constants::{ADV_TYPE_CHAT, MAX_FRAME_SIZE, MAX_PATH_SIZE, TXT_TYPE_PLAIN},
     frame::OutboundFrame,
-    types::SelfInfo,
+    types::{Contact, SelfInfo},
 };
 
 /// Maximum bytes of plain text that fit in one `SendTxtMsg` companion frame.
@@ -353,6 +353,9 @@ pub struct MeshTransport {
     /// Cumulative reply-delivery counters, surfaced to the admin UI. Shared with
     /// the event-loop and notification tasks; lock-free. See [`crate::metrics`].
     delivery_stats: Arc<DeliveryStats>,
+    /// Maximum simultaneously-protected contacts on this transport (see
+    /// [`MeshConfig::protected_contact_cap`]). `0` disables protection.
+    protected_contact_cap: usize,
 }
 
 impl MeshTransport {
@@ -447,6 +450,7 @@ impl Plugin for MeshTransport {
                 max_timeout: REPLY_ACK_MAX_WAIT,
             }))),
             delivery_stats: Arc::new(DeliveryStats::default()),
+            protected_contact_cap: config.protected_contact_cap,
         })
     }
 
@@ -560,6 +564,7 @@ impl Plugin for MeshTransport {
             send_tracker,
             delivery_stats,
             key_rx,
+            self.protected_contact_cap,
         ));
 
         info!("mesh transport started");
@@ -846,6 +851,7 @@ async fn event_loop(
     send_tracker: Arc<Mutex<SendTracker>>,
     delivery_stats: Arc<DeliveryStats>,
     mut key_rx: tokio::sync::mpsc::Receiver<bbs_plugin_api::MeshKeyRequest>,
+    protected_contact_cap: usize,
 ) {
     // Pending one-shot key operation. At most one at a time.
     let mut pending_key_op: Option<PendingKeyOp> = None;
@@ -905,6 +911,7 @@ async fn event_loop(
         workflow_timeout_secs,
         Arc::clone(&send_tracker),
         Arc::clone(&delivery_stats),
+        protected_contact_cap,
     ));
 
     loop {
@@ -1137,7 +1144,7 @@ async fn event_loop(
                             _ => false,
                         };
                         if !consumed {
-                            handle_frame(frame, &host, &cmd_tx, &state, &draining, &send_tracker, &delivery_stats, &cmd_worker_tx).await;
+                            handle_frame(frame, &host, &cmd_tx, &state, &draining, &send_tracker, &delivery_stats, &cmd_worker_tx, protected_contact_cap).await;
                         }
                     }
                 }
@@ -1194,6 +1201,29 @@ async fn event_loop(
                             });
                         }
                     }
+                    MeshKeyRequest::RemoveContact { pubkey, reply } => {
+                        // Fire-and-forget, unlike Export/Import/ApplyRadio above:
+                        // RemoveContact has no correlated wire response to wait
+                        // for, so it never touches `pending_key_op` (see
+                        // specs/001-persist-mesh-contacts/research.md Decision 12).
+                        //
+                        // Decision 12c: re-validate immediately before sending —
+                        // a fresher protect for the same identity may have landed
+                        // after the caller's own `unprotect()` call (e.g. a
+                        // concurrent re-DM on `command_worker`); sending a stale
+                        // removal in that case would silently undo it.
+                        if host.advert_bus().is_currently_favourited(&pubkey) {
+                            debug!(
+                                "mesh: skipping contact removal — a fresher protect landed since this delete was requested"
+                            );
+                            let _ = reply.send(Ok(()));
+                        } else {
+                            let result = cmd_tx
+                                .try_send(OutboundFrame::RemoveContact { pubkey })
+                                .map_err(|e| format!("failed to queue contact removal: {e}"));
+                            let _ = reply.send(result);
+                        }
+                    }
                 }
             }
             _ = shutdown_rx.changed() => {
@@ -1222,6 +1252,7 @@ async fn handle_frame(
     send_tracker: &Arc<Mutex<SendTracker>>,
     delivery_stats: &Arc<DeliveryStats>,
     cmd_worker_tx: &mpsc::Sender<InboundCommand>,
+    protected_contact_cap: usize,
 ) {
     use meshcore_companion::frame::InboundFrame;
 
@@ -1352,12 +1383,18 @@ async fn handle_frame(
             } else {
                 (contact.gps_lat, contact.gps_lon)
             };
-            host.advert_bus().upsert(
+            host.advert_bus().upsert_contact(
                 contact.pubkey,
                 contact.name.clone(),
                 contact.adv_type,
                 gps_lat,
                 gps_lon,
+                contact.last_advert_timestamp as i64,
+                contact.flags,
+                contact.last_advert_timestamp,
+                contact.lastmod,
+                contact.out_path.to_vec(),
+                contact.out_path_len,
                 TRANSPORT_NAME,
             );
             // Record the full pubkey so we can send ResetPath after delivers.
@@ -1367,6 +1404,24 @@ async fn handle_frame(
                 .expect("state mutex poisoned")
                 .set_full_pubkey(&prefix, contact.pubkey);
             debug!(name = %contact.name, "mesh: full advert (new contact) received");
+
+            // Persist Mesh Contacts: retry a pending protect now that this
+            // identity's full record is available (research.md Decision 3).
+            let pending = state
+                .lock()
+                .expect("state mutex poisoned")
+                .is_pending_protect(&prefix);
+            if pending {
+                attempt_protect_and_update_pending(
+                    host,
+                    cmd_tx,
+                    state,
+                    prefix,
+                    contact.pubkey,
+                    protected_contact_cap,
+                )
+                .await;
+            }
         }
 
         // ── Contact list sync (response to CMD_GET_CONTACTS) ─────────────────
@@ -1379,13 +1434,18 @@ async fn handle_frame(
             // real last-advert time stored on the device rather than the moment
             // we happened to run GetContacts (which would make every row show
             // the same timestamp).
-            host.advert_bus().upsert_with_timestamp(
+            host.advert_bus().upsert_contact(
                 contact.pubkey,
                 contact.name.clone(),
                 contact.adv_type,
                 contact.gps_lat,
                 contact.gps_lon,
                 contact.last_advert_timestamp as i64,
+                contact.flags,
+                contact.last_advert_timestamp,
+                contact.lastmod,
+                contact.out_path.to_vec(),
+                contact.out_path_len,
                 TRANSPORT_NAME,
             );
             // Record the full pubkey mapping so ResetPath can find the node.
@@ -1395,6 +1455,24 @@ async fn handle_frame(
                 .expect("state mutex poisoned")
                 .set_full_pubkey(&prefix, contact.pubkey);
             debug!(name = %contact.name, "mesh: contact list entry → advert bus");
+
+            // Persist Mesh Contacts: retry a pending protect now that this
+            // identity's full record is available (research.md Decision 3).
+            let pending = state
+                .lock()
+                .expect("state mutex poisoned")
+                .is_pending_protect(&prefix);
+            if pending {
+                attempt_protect_and_update_pending(
+                    host,
+                    cmd_tx,
+                    state,
+                    prefix,
+                    contact.pubkey,
+                    protected_contact_cap,
+                )
+                .await;
+            }
         }
         InboundFrame::ContactsStart { count: _ } => {
             debug!("mesh: contact list sync started");
@@ -1565,28 +1643,67 @@ async fn handle_frame(
                     exclude.push(sp);
                 }
             }
-            match host.advert_bus().stalest_pubkey_excluding(&exclude) {
+            // `stalest_pubkey_excluding` already skips protected/favourited
+            // records (research.md Decision 6) — no separate favourite check
+            // is needed to select a candidate.
+            match host
+                .advert_bus()
+                .stalest_pubkey_excluding(&exclude, TRANSPORT_NAME)
+            {
                 Some(stale_pubkey) => {
                     let prefix_hex: String = stale_pubkey[..6]
                         .iter()
                         .map(|b| format!("{b:02x}"))
                         .collect();
-                    warn!(
-                        prefix = %prefix_hex,
-                        "mesh: removing stale contact from radio table to free a slot"
-                    );
-                    let _ = cmd_tx
-                        .send(OutboundFrame::RemoveContact {
+                    // Decision 6a: re-validate immediately before sending —
+                    // a concurrent protect for this exact pubkey (on
+                    // command_worker) could have committed in the window
+                    // since selection; sending the removal anyway would
+                    // silently undo it.
+                    if host.advert_bus().is_currently_favourited(&stale_pubkey) {
+                        debug!(
+                            prefix = %prefix_hex,
+                            "mesh: skipping stale-contact eviction — it was protected \
+                             since being selected"
+                        );
+                    } else {
+                        warn!(
+                            prefix = %prefix_hex,
+                            "mesh: removing stale contact from radio table to free a slot"
+                        );
+                        // try_send, not an awaited send (research.md Decision
+                        // 8/10): this handler's own trigger condition
+                        // (ContactsFull) is most likely to coincide with
+                        // exactly the burst traffic that also saturates
+                        // cmd_tx — an awaited send here would stall all
+                        // inbound frame processing, not just this eviction.
+                        let _ = cmd_tx.try_send(OutboundFrame::RemoveContact {
                             pubkey: stale_pubkey,
-                        })
-                        .await;
+                        });
+                    }
                 }
                 None => {
-                    warn!(
-                        "mesh: radio table full but no evictable stale contact found \
-                         (all known contacts have active sessions); \
-                         new nodes cannot be added until sessions close"
-                    );
+                    // FR-009: distinguish "every remaining contact is
+                    // favourited" (nothing this BBS can do — an operator
+                    // must manually free a slot) from the ordinary
+                    // "everything is session-active" case already logged by
+                    // the general warning below.
+                    if host
+                        .advert_bus()
+                        .all_remaining_favourited(&exclude, TRANSPORT_NAME)
+                    {
+                        warn!(
+                            "mesh: radio contact table is full and every remaining \
+                             contact is protected — no contact, protected or not, can \
+                             be added until an operator manually frees a slot"
+                        );
+                    } else {
+                        warn!(
+                            "mesh: radio table full but no evictable stale contact found \
+                             (all known contacts have active sessions); \
+                             new nodes cannot be added until sessions close"
+                        );
+                    }
                 }
             }
         }
@@ -1652,6 +1769,7 @@ async fn command_worker(
     workflow_timeout_secs: u64,
     send_tracker: Arc<Mutex<SendTracker>>,
     delivery_stats: Arc<DeliveryStats>,
+    protected_contact_cap: usize,
 ) {
     while let Some(cmd) = rx.recv().await {
         dispatch_message(
@@ -1668,10 +1786,173 @@ async fn command_worker(
             workflow_timeout_secs,
             &send_tracker,
             &delivery_stats,
+            protected_contact_cap,
         )
         .await;
     }
     debug!("mesh: command worker stopped (queue closed)");
+}
+
+// ── Contact protection ("Persist Mesh Contacts" feature) ───────────────────
+
+/// Eligibility gate for protection: only a real chat/person contact, never a
+/// repeater/room-server/sensor (see `specs/001-persist-mesh-contacts/spec.md`
+/// FR-003). MeshCore's `adv_type` is an allow-list of exactly one value —
+/// unlike Meshtastic's multi-value role allow-list, since MeshCore only
+/// distinguishes chat from three non-person types.
+fn is_meshcore_chat_type(adv_type: u8) -> bool {
+    adv_type == ADV_TYPE_CHAT
+}
+
+/// Build the outbound `AddUpdateContact` frame from a protect snapshot,
+/// converting the cached `Vec<u8>` path into `Contact.out_path`'s
+/// fixed-size array (always exactly `MAX_PATH_SIZE` bytes in practice: any
+/// snapshot actually populated from a real `Contact` frame was itself
+/// decoded from that same fixed array — see research.md Decision 1's round-11
+/// simplification) and the cached `lat`/`lon` (`f64` decimal degrees) into
+/// `Contact.gps_lat`/`gps_lon` (`i32` degrees×1,000,000).
+fn protect_frame_for(snapshot: &FavouriteSnapshot) -> OutboundFrame {
+    let mut out_path = [0u8; MAX_PATH_SIZE];
+    let n = snapshot.out_path.len().min(MAX_PATH_SIZE);
+    out_path[..n].copy_from_slice(&snapshot.out_path[..n]);
+
+    OutboundFrame::AddUpdateContact(Contact {
+        pubkey: snapshot.pubkey,
+        adv_type: snapshot.adv_type,
+        flags: snapshot.flags,
+        out_path_len: snapshot.out_path_len,
+        out_path,
+        name: snapshot.name.clone(),
+        last_advert_timestamp: snapshot.last_advert_timestamp,
+        gps_lat: (snapshot.lat * 1_000_000.0) as i32,
+        gps_lon: (snapshot.lon * 1_000_000.0) as i32,
+        lastmod: snapshot.lastmod,
+    })
+}
+
+/// Attempt to protect `pubkey`'s contact entry, enforcing the configured
+/// per-transport cap (`specs/001-persist-mesh-contacts/research.md`
+/// Decision 5b). Fire-and-forget on the wire — never awaits a device
+/// response, never delays the caller (Decision 8): the outbound frame is
+/// sent via `try_send`, and a synchronously-detected failure reverts the
+/// local commit so the sender stays eligible for a retry on their next
+/// message (Decision 8a) rather than being permanently, silently
+/// unprotected while `AdvertBus` believes otherwise.
+async fn try_protect_contact(
+    host: &Arc<dyn Host>,
+    cmd_tx: &mpsc::Sender<OutboundFrame>,
+    state: &Arc<Mutex<SessionState>>,
+    pubkey: [u8; 32],
+    protected_contact_cap: usize,
+) -> FavouriteOutcome {
+    // Exclude active sessions (and our own node) from eviction — mirrors the
+    // ContactsFull handler's own exclusion list exactly (never evict someone
+    // mid-conversation).
+    let (active_prefixes, self_prefix) = {
+        let st = state.lock().expect("state mutex poisoned");
+        let active: Vec<[u8; 6]> = st.by_prefix.keys().copied().collect();
+        let sp = st
+            .self_pubkey
+            .map(|pk| pk[..6].try_into().expect("pubkey is 32 bytes"));
+        (active, sp)
+    };
+    let mut exclude = active_prefixes;
+    if let Some(sp) = self_prefix {
+        if !exclude.contains(&sp) {
+            exclude.push(sp);
+        }
+    }
+
+    let outcome = host.advert_bus().mark_favourite_if_eligible(
+        pubkey,
+        is_meshcore_chat_type,
+        protected_contact_cap,
+        &exclude,
+    );
+
+    match outcome {
+        FavouriteOutcome::Protected(snapshot) => {
+            if cmd_tx.try_send(protect_frame_for(&snapshot)).is_ok() {
+                FavouriteOutcome::Protected(snapshot)
+            } else {
+                host.advert_bus()
+                    .revert_protect(&pubkey, snapshot.generation);
+                FavouriteOutcome::NoRecordYet
+            }
+        }
+        FavouriteOutcome::ProtectedWithEviction(snapshot, evicted_pubkey, evicted_record) => {
+            if cmd_tx.try_send(protect_frame_for(&snapshot)).is_ok() {
+                // Best-effort native removal for the evicted contact, off the
+                // hot path — awaiting `admin_remove_meshcore_contact` here
+                // would block this task (command_worker) on a channel
+                // round-trip, exactly what FR-006/Decision 8 forbid. The
+                // send itself is re-validated (TOCTOU re-check) immediately
+                // before it reaches the radio — see the `key_rx` handler.
+                let host = Arc::clone(host);
+                tokio::spawn(async move {
+                    if let Err(e) = host.admin_remove_meshcore_contact(evicted_pubkey).await {
+                        warn!(
+                            evicted_pubkey = ?&evicted_pubkey[..6],
+                            "mesh: failed to remove evicted contact from radio: {e}"
+                        );
+                    }
+                });
+                FavouriteOutcome::ProtectedWithEviction(snapshot, evicted_pubkey, evicted_record)
+            } else {
+                // The new protect's send failed after the eviction already
+                // committed (both happened atomically inside decide_favourite,
+                // Decision 0) — reverting only undoes the new protect, not the
+                // already-applied eviction, so the protected count is
+                // transiently down by one. Accepted, not fixed: this requires
+                // channel saturation and a cap-eviction to coincide (an
+                // already-narrow window intersecting an already-rare one), and
+                // it self-heals on the sender's own retry (pending_protect
+                // keeps them eligible), which by then finds the freed slot
+                // still open with no eviction needed.
+                host.advert_bus()
+                    .revert_protect(&pubkey, snapshot.generation);
+                warn!(
+                    "mesh: evicted a protected contact to make room but the new \
+                     protect's send failed — the freed slot will be reclaimed on retry"
+                );
+                FavouriteOutcome::NoRecordYet
+            }
+        }
+        other => other,
+    }
+}
+
+/// Attempt protection for `pubkey` and update `prefix`'s pending-protect
+/// mark accordingly — shared by `dispatch_message`'s own first attempt and
+/// `handle_frame`'s retry-on-more-data-arrived hooks (research.md
+/// Decision 3): terminal outcomes clear the mark; `NoRecordYet`
+/// unconditionally re-inserts it (round-21 fix — see `try_protect_contact`).
+async fn attempt_protect_and_update_pending(
+    host: &Arc<dyn Host>,
+    cmd_tx: &mpsc::Sender<OutboundFrame>,
+    state: &Arc<Mutex<SessionState>>,
+    prefix: [u8; 6],
+    pubkey: [u8; 32],
+    protected_contact_cap: usize,
+) {
+    let outcome = try_protect_contact(host, cmd_tx, state, pubkey, protected_contact_cap).await;
+    if matches!(outcome, FavouriteOutcome::CapReached) {
+        // FR-015: distinct warning when the cap is reached and nothing was
+        // evictable — an operator needs to know this sender was NOT
+        // protected, unlike every other terminal outcome, which is either
+        // success or a deliberate, silent exclusion (Ineligible).
+        warn!(
+            "mesh: protected-contact cap reached with nothing evictable (all \
+             protected contacts are either in an active session or were \
+             protected too recently) — this sender was not protected"
+        );
+    }
+    let mut st = state.lock().expect("state mutex poisoned");
+    if matches!(outcome, FavouriteOutcome::NoRecordYet) {
+        st.mark_pending_protect(prefix);
+    } else {
+        st.clear_pending_protect(&prefix);
+    }
 }
 
 /// Parse a direct message text, route it through the host, and send the reply.
@@ -1690,7 +1971,31 @@ async fn dispatch_message(
     workflow_timeout_secs: u64,
     send_tracker: &Arc<Mutex<SendTracker>>,
     delivery_stats: &Arc<DeliveryStats>,
+    protected_contact_cap: usize,
 ) {
+    // Persist Mesh Contacts (research.md Decision 3's "Precise ordering
+    // requirement"): this MUST be the literal first statement this function
+    // executes — before get_or_create_session, before anything else. There
+    // is then no gap for a concurrently-resolving frame (on `event_loop`) to
+    // race into: either it finds the mark already set and retries
+    // correctly, or dispatch_message's own protect attempt below runs first
+    // and reaches a terminal outcome, in which case the concurrent retry
+    // (if any) will simply see `AlreadyProtected`/`Ineligible`.
+    //
+    // A third, benign case exists: attempt_protect_and_update_pending decides
+    // the outcome and later writes the pending-protect mark as two separate
+    // lock acquisitions, so a stale `NoRecordYet` write from one task can
+    // land after a concurrent task's terminal-outcome write already cleared
+    // the mark for the same prefix, leaving it spuriously set. This never
+    // undoes an actual protection or sends a duplicate frame — it self-heals
+    // on the next DM (this statement unconditionally re-marks and the
+    // subsequent attempt resolves to `AlreadyProtected`), on the next
+    // advert/contact retry hook, or via the 24h pending-protect TTL sweep.
+    state
+        .lock()
+        .expect("state mutex poisoned")
+        .mark_pending_protect(sender_prefix);
+
     // ── Get or create a session for this node ─────────────────────────────────
     let Some((session, is_new)) = get_or_create_session(sender_prefix, host, state).await else {
         // Session creation failed; the error was already logged inside
@@ -1709,6 +2014,22 @@ async fn dispatch_message(
         .lock()
         .expect("state mutex poisoned")
         .get_full_pubkey(&sender_prefix);
+
+    // ── Attempt contact protection (best-effort, never delays the reply) ─────
+    // If the identity itself isn't resolved yet (`full_pubkey` is `None`),
+    // the pending mark set above simply stays — `handle_frame`'s NewAdvert/
+    // Contact retry hook picks it up once the identity resolves.
+    if let Some(pubkey) = full_pubkey {
+        attempt_protect_and_update_pending(
+            host,
+            cmd_tx,
+            state,
+            sender_prefix,
+            pubkey,
+            protected_contact_cap,
+        )
+        .await;
+    }
 
     // ── Determine if we're awaiting a workflow reply ──────────────────────────
     let awaiting_reply = state
@@ -1931,6 +2252,22 @@ async fn dispatch_message(
                 .lock()
                 .expect("state mutex poisoned")
                 .get_or_insert(sender_prefix, fresh);
+            // Persist Mesh Contacts (research.md Decision 3's round-11 fix):
+            // this fresh SessionEntry starts with full_pubkey = None just
+            // like get_or_create_session's own slow path does — reseed it
+            // from AdvertBus here too, or a sender whose session happens to
+            // go stale (e.g. a BBS restart) loses first-message protection
+            // eligibility on their very next message for no reason AdvertBus
+            // itself would justify (it still has the full record).
+            if let Some(pubkey) = host
+                .advert_bus()
+                .full_pubkey_by_prefix(&sender_prefix, TRANSPORT_NAME)
+            {
+                state
+                    .lock()
+                    .expect("state mutex poisoned")
+                    .set_full_pubkey(&sender_prefix, pubkey);
+            }
             // Track the fresh session so credential operations below use it.
             active_sid = fresh_sid;
             // Attempt auto-login on the refreshed session before replaying the command.
@@ -2152,6 +2489,25 @@ async fn get_or_create_session(
         .lock()
         .expect("state mutex poisoned")
         .get_or_insert(prefix, new_id);
+
+    // Persist Mesh Contacts (research.md Decision 3's round-11 fix): seed
+    // this brand-new session's full pubkey from an already-known AdvertBus
+    // record, if one exists — a node whose full contact record predates its
+    // first-ever DM (the common case on an already-flooding mesh, exactly
+    // issue #185's premise) is otherwise stuck with an unresolved identity
+    // until a second, unrelated frame happens to arrive, blocking
+    // protection on the very first message that should trigger it.
+    if is_new {
+        if let Some(pubkey) = host
+            .advert_bus()
+            .full_pubkey_by_prefix(&prefix, TRANSPORT_NAME)
+        {
+            state
+                .lock()
+                .expect("state mutex poisoned")
+                .set_full_pubkey(&prefix, pubkey);
+        }
+    }
 
     Some((sid, is_new))
 }

--- a/crates/bbs-mesh/src/transport.rs
+++ b/crates/bbs-mesh/src/transport.rs
@@ -904,6 +904,7 @@ async fn event_loop(
         Arc::clone(&host),
         cmd_tx.clone(),
         Arc::clone(&state),
+        Arc::clone(&draining),
         command_prefix,
         welcome_message,
         node_credential_ttl_days,
@@ -1368,7 +1369,36 @@ async fn handle_frame(
         // Sessions are minted on first DM, not on advert.
         InboundFrame::Advert { pubkey } => {
             host.advert_bus().upsert_short(pubkey, TRANSPORT_NAME);
+            let prefix: [u8; 6] = pubkey[..6].try_into().expect("pubkey is 32 bytes");
+            state
+                .lock()
+                .expect("state mutex poisoned")
+                .set_full_pubkey(&prefix, pubkey);
             debug!(prefix = ?&pubkey[..6], "mesh: short advert received");
+
+            // Persist Mesh Contacts / supply-drop-bbs-9vt: a sender who DMs
+            // before ever advertising gets no full_pubkey at session-creation
+            // time (get_or_create_session's seed only runs for a brand-new
+            // session), so dispatch_message's own protect attempt is skipped
+            // entirely — this short advert, arriving after, is often the
+            // FIRST identity data the BBS ever gets for them. Retry now,
+            // mirroring NewAdvert/Contact's identical hook below.
+            let pending = state
+                .lock()
+                .expect("state mutex poisoned")
+                .is_pending_protect(&prefix);
+            if pending {
+                attempt_protect_and_update_pending(
+                    host,
+                    cmd_tx,
+                    state,
+                    draining,
+                    prefix,
+                    pubkey,
+                    protected_contact_cap,
+                )
+                .await;
+            }
         }
         InboundFrame::NewAdvert(contact) => {
             // When the radio echoes our own advert back, its GPS fields reflect
@@ -1416,6 +1446,7 @@ async fn handle_frame(
                     host,
                     cmd_tx,
                     state,
+                    draining,
                     prefix,
                     contact.pubkey,
                     protected_contact_cap,
@@ -1467,6 +1498,7 @@ async fn handle_frame(
                     host,
                     cmd_tx,
                     state,
+                    draining,
                     prefix,
                     contact.pubkey,
                     protected_contact_cap,
@@ -1714,11 +1746,15 @@ async fn handle_frame(
         // lost on a stale multi-hop direct path) is done with `ResetPath`, which
         // needs the full key — but an inbound DM only carries the 6-byte prefix,
         // and `GetContacts` runs once on connect, before first-contact sessions
-        // exist. Without this the full key stays unknown for exactly the far
-        // nodes that need flooding, so `flood_after_send`'s post-reply ResetPath
-        // is silently skipped (`get_full_pubkey` returns None) and every reply
-        // goes direct. `set_full_pubkey` no-ops until a session exists; PathUpdated
-        // arrives after the inbound DM created it, so it lands.
+        // exist. Advert/NewAdvert/Contact frames can also resolve the full key
+        // (see their handlers above), but none of those is guaranteed to arrive
+        // for a given far node — real radio propagation decides that, not this
+        // code — so without ALSO capturing it here, a multi-hop node that never
+        // happens to (re)advertise stays without a full key indefinitely, and
+        // `flood_after_send`'s post-reply ResetPath is silently skipped
+        // (`get_full_pubkey` returns None), leaving every reply direct.
+        // `set_full_pubkey` no-ops until a session exists; PathUpdated typically
+        // arrives after the inbound DM already created one, so it lands.
         InboundFrame::PathUpdated { pubkey } => {
             let prefix: [u8; 6] = pubkey[..6].try_into().expect("pubkey is 32 bytes");
             state
@@ -1729,6 +1765,27 @@ async fn handle_frame(
                 prefix = prefix[0],
                 "mesh: PathUpdated — captured full pubkey (enables flood-after-send for this node)"
             );
+
+            // Persist Mesh Contacts / supply-drop-bbs-9vt: same reachability
+            // gap as the short-advert hook above — PathUpdated can likewise
+            // be the first frame that ever resolves this sender's identity
+            // after a DM whose own protect attempt found no full_pubkey yet.
+            let pending = state
+                .lock()
+                .expect("state mutex poisoned")
+                .is_pending_protect(&prefix);
+            if pending {
+                attempt_protect_and_update_pending(
+                    host,
+                    cmd_tx,
+                    state,
+                    draining,
+                    prefix,
+                    pubkey,
+                    protected_contact_cap,
+                )
+                .await;
+            }
         }
 
         // ── Everything else ───────────────────────────────────────────────────
@@ -1762,6 +1819,7 @@ async fn command_worker(
     host: Arc<dyn Host>,
     cmd_tx: mpsc::Sender<OutboundFrame>,
     state: Arc<Mutex<SessionState>>,
+    draining: Arc<AtomicBool>,
     command_prefix: Option<char>,
     welcome_message: String,
     node_credential_ttl_days: u32,
@@ -1779,6 +1837,7 @@ async fn command_worker(
             &host,
             &cmd_tx,
             &state,
+            &draining,
             command_prefix,
             &welcome_message,
             node_credential_ttl_days,
@@ -1931,6 +1990,7 @@ async fn attempt_protect_and_update_pending(
     host: &Arc<dyn Host>,
     cmd_tx: &mpsc::Sender<OutboundFrame>,
     state: &Arc<Mutex<SessionState>>,
+    draining: &Arc<AtomicBool>,
     prefix: [u8; 6],
     pubkey: [u8; 32],
     protected_contact_cap: usize,
@@ -1950,6 +2010,42 @@ async fn attempt_protect_and_update_pending(
     let mut st = state.lock().expect("state mutex poisoned");
     if matches!(outcome, FavouriteOutcome::NoRecordYet) {
         st.mark_pending_protect(prefix);
+        // The one-time, connect-time GetContacts (see `transport.rs`'s
+        // `event_loop` — its `ClientEvent::Connected` handler) only ever
+        // captures contacts the device already knew about at that exact
+        // moment — a sender who first DMs the BBS afterward is stuck with
+        // `NoRecordYet` forever otherwise, since the device's own later
+        // adverts for an already-known contact are the lightweight,
+        // name/type-less kind (confirmed via live hardware testing,
+        // supply-drop-bbs-9vt). Cooldown-gated and non-blocking (`try_send`,
+        // FR-006) so this never delays the reply this DM is also waiting on.
+        //
+        // Skipped entirely while `draining`: the connect-time GetContacts
+        // above is itself a stateful, single-outstanding-iterator device
+        // command — a second one issued before the first finishes is
+        // rejected (ERR_CODE_BAD_STATE), and that error frame would be
+        // misattributed by the drain-recovery handler below as "the device
+        // doesn't support SyncNextMessage," clearing `draining` early and
+        // silently dropping the rest of the real backlog. The retry hooks on
+        // NewAdvert/Contact/Advert/PathUpdated cover this sender again once
+        // draining clears, so nothing is permanently lost by waiting.
+        if st.should_request_contacts_catchup() && !draining.load(Ordering::Relaxed) {
+            match cmd_tx.try_send(OutboundFrame::GetContacts { since: 0 }) {
+                Ok(()) => {
+                    st.mark_contacts_catchup_requested();
+                    info!(
+                        "mesh: requesting a contact-list catch-up — a sender's full \
+                         record is still missing after their identity resolved"
+                    );
+                }
+                Err(mpsc::error::TrySendError::Full(_)) => {
+                    debug!("mesh: contact-list catch-up request dropped — outbound channel full");
+                }
+                Err(mpsc::error::TrySendError::Closed(_)) => {
+                    debug!("mesh: contact-list catch-up request dropped — outbound channel closed");
+                }
+            }
+        }
     } else {
         st.clear_pending_protect(&prefix);
     }
@@ -1964,6 +2060,7 @@ async fn dispatch_message(
     host: &Arc<dyn Host>,
     cmd_tx: &mpsc::Sender<OutboundFrame>,
     state: &Arc<Mutex<SessionState>>,
+    draining: &Arc<AtomicBool>,
     command_prefix: Option<char>,
     welcome_message: &str,
     node_credential_ttl_days: u32,
@@ -2024,6 +2121,7 @@ async fn dispatch_message(
             host,
             cmd_tx,
             state,
+            draining,
             sender_prefix,
             pubkey,
             protected_contact_cap,

--- a/crates/bbs-mesh/tests/transport.rs
+++ b/crates/bbs-mesh/tests/transport.rs
@@ -2048,11 +2048,8 @@ async fn real_host_retransmitted_login_is_not_reprocessed() {
 /// can.
 async fn drain_command_types(bridge: &mut Bridge, per_read_timeout: Duration) -> Vec<u8> {
     let mut types = Vec::new();
-    loop {
-        match tokio::time::timeout(per_read_timeout, bridge.read_command()).await {
-            Ok(cmd) => types.push(cmd[0]),
-            Err(_) => break,
-        }
+    while let Ok(cmd) = tokio::time::timeout(per_read_timeout, bridge.read_command()).await {
+        types.push(cmd[0]);
     }
     types
 }

--- a/crates/bbs-mesh/tests/transport.rs
+++ b/crates/bbs-mesh/tests/transport.rs
@@ -25,7 +25,7 @@ use bbs_plugin_api::{
     plugin::Plugin,
     testing::MockHost,
     transport::TransportEngine,
-    Command, Response,
+    Command, Host, Response,
 };
 use meshcore_companion::constants::*;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
@@ -127,6 +127,48 @@ fn path_updated_frame(pubkey: [u8; 32]) -> Vec<u8> {
     let mut payload = vec![PUSH_CODE_PATH_UPDATED];
     payload.extend_from_slice(&pubkey);
     radio_frame(&payload)
+}
+
+/// Build a 32-byte pubkey whose first 6 bytes are `prefix` (the wire-level
+/// identity a `ContactMsgRecv` carries) so a seeded advert record and a DM
+/// from the same node resolve to the same identity in tests.
+fn pubkey_for_prefix(prefix: [u8; 6]) -> [u8; 32] {
+    let mut pk = [0xEEu8; 32];
+    pk[..6].copy_from_slice(&prefix);
+    pk
+}
+
+/// PUSH_CODE_NEW_ADVERT: a full 147-byte contact record — see
+/// `meshcore_companion::frame::parse_contact` for the exact layout this
+/// mirrors (pubkey[32] + adv_type[1] + flags[1] + out_path_len[1] +
+/// out_path[64] + name[32] + last_advert_timestamp[4] + gps_lat[4] +
+/// gps_lon[4] + lastmod[4] = 147 bytes).
+fn new_advert_frame(pubkey: [u8; 32], name: &str, adv_type: u8) -> Vec<u8> {
+    let mut body = Vec::with_capacity(147);
+    body.extend_from_slice(&pubkey);
+    body.push(adv_type);
+    body.push(0u8); // flags — not yet favourited
+    body.push(0xFFu8); // out_path_len: unknown
+    body.extend_from_slice(&[0u8; 64]); // out_path
+    let mut name_buf = [0u8; 32];
+    let nb = name.as_bytes();
+    let n = nb.len().min(32);
+    name_buf[..n].copy_from_slice(&nb[..n]);
+    body.extend_from_slice(&name_buf);
+    body.extend_from_slice(&0u32.to_le_bytes()); // last_advert_timestamp
+    body.extend_from_slice(&0i32.to_le_bytes()); // gps_lat
+    body.extend_from_slice(&0i32.to_le_bytes()); // gps_lon
+    body.extend_from_slice(&0u32.to_le_bytes()); // lastmod
+    assert_eq!(body.len(), 147, "Contact body must be exactly 147 bytes");
+
+    let mut payload = vec![PUSH_CODE_NEW_ADVERT];
+    payload.extend_from_slice(&body);
+    radio_frame(&payload)
+}
+
+/// PUSH_CODE_CONTACTS_FULL: the radio's contact table is at capacity.
+fn contacts_full_frame() -> Vec<u8> {
+    radio_frame(&[PUSH_CODE_CONTACTS_FULL])
 }
 
 // ── Test harness ──────────────────────────────────────────────────────────────
@@ -1984,6 +2026,261 @@ async fn real_host_retransmitted_login_is_not_reprocessed() {
             "retransmitted login was reprocessed by the host: {t:?}"
         );
     }
+
+    transport.stop().await.unwrap();
+}
+
+// ── Persist Mesh Contacts (User Story 1: MeshCore) ──────────────────────────
+
+/// Read command-frame type bytes until `per_read_timeout` elapses with
+/// nothing new arriving. Used to assert a command was NOT sent — reading a
+/// single frame with a timeout can't distinguish "never coming" from "not
+/// here yet"; draining for a bounded window and checking the collected set
+/// can.
+async fn drain_command_types(bridge: &mut Bridge, per_read_timeout: Duration) -> Vec<u8> {
+    let mut types = Vec::new();
+    loop {
+        match tokio::time::timeout(per_read_timeout, bridge.read_command()).await {
+            Ok(cmd) => types.push(cmd[0]),
+            Err(_) => break,
+        }
+    }
+    types
+}
+
+/// User Story 1, Acceptance Scenario 1: a node whose full contact record is
+/// already cached (e.g. from an earlier advert) gets protected on its first
+/// DM — `AddUpdateContact` with the protect bit set, addressed to the
+/// sender's own pubkey.
+#[tokio::test]
+async fn protects_contact_on_first_dm_from_cache() {
+    let host = Arc::new(MockHost::new());
+    host.set_default_response(Response::Text("hi".to_owned()));
+    let (transport, mut bridge) = make_transport(Arc::clone(&host), None).await;
+    bridge.complete_handshake("TestNode").await;
+
+    let sender = [0x21u8, 0x22, 0x23, 0x24, 0x25, 0x26];
+    let pubkey = pubkey_for_prefix(sender);
+    host.advert_bus().upsert_contact(
+        pubkey,
+        "Alice".into(),
+        ADV_TYPE_CHAT,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        Vec::new(),
+        -1,
+        "meshcore",
+    );
+
+    bridge.send(&contact_msg_frame(sender, "help")).await;
+
+    let add_update = tokio::time::timeout(
+        Duration::from_secs(2),
+        bridge.read_until_cmd(CMD_ADD_UPDATE_CONTACT),
+    )
+    .await
+    .expect("expected AddUpdateContact on first DM from a cached, eligible contact");
+    assert_eq!(
+        &add_update[1..33],
+        &pubkey[..],
+        "AddUpdateContact must address the sender's own pubkey"
+    );
+    assert_eq!(add_update[34] & 1, 1, "protect bit must be set");
+    assert!(
+        host.advert_bus().is_currently_favourited(&pubkey),
+        "AdvertBus must reflect the protection locally"
+    );
+
+    transport.stop().await.unwrap();
+}
+
+/// User Story 1, Acceptance Scenario 3: a second DM from an already-protected
+/// sender must not trigger a redundant `AddUpdateContact`.
+#[tokio::test]
+async fn does_not_reprotect_already_favourited_contact() {
+    let host = Arc::new(MockHost::new());
+    host.set_default_response(Response::Text("hi".to_owned()));
+    let (transport, mut bridge) = make_transport(Arc::clone(&host), None).await;
+    bridge.complete_handshake("TestNode").await;
+
+    let sender = [0x31u8, 0x32, 0x33, 0x34, 0x35, 0x36];
+    let pubkey = pubkey_for_prefix(sender);
+    host.advert_bus().upsert_contact(
+        pubkey,
+        "Bob".into(),
+        ADV_TYPE_CHAT,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        Vec::new(),
+        -1,
+        "meshcore",
+    );
+
+    bridge.send(&contact_msg_frame(sender, "help")).await;
+    tokio::time::timeout(
+        Duration::from_secs(2),
+        bridge.read_until_cmd(CMD_ADD_UPDATE_CONTACT),
+    )
+    .await
+    .expect("expected the first DM to protect the contact");
+
+    bridge.send(&contact_msg_frame(sender, "help")).await;
+    let types = drain_command_types(&mut bridge, Duration::from_millis(500)).await;
+    assert!(
+        !types.contains(&CMD_ADD_UPDATE_CONTACT),
+        "an already-protected contact must not be re-protected on a second DM; saw: {types:?}"
+    );
+
+    transport.stop().await.unwrap();
+}
+
+/// FR-004: if the BBS doesn't yet know a sender's full contact record at the
+/// moment of their first DM, protection must apply retroactively once that
+/// record becomes available — not be silently skipped forever.
+#[tokio::test]
+async fn protection_deferred_until_full_contact_data_cached() {
+    let host = Arc::new(MockHost::new());
+    host.set_default_response(Response::Text("hi".to_owned()));
+    let (transport, mut bridge) = make_transport(Arc::clone(&host), None).await;
+    bridge.complete_handshake("TestNode").await;
+
+    let sender = [0x41u8, 0x42, 0x43, 0x44, 0x45, 0x46];
+    let pubkey = pubkey_for_prefix(sender);
+
+    // The DM arrives with no cached advert data at all yet.
+    bridge.send(&contact_msg_frame(sender, "help")).await;
+    let types = drain_command_types(&mut bridge, Duration::from_millis(500)).await;
+    assert!(
+        !types.contains(&CMD_ADD_UPDATE_CONTACT),
+        "must not protect before the full contact record is known; saw: {types:?}"
+    );
+
+    // The node's own advert now arrives, supplying the missing data.
+    bridge
+        .send(&new_advert_frame(pubkey, "Carol", ADV_TYPE_CHAT))
+        .await;
+
+    let add_update = tokio::time::timeout(
+        Duration::from_secs(2),
+        bridge.read_until_cmd(CMD_ADD_UPDATE_CONTACT),
+    )
+    .await
+    .expect("expected retroactive protection once the full contact record arrived");
+    assert_eq!(&add_update[1..33], &pubkey[..]);
+
+    transport.stop().await.unwrap();
+}
+
+/// FR-003: a repeater-type node must never be protected through this
+/// mechanism, even if it sends a message-like frame.
+#[tokio::test]
+async fn never_protects_non_chat_contact() {
+    let host = Arc::new(MockHost::new());
+    host.set_default_response(Response::Text("hi".to_owned()));
+    let (transport, mut bridge) = make_transport(Arc::clone(&host), None).await;
+    bridge.complete_handshake("TestNode").await;
+
+    let sender = [0x51u8, 0x52, 0x53, 0x54, 0x55, 0x56];
+    let pubkey = pubkey_for_prefix(sender);
+    host.advert_bus().upsert_contact(
+        pubkey,
+        "Repeater1".into(),
+        ADV_TYPE_REPEATER,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        Vec::new(),
+        -1,
+        "meshcore",
+    );
+
+    bridge.send(&contact_msg_frame(sender, "help")).await;
+    let types = drain_command_types(&mut bridge, Duration::from_millis(500)).await;
+    assert!(
+        !types.contains(&CMD_ADD_UPDATE_CONTACT),
+        "a repeater-type contact must never be protected; saw: {types:?}"
+    );
+    assert!(!host.advert_bus().is_currently_favourited(&pubkey));
+
+    transport.stop().await.unwrap();
+}
+
+/// User Story 1, Acceptance Scenario 2: when the contact table fills up, the
+/// BBS's own `ContactsFull` eviction handler must skip protected contacts
+/// and evict an unprotected one instead.
+#[tokio::test]
+async fn protected_contact_excluded_from_contacts_full_eviction() {
+    let host = Arc::new(MockHost::new());
+    let (transport, mut bridge) = make_transport(Arc::clone(&host), None).await;
+    bridge.complete_handshake("TestNode").await;
+
+    let protected_prefix = [0x61u8, 0x62, 0x63, 0x64, 0x65, 0x66];
+    let protected_pubkey = pubkey_for_prefix(protected_prefix);
+    let stale_prefix = [0x71u8, 0x72, 0x73, 0x74, 0x75, 0x76];
+    let stale_pubkey = pubkey_for_prefix(stale_prefix);
+
+    host.advert_bus().upsert_contact(
+        protected_pubkey,
+        "Protected".into(),
+        ADV_TYPE_CHAT,
+        0,
+        0,
+        1_700_000_000,
+        0,
+        0,
+        0,
+        Vec::new(),
+        -1,
+        "meshcore",
+    );
+    assert!(matches!(
+        host.advert_bus().mark_favourite_if_eligible(
+            protected_pubkey,
+            |t| t == ADV_TYPE_CHAT,
+            350,
+            &[]
+        ),
+        bbs_plugin_api::FavouriteOutcome::Protected(_)
+    ));
+    host.advert_bus().upsert_contact(
+        stale_pubkey,
+        "Stale".into(),
+        ADV_TYPE_CHAT,
+        0,
+        0,
+        1_600_000_000,
+        0,
+        0,
+        0,
+        Vec::new(),
+        -1,
+        "meshcore",
+    );
+
+    bridge.send(&contacts_full_frame()).await;
+
+    let remove = tokio::time::timeout(
+        Duration::from_secs(2),
+        bridge.read_until_cmd(CMD_REMOVE_CONTACT),
+    )
+    .await
+    .expect("expected a RemoveContact for the stale, unprotected contact");
+    assert_eq!(
+        &remove[1..33],
+        &stale_pubkey[..],
+        "must evict the stale, unprotected contact, never the protected one"
+    );
 
     transport.stop().await.unwrap();
 }

--- a/crates/bbs-mesh/tests/transport.rs
+++ b/crates/bbs-mesh/tests/transport.rs
@@ -25,7 +25,7 @@ use bbs_plugin_api::{
     plugin::Plugin,
     testing::MockHost,
     transport::TransportEngine,
-    Command, Host, Response,
+    Command, Host, MeshKeyRequest, Response,
 };
 use meshcore_companion::constants::*;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
@@ -2142,6 +2142,110 @@ async fn does_not_reprotect_already_favourited_contact() {
     transport.stop().await.unwrap();
 }
 
+/// T048b: `key_rx`'s `RemoveContact` handler re-checks `is_currently_favourited`
+/// immediately before sending the wire removal, protecting a contact that
+/// was re-protected after a delete-triggered removal was requested but
+/// before that request was actually processed (Decision 12c). Unlike the
+/// analogous Meshtastic regression test (where `key_rx` and message
+/// dispatch genuinely do share one task), MeshCore's `key_rx` is owned
+/// solely by `event_loop`, while a DM's own protect decision runs on the
+/// separate `command_worker` task (see the production `RemoveContact` arm's
+/// own comment: the re-check exists specifically because of "a concurrent
+/// re-DM on command_worker") — a real cross-task race is architecturally
+/// possible here. This test does not attempt to force that race
+/// deterministically (real inter-task timing, not something a test should
+/// depend on); instead it drives the re-protecting DM to full completion
+/// (confirmed via the wire) before ever sending the stale removal request,
+/// proving the guard is correct against pre-processing settled state — a
+/// real but narrower property than a genuine interleaving would prove.
+#[tokio::test]
+async fn stale_removal_via_key_rx_is_skipped_when_a_fresher_protect_landed() {
+    let host = Arc::new(MockHost::new());
+    host.set_default_response(Response::Text("hi".to_owned()));
+    let (transport, mut bridge) = make_transport(Arc::clone(&host), None).await;
+    bridge.complete_handshake("TestNode").await;
+
+    let sender = [0x81u8, 0x82, 0x83, 0x84, 0x85, 0x86];
+    let pubkey = pubkey_for_prefix(sender);
+    host.advert_bus().upsert_contact(
+        pubkey,
+        "Dave".into(),
+        ADV_TYPE_CHAT,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        Vec::new(),
+        -1,
+        "meshcore",
+    );
+
+    // First DM protects it.
+    bridge.send(&contact_msg_frame(sender, "help")).await;
+    tokio::time::timeout(
+        Duration::from_secs(2),
+        bridge.read_until_cmd(CMD_ADD_UPDATE_CONTACT),
+    )
+    .await
+    .expect("expected the first DM to protect the contact");
+    assert!(host.advert_bus().is_currently_favourited(&pubkey));
+
+    // Simulate the delete flow's own first step — bbs-web's
+    // api_delete_contact calls AdvertBus::unprotect locally before
+    // best-effort asking the radio to remove the contact.
+    host.advert_bus().unprotect(&pubkey);
+    assert!(!host.advert_bus().is_currently_favourited(&pubkey));
+
+    // Before the (not-yet-sent) native removal request is processed, the
+    // same identity DMs the BBS again — a fresh, valid re-protect.
+    bridge.send(&contact_msg_frame(sender, "help again")).await;
+    tokio::time::timeout(
+        Duration::from_secs(2),
+        bridge.read_until_cmd(CMD_ADD_UPDATE_CONTACT),
+    )
+    .await
+    .expect("expected the second DM to re-protect the contact");
+    assert!(host.advert_bus().is_currently_favourited(&pubkey));
+
+    // Only now send the stale removal request through key_rx — the same
+    // channel `admin_remove_meshcore_contact` sends through in production.
+    // (This mock's own override of that method short-circuits and never
+    // touches key_rx, so the request is sent directly here to actually
+    // exercise transport.rs's TOCTOU re-check rather than bypassing it.)
+    let key_tx = host
+        .mesh_key_tx()
+        .expect("MeshTransport::start must have registered its key_tx by now");
+    let (reply_tx, reply_rx) = tokio::sync::oneshot::channel();
+    key_tx
+        .send(MeshKeyRequest::RemoveContact {
+            pubkey,
+            reply: reply_tx,
+        })
+        .await
+        .expect("transport's key_rx must still be alive");
+    tokio::time::timeout(Duration::from_secs(2), reply_rx)
+        .await
+        .expect("transport must reply to the RemoveContact request within 2s")
+        .expect("reply sender must not be dropped without a value")
+        .expect("a skipped removal is still Ok(()), not an error");
+
+    // The re-check must have declined to send the removal, and the contact
+    // must remain protected.
+    let types = drain_command_types(&mut bridge, Duration::from_millis(500)).await;
+    assert!(
+        !types.contains(&CMD_REMOVE_CONTACT),
+        "a stale removal must not undo a fresher protect; saw: {types:?}"
+    );
+    assert!(
+        host.advert_bus().is_currently_favourited(&pubkey),
+        "contact must remain protected after the stale removal was correctly declined"
+    );
+
+    transport.stop().await.unwrap();
+}
+
 /// FR-004: if the BBS doesn't yet know a sender's full contact record at the
 /// moment of their first DM, protection must apply retroactively once that
 /// record becomes available — not be silently skipped forever.
@@ -2175,6 +2279,207 @@ async fn protection_deferred_until_full_contact_data_cached() {
     .await
     .expect("expected retroactive protection once the full contact record arrived");
     assert_eq!(&add_update[1..33], &pubkey[..]);
+
+    transport.stop().await.unwrap();
+}
+
+/// T012a (round-14 regression): a resync frame reporting the pre-protect
+/// (unfavourited) state, arriving within `PROTECT_GRACE_SECS` of a protect,
+/// must not clear the cached protected flag — and a subsequent DM from the
+/// same sender must not trigger a redundant `AddUpdateContact` (Decision
+/// 7a's round-14 correction: the write-layer fix, T004, is symmetric with
+/// the read-side one, not narrowed back to a read-only patch).
+#[tokio::test]
+async fn stale_resync_within_grace_window_does_not_clear_protection() {
+    let host = Arc::new(MockHost::new());
+    host.set_default_response(Response::Text("hi".to_owned()));
+    let (transport, mut bridge) = make_transport(Arc::clone(&host), None).await;
+    bridge.complete_handshake("TestNode").await;
+
+    let sender = [0x91u8, 0x92, 0x93, 0x94, 0x95, 0x96];
+    let pubkey = pubkey_for_prefix(sender);
+    host.advert_bus().upsert_contact(
+        pubkey,
+        "Eve".into(),
+        ADV_TYPE_CHAT,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        Vec::new(),
+        -1,
+        "meshcore",
+    );
+
+    bridge.send(&contact_msg_frame(sender, "help")).await;
+    tokio::time::timeout(
+        Duration::from_secs(2),
+        bridge.read_until_cmd(CMD_ADD_UPDATE_CONTACT),
+    )
+    .await
+    .expect("expected the DM to protect the contact");
+    assert!(host.advert_bus().is_currently_favourited(&pubkey));
+
+    // A resync frame lands within the grace window, reporting the
+    // pre-protect (unfavourited) state — e.g. a device sync that started
+    // before the protect committed.
+    bridge
+        .send(&new_advert_frame(pubkey, "Eve", ADV_TYPE_CHAT))
+        .await;
+    tokio::time::sleep(Duration::from_millis(200)).await;
+
+    assert!(
+        host.advert_bus().is_currently_favourited(&pubkey),
+        "a stale resync within the grace window must not clear an already-protected flag"
+    );
+
+    // A subsequent DM from the same sender must not trigger a second protect.
+    bridge.send(&contact_msg_frame(sender, "help again")).await;
+    let types = drain_command_types(&mut bridge, Duration::from_millis(500)).await;
+    assert!(
+        !types.contains(&CMD_ADD_UPDATE_CONTACT),
+        "must not re-send AddUpdateContact for an already-protected contact; saw: {types:?}"
+    );
+
+    transport.stop().await.unwrap();
+}
+
+/// T012b (round-17 regression, the grace-window overlap case): delete a
+/// protected contact, then have the same identity DM again within
+/// `PROTECT_GRACE_SECS` — both the delete's `unprotected_at` and the
+/// re-DM's `protected_at` are now simultaneously "live" grace-window
+/// timestamps — then a resync frame reports the pre-write unfavourited
+/// state. Confirms the contact stays protected rather than being silently
+/// reverted by an order-dependent merge bug (Decision 7a's round-17
+/// correction; neither T012a alone, protect-then-stale-sync with no prior
+/// delete, nor T048a, delete-then-stale-sync with no subsequent re-protect,
+/// exercises this specific overlap where both grace windows are live at once).
+#[tokio::test]
+async fn resync_during_delete_then_reprotect_overlap_does_not_revert_protection() {
+    let host = Arc::new(MockHost::new());
+    host.set_default_response(Response::Text("hi".to_owned()));
+    let (transport, mut bridge) = make_transport(Arc::clone(&host), None).await;
+    bridge.complete_handshake("TestNode").await;
+
+    let sender = [0xA1u8, 0xA2, 0xA3, 0xA4, 0xA5, 0xA6];
+    let pubkey = pubkey_for_prefix(sender);
+    host.advert_bus().upsert_contact(
+        pubkey,
+        "Frank".into(),
+        ADV_TYPE_CHAT,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        Vec::new(),
+        -1,
+        "meshcore",
+    );
+
+    // Protect it (T1 window opens).
+    bridge.send(&contact_msg_frame(sender, "help")).await;
+    tokio::time::timeout(
+        Duration::from_secs(2),
+        bridge.read_until_cmd(CMD_ADD_UPDATE_CONTACT),
+    )
+    .await
+    .expect("expected the first DM to protect the contact");
+
+    // Delete it — unprotected_at = T1.
+    host.advert_bus().unprotect(&pubkey);
+    assert!(!host.advert_bus().is_currently_favourited(&pubkey));
+
+    // The same identity DMs again within the grace window — protected_at =
+    // T2 > T1; both timestamps are now simultaneously "live".
+    bridge.send(&contact_msg_frame(sender, "help again")).await;
+    tokio::time::timeout(
+        Duration::from_secs(2),
+        bridge.read_until_cmd(CMD_ADD_UPDATE_CONTACT),
+    )
+    .await
+    .expect("expected the second DM to re-protect the contact");
+    assert!(host.advert_bus().is_currently_favourited(&pubkey));
+
+    // A resync frame now reports the pre-write (unfavourited) state — the
+    // device's own report predates both the delete and the re-protect.
+    bridge
+        .send(&new_advert_frame(pubkey, "Frank", ADV_TYPE_CHAT))
+        .await;
+    tokio::time::sleep(Duration::from_millis(200)).await;
+
+    assert!(
+        host.advert_bus().is_currently_favourited(&pubkey),
+        "the overlap between a live unprotected_at (T1) and a live protected_at (T2) \
+         must resolve to protected — the resync must not silently revert it"
+    );
+
+    // A follow-up assertion that doesn't depend on the sleep's timing being
+    // exactly right: if the resync HAD silently reverted protection, a
+    // third DM from the same sender would show up as a fresh
+    // CMD_ADD_UPDATE_CONTACT (re-protecting from scratch) rather than being
+    // recognized as already-protected.
+    bridge
+        .send(&contact_msg_frame(sender, "help a third time"))
+        .await;
+    let types = drain_command_types(&mut bridge, Duration::from_millis(500)).await;
+    assert!(
+        !types.contains(&CMD_ADD_UPDATE_CONTACT),
+        "must not re-protect a contact the resync should have left already-protected; saw: {types:?}"
+    );
+
+    transport.stop().await.unwrap();
+}
+
+/// T017 (FR-009): when the radio table is full and every remaining contact
+/// is already favourited (nothing this BBS can safely evict), the BBS must
+/// not send a removal for any of them — the distinct `all_remaining_favourited`
+/// warning path exists precisely so an operator can distinguish "no
+/// evictable candidate" from "every remaining contact is protected". This
+/// asserts the observable behavior a caller can actually depend on (no
+/// removal is ever sent); distinguishing *which* of the two `warn!`
+/// branches fired at the log-message level would need a tracing capture
+/// layer, which nothing in this test suite has — the only existing capture
+/// layer in the codebase (`bbs-web`'s `LogBuffer`) is production admin-UI
+/// code, not test infrastructure, and wiring it in as a dependency here
+/// would be a backwards (bbs-mesh depending on bbs-web) layering violation.
+#[tokio::test]
+async fn contacts_full_with_all_favourited_sends_no_removal() {
+    let host = Arc::new(MockHost::new());
+    let (transport, mut bridge) = make_transport(Arc::clone(&host), None).await;
+    bridge.complete_handshake("TestNode").await;
+
+    let sender = [0xB1u8, 0xB2, 0xB3, 0xB4, 0xB5, 0xB6];
+    let pubkey = pubkey_for_prefix(sender);
+    host.advert_bus().upsert_contact(
+        pubkey,
+        "Grace".into(),
+        ADV_TYPE_CHAT,
+        0,
+        0,
+        1_700_000_000,
+        0,
+        0,
+        0,
+        Vec::new(),
+        -1,
+        "meshcore",
+    );
+    assert!(matches!(
+        host.advert_bus()
+            .mark_favourite_if_eligible(pubkey, |t| t == ADV_TYPE_CHAT, 350, &[]),
+        bbs_plugin_api::FavouriteOutcome::Protected(_)
+    ));
+
+    bridge.send(&contacts_full_frame()).await;
+    let types = drain_command_types(&mut bridge, Duration::from_millis(500)).await;
+    assert!(
+        !types.contains(&CMD_REMOVE_CONTACT),
+        "must never remove a favourited-only contact set; saw: {types:?}"
+    );
 
     transport.stop().await.unwrap();
 }

--- a/crates/bbs-mesh/tests/transport.rs
+++ b/crates/bbs-mesh/tests/transport.rs
@@ -129,6 +129,15 @@ fn path_updated_frame(pubkey: [u8; 32]) -> Vec<u8> {
     radio_frame(&payload)
 }
 
+/// PUSH_CODE_ADVERT: the lightweight, pubkey-only advert a device sends for
+/// an already-known contact (as opposed to `PUSH_CODE_NEW_ADVERT`'s full
+/// 147-byte record) — see `meshcore_companion::frame::decode`'s `PUSH_CODE_ADVERT` arm.
+fn short_advert_frame(pubkey: [u8; 32]) -> Vec<u8> {
+    let mut payload = vec![PUSH_CODE_ADVERT];
+    payload.extend_from_slice(&pubkey);
+    radio_frame(&payload)
+}
+
 /// Build a 32-byte pubkey whose first 6 bytes are `prefix` (the wire-level
 /// identity a `ContactMsgRecv` carries) so a seeded advert record and a DM
 /// from the same node resolve to the same identity in tests.
@@ -2279,6 +2288,90 @@ async fn protection_deferred_until_full_contact_data_cached() {
     .await
     .expect("expected retroactive protection once the full contact record arrived");
     assert_eq!(&add_update[1..33], &pubkey[..]);
+
+    transport.stop().await.unwrap();
+}
+
+/// supply-drop-bbs-9vt: the real-world failure sequence is a DM arriving
+/// *before* the BBS has ever heard anything about the sender — so
+/// `get_or_create_session`'s seed-from-AdvertBus never finds a record, and
+/// `dispatch_message`'s own protect attempt is skipped entirely (no
+/// `full_pubkey` to work with). A short advert arriving afterward is often
+/// the first identity data the BBS ever gets for that sender; it must retry
+/// the pending protect (mirroring `NewAdvert`/`Contact`'s hook), which then
+/// finds only a short (`has_full_record: false`) record and hits
+/// `NoRecordYet` — which must in turn trigger a catch-up `GetContacts`,
+/// since the one-time connect-time `GetContacts` (drained by
+/// `complete_handshake` below) already ran before this sender existed.
+#[tokio::test]
+async fn short_advert_after_unresolved_dm_retries_and_triggers_contacts_catchup() {
+    let host = Arc::new(MockHost::new());
+    host.set_default_response(Response::Text("hi".to_owned()));
+    let (transport, mut bridge) = make_transport(Arc::clone(&host), None).await;
+    bridge.complete_handshake("TestNode").await;
+
+    let sender = [0x51u8, 0x52, 0x53, 0x54, 0x55, 0x56];
+    let pubkey = pubkey_for_prefix(sender);
+
+    // The DM arrives with no cached advert data and no resolved identity —
+    // dispatch_message's own protect attempt is skipped, but the pending
+    // mark is still set unconditionally.
+    bridge.send(&contact_msg_frame(sender, "help")).await;
+    let types = drain_command_types(&mut bridge, Duration::from_millis(300)).await;
+    assert!(
+        !types.contains(&CMD_ADD_UPDATE_CONTACT) && !types.contains(&CMD_GET_CONTACTS),
+        "no protect attempt should have run yet — identity is still unresolved; saw: {types:?}"
+    );
+
+    // A short (pubkey-only) advert now resolves the sender's identity —
+    // this must retry the pending protect and, finding only a short record,
+    // request a contacts catch-up.
+    bridge.send(&short_advert_frame(pubkey)).await;
+
+    tokio::time::timeout(
+        Duration::from_secs(2),
+        bridge.read_until_cmd(CMD_GET_CONTACTS),
+    )
+    .await
+    .expect(
+        "expected a catch-up GetContacts request once the short advert \
+             resolved this sender's identity but not their full record",
+    );
+
+    transport.stop().await.unwrap();
+}
+
+/// The catch-up trigger is a single, connection-wide cooldown (matching
+/// `MIN_ADVERT_SPACING`'s scale) — it must not fire again for a second
+/// sender whose identity resolves (via a short advert) moments later.
+#[tokio::test]
+async fn contacts_catchup_request_is_cooldown_gated_across_senders() {
+    let host = Arc::new(MockHost::new());
+    host.set_default_response(Response::Text("hi".to_owned()));
+    let (transport, mut bridge) = make_transport(Arc::clone(&host), None).await;
+    bridge.complete_handshake("TestNode").await;
+
+    let first_sender = [0x61u8, 0x62, 0x63, 0x64, 0x65, 0x66];
+    let first_pubkey = pubkey_for_prefix(first_sender);
+    bridge.send(&contact_msg_frame(first_sender, "help")).await;
+    bridge.send(&short_advert_frame(first_pubkey)).await;
+    tokio::time::timeout(
+        Duration::from_secs(2),
+        bridge.read_until_cmd(CMD_GET_CONTACTS),
+    )
+    .await
+    .expect("expected the first resolved sender to trigger a catch-up request");
+
+    let second_sender = [0x71u8, 0x72, 0x73, 0x74, 0x75, 0x76];
+    let second_pubkey = pubkey_for_prefix(second_sender);
+    bridge.send(&contact_msg_frame(second_sender, "help")).await;
+    bridge.send(&short_advert_frame(second_pubkey)).await;
+    let types = drain_command_types(&mut bridge, Duration::from_millis(500)).await;
+    assert!(
+        !types.contains(&CMD_GET_CONTACTS),
+        "a second sender resolved within the cooldown window must not trigger \
+         another catch-up request; saw: {types:?}"
+    );
 
     transport.stop().await.unwrap();
 }

--- a/crates/bbs-meshtastic/Cargo.toml
+++ b/crates/bbs-meshtastic/Cargo.toml
@@ -19,7 +19,8 @@ tokio-serial   = { workspace = true }
 tracing        = { workspace = true }
 
 [dev-dependencies]
-toml = { workspace = true }
+toml  = { workspace = true }
+tokio = { workspace = true, features = ["test-util"] }
 
 [lints]
 workspace = true

--- a/crates/bbs-meshtastic/src/lib.rs
+++ b/crates/bbs-meshtastic/src/lib.rs
@@ -13,7 +13,7 @@ use std::{
         atomic::{AtomicU32, Ordering},
         Arc, Mutex,
     },
-    time::Duration,
+    time::{Duration, Instant},
 };
 
 use async_trait::async_trait;
@@ -22,7 +22,7 @@ use bbs_plugin_api::{
     event::{DomainEvent, Notification, NotifyOutcome},
     identity::SessionId,
     transport::TransportEngine,
-    Host, PermissionLevel, Plugin, Response,
+    FavouriteOutcome, Host, PermissionLevel, Plugin, Response,
 };
 use prost::Message as _;
 use serde::{Deserialize, Serialize};
@@ -35,11 +35,12 @@ use crate::{
     command::{format_response, parse_command, render_notification, truncate_utf8},
     proto::{
         admin_get_lora_config, admin_get_owner, admin_get_security_config, admin_get_session_key,
-        admin_message, admin_reboot, admin_remove_fixed_position, admin_set_device_config,
-        admin_set_fixed_position, admin_set_lora_config, admin_set_owner, admin_set_time,
-        direct_text_packet, from_radio, mesh_packet, mt_config, synthetic_pubkey, AdminMessage,
-        Data, LoRaConfig, MeshPacket, MtConfig, NodeInfo, User, BROADCAST_ADDR, PORT_ADMIN_APP,
-        PORT_NODEINFO_APP, PORT_TEXT_MESSAGE_APP,
+        admin_message, admin_reboot, admin_remove_favorite_node, admin_remove_fixed_position,
+        admin_set_device_config, admin_set_favorite_node, admin_set_fixed_position,
+        admin_set_lora_config, admin_set_owner, admin_set_time, direct_text_packet, from_radio,
+        mesh_packet, mt_config, synthetic_pubkey, AdminMessage, Data, LoRaConfig, MeshPacket,
+        MtConfig, NodeInfo, User, BROADCAST_ADDR, PORT_ADMIN_APP, PORT_NODEINFO_APP,
+        PORT_TEXT_MESSAGE_APP,
     },
     session::SessionState,
     stream::{ClientEvent, MeshtasticClient, SerialConfig, TcpConfig},
@@ -197,6 +198,25 @@ pub struct MeshtasticConfig {
     /// Applied to the device automatically when the BBS connects.
     #[serde(default)]
     pub long_name: Option<String>,
+
+    /// Maximum number of nodes that may be protected (favorited) at once —
+    /// see the "Persist Mesh Contacts" feature
+    /// (`specs/001-persist-mesh-contacts/research.md` Decision 5b).
+    ///
+    /// Once this many nodes are protected, a newly-eligible sender's first
+    /// DM evicts the oldest-protected, currently session-inactive node to
+    /// make room, rather than growing the protected set further. Set this
+    /// to your device's real `MAX_NUM_NODES` (firmware/hardware-dependent —
+    /// check your device). Defaults to `100`. `0` disables protection
+    /// entirely on this transport (no new node is ever protected).
+    ///
+    /// Enforced in `try_protect_node`'s call to
+    /// `AdvertBus::mark_favourite_if_eligible_by_node_num`. (MeshCore's
+    /// equivalent default is `350`, not `100` — the two are intentionally
+    /// different, not drifted; real device capacity varies by transport and
+    /// hardware.)
+    #[serde(default = "default_protected_contact_cap")]
+    pub protected_contact_cap: usize,
 }
 
 impl Default for MeshtasticConfig {
@@ -218,6 +238,7 @@ impl Default for MeshtasticConfig {
             radio: None,
             short_name: None,
             long_name: None,
+            protected_contact_cap: default_protected_contact_cap(),
         }
     }
 }
@@ -273,6 +294,9 @@ fn default_reconnect_delay_initial_ms() -> u64 {
 fn default_reconnect_delay_max_ms() -> u64 {
     60_000
 }
+fn default_protected_contact_cap() -> usize {
+    100
+}
 
 // ── Transport ─────────────────────────────────────────────────────────────────
 
@@ -290,6 +314,9 @@ pub struct MeshtasticTransport {
     hop_limit: u32,
     want_ack: bool,
     packet_counter: Arc<AtomicU32>,
+    /// Maximum simultaneously-protected contacts on this transport (Persist
+    /// Mesh Contacts feature) — see `MeshtasticConfig::protected_contact_cap`.
+    protected_contact_cap: usize,
     /// Admin channel sender — stored so `start()` can register it with the host.
     admin_tx: mpsc::Sender<MeshtasticAdminRequest>,
     /// Admin channel receiver — taken by `start()` into the event loop.
@@ -363,6 +390,7 @@ impl Plugin for MeshtasticTransport {
             hop_limit: config.hop_limit,
             want_ack: config.want_ack,
             packet_counter: Arc::new(AtomicU32::new(1)),
+            protected_contact_cap: config.protected_contact_cap,
             admin_tx,
             admin_rx: Mutex::new(Some(admin_rx)),
             radio_config: config.radio,
@@ -405,6 +433,7 @@ impl Plugin for MeshtasticTransport {
         let hop_limit = self.hop_limit;
         let want_ack = self.want_ack;
         let packet_counter = Arc::clone(&self.packet_counter);
+        let protected_contact_cap = self.protected_contact_cap;
         let auto_apply = AutoApplyConfig {
             radio: self.radio_config.clone(),
             short_name: self.short_name.clone(),
@@ -424,6 +453,7 @@ impl Plugin for MeshtasticTransport {
             hop_limit,
             want_ack,
             packet_counter,
+            protected_contact_cap,
             admin_rx,
             auto_apply,
         ));
@@ -595,6 +625,41 @@ enum DeferredWrite {
     SetFixedPosition { lat: f64, lon: f64 },
     /// Clear any fixed GPS position. No reply, no reboot.
     RemoveFixedPosition,
+    /// Favorite a node — the native protect half of the "Persist Mesh
+    /// Contacts" feature. No reply-bearing wire response. Unlike
+    /// `SetOwner`/`SetConfig`/`Reboot`, nothing in the vendored
+    /// `admin.proto` or this codebase's own testing asserts whether this
+    /// command reboots the device — treated as reply-less rather than as
+    /// verified reboot-free (audit finding, needs citation).
+    /// `expected_generation` (from `FavouriteSnapshot.generation`) guards
+    /// `flush_deferred_writes`'s and the disconnect handler's own
+    /// revert-on-failure calls against clobbering a different, later protect
+    /// on the same `node_num` (specs/001-persist-mesh-contacts/research.md
+    /// Decision 8d).
+    SetFavoriteNode {
+        node_num: u32,
+        expected_generation: u64,
+    },
+    /// Un-favorite a node — the native removal half of the "Persist Mesh
+    /// Contacts" delete/eviction flow. No reply-bearing wire response, no
+    /// reboot, and deliberately no `expected_generation`-style revert-on-
+    /// failure field (unlike `SetFavoriteNode`), matching the delete
+    /// direction's existing best-effort framing (specs/001-persist-mesh-
+    /// contacts/research.md Decision 12, Decision 8c's "Scope note").
+    /// **Not consequence-free**: if this write is lost (channel full, or
+    /// the connection drops before it flushes) *and* the device's own
+    /// periodic sync still reports the node as favorited when the next
+    /// full sync arrives, `AdvertBus`'s grace-window merge
+    /// (`PROTECT_GRACE_SECS`, `merge_protected_bit`) will re-adopt that
+    /// reported state once the caller's `unprotect()` grace window has
+    /// elapsed — silently reversing the local unprotect. This is the same,
+    /// disclosed, time-bounded tradeoff Decision 12a already accepts for
+    /// the identical reason on the protect side (a permanent latch would
+    /// block legitimate external re-favoriting); it is not "no
+    /// consequence," just a bounded and already-tested one (see
+    /// `lost_removal_write_lets_stale_favorited_resync_re_adopt_after_grace_window`
+    /// in `crates/bbs-plugin-api/src/advert.rs`).
+    RemoveFavoriteNode { node_num: u32 },
 }
 
 /// Extract the `session_passkey` (AdminMessage field 101) from an inbound admin
@@ -616,11 +681,14 @@ fn harvest_session_passkey(msg: &proto::FromRadio) -> Option<Vec<u8>> {
 }
 
 /// Send all deferred writes now that a session passkey is available.
+#[allow(clippy::too_many_arguments)]
 async fn flush_deferred_writes(
     cmd_tx: &mpsc::Sender<proto::ToRadio>,
     node: u32,
     passkey: &[u8],
     deferred: &mut Vec<DeferredWrite>,
+    host: &Arc<dyn Host>,
+    state: &Arc<Mutex<SessionState>>,
 ) {
     for w in deferred.drain(..) {
         let rid = random_packet_id();
@@ -659,8 +727,7 @@ async fn flush_deferred_writes(
             }
             DeferredWrite::Device { device } => {
                 if cmd_tx
-                    .send(admin_set_device_config(node, rid, device, passkey.to_vec()))
-                    .await
+                    .try_send(admin_set_device_config(node, rid, device, passkey.to_vec()))
                     .is_ok()
                 {
                     info!("meshtastic: applied device config (node_info_broadcast_secs) to device");
@@ -685,8 +752,7 @@ async fn flush_deferred_writes(
             DeferredWrite::Time => {
                 let secs = unix_now_secs();
                 if cmd_tx
-                    .send(admin_set_time(node, rid, secs, passkey.to_vec()))
-                    .await
+                    .try_send(admin_set_time(node, rid, secs, passkey.to_vec()))
                     .is_ok()
                 {
                     info!(unix_secs = secs, "meshtastic: synced device time");
@@ -694,14 +760,13 @@ async fn flush_deferred_writes(
             }
             DeferredWrite::SetFixedPosition { lat, lon } => {
                 if cmd_tx
-                    .send(admin_set_fixed_position(
+                    .try_send(admin_set_fixed_position(
                         node,
                         rid,
                         lat,
                         lon,
                         passkey.to_vec(),
                     ))
-                    .await
                     .is_ok()
                 {
                     info!(lat, lon, "meshtastic: set fixed position on device");
@@ -709,13 +774,140 @@ async fn flush_deferred_writes(
             }
             DeferredWrite::RemoveFixedPosition => {
                 if cmd_tx
-                    .send(admin_remove_fixed_position(node, rid, passkey.to_vec()))
-                    .await
+                    .try_send(admin_remove_fixed_position(node, rid, passkey.to_vec()))
                     .is_ok()
                 {
                     info!("meshtastic: cleared fixed position on device");
                 }
             }
+            DeferredWrite::SetFavoriteNode {
+                node_num,
+                expected_generation,
+            } => {
+                // try_send, not an awaited send (specs/001-persist-mesh-contacts/
+                // research.md Decision 8): this write must never delay this
+                // drain loop's other entries or event_loop's own message
+                // processing. Round-21 fix, Decision 8d: on failure (plausible
+                // specifically under the node-database-flood traffic this
+                // feature targets), revert the local commit and re-arm the
+                // pending-protect mark so a future message/advert retries —
+                // without this, AdvertBus would permanently believe the
+                // contact protected while the radio was never told.
+                match cmd_tx.try_send(admin_set_favorite_node(
+                    node,
+                    rid,
+                    node_num,
+                    passkey.to_vec(),
+                )) {
+                    Ok(()) => info!(node_num, "meshtastic: set favorite flag on device"),
+                    Err(e) => {
+                        warn!(
+                            node_num,
+                            error = %e,
+                            "meshtastic: favorite-set write dropped; reverting local protect"
+                        );
+                        host.advert_bus()
+                            .revert_protect_by_node_num(node_num, expected_generation);
+                        state
+                            .lock()
+                            .expect("state mutex poisoned")
+                            .mark_pending_protect(node_num);
+                    }
+                }
+            }
+            DeferredWrite::RemoveFavoriteNode { node_num } => {
+                // Decision 12c: re-validate immediately before sending — a
+                // fresher protect for the same node may have landed after
+                // the caller's own `unprotect()` call (e.g. this same drain
+                // loop also carrying a newer SetFavoriteNode for node_num);
+                // sending a stale removal in that case would silently undo
+                // it.
+                if host
+                    .advert_bus()
+                    .is_currently_favourited_by_node_num(node_num)
+                {
+                    debug!(
+                        node_num,
+                        "meshtastic: skipping favorite removal — a fresher protect landed since this write was queued"
+                    );
+                    continue;
+                }
+                // try_send, not an awaited send (specs/001-persist-mesh-contacts/
+                // research.md Decision 8): this write must never delay this
+                // drain loop's other entries or event_loop's own message
+                // processing. Best-effort: if the channel is momentarily
+                // full, this write is silently dropped (see
+                // DeferredWrite::RemoveFavoriteNode's own doc comment for the
+                // accepted, bounded residual risk) — logged here so it's at
+                // least visible, not retried.
+                match cmd_tx.try_send(admin_remove_favorite_node(
+                    node,
+                    rid,
+                    node_num,
+                    passkey.to_vec(),
+                )) {
+                    Ok(()) => info!(node_num, "meshtastic: cleared favorite flag on device"),
+                    Err(e) => warn!(
+                        node_num,
+                        error = %e,
+                        "meshtastic: favorite-removal write dropped"
+                    ),
+                }
+            }
+        }
+    }
+}
+
+/// Fail/discard all deferred writes on a radio disconnect — called from
+/// `event_loop`'s `ClientEvent::Disconnected` handling before any of these
+/// writes ever reached `flush_deferred_writes`.
+///
+/// **BLOCKING fix, round 20, [research.md](research.md) Decision 8c**: a
+/// connection drop between a protect commit and its deferred
+/// `SetFavoriteNode` write actually flushing would otherwise silently and
+/// permanently lose that protect for the life of the reconnect —
+/// `decide_favourite` already committed local "Protected" state
+/// synchronously, so the sender's next DM would see the terminal
+/// `AlreadyProtected` outcome and nothing would ever retry. Reverts the
+/// local commit and re-arms pending-protect, mirroring
+/// `flush_deferred_writes`'s own channel-saturation revert (Decision 8d) for
+/// the other way this write can fail to reach the radio.
+/// `DeferredWrite::RemoveFavoriteNode` is deliberately left out — a dropped
+/// delete write needs no revert-and-retry here the way `SetFavoriteNode`
+/// does, matching Decision 12's best-effort framing for that direction (see
+/// that variant's own doc comment for the bounded, disclosed residual risk
+/// this framing accepts — it is not consequence-free, just not something
+/// this function needs to actively correct).
+fn discard_deferred_writes_on_disconnect(
+    deferred_writes: &mut Vec<DeferredWrite>,
+    host: &Arc<dyn Host>,
+    state: &Arc<Mutex<SessionState>>,
+) {
+    for w in deferred_writes.drain(..) {
+        let r = match w {
+            DeferredWrite::Lora { reply, .. } => reply,
+            DeferredWrite::Owner { reply, .. } => reply,
+            DeferredWrite::Reboot { reply, .. } => reply,
+            DeferredWrite::SetFavoriteNode {
+                node_num,
+                expected_generation,
+            } => {
+                host.advert_bus()
+                    .revert_protect_by_node_num(node_num, expected_generation);
+                state
+                    .lock()
+                    .expect("state mutex poisoned")
+                    .mark_pending_protect(node_num);
+                None
+            }
+            DeferredWrite::Device { .. }
+            | DeferredWrite::Time
+            | DeferredWrite::SetFixedPosition { .. }
+            | DeferredWrite::RemoveFixedPosition
+            | DeferredWrite::RemoveFavoriteNode { .. } => None,
+        };
+        if let Some(r) = r {
+            let _ = r.send(Err("device disconnected".into()));
         }
     }
 }
@@ -743,6 +935,7 @@ async fn event_loop(
     hop_limit: u32,
     want_ack: bool,
     packet_counter: Arc<AtomicU32>,
+    protected_contact_cap: usize,
     mut admin_rx: mpsc::Receiver<MeshtasticAdminRequest>,
     auto_apply: AutoApplyConfig,
 ) {
@@ -754,6 +947,13 @@ async fn event_loop(
     let mut deferred_writes: Vec<DeferredWrite> = Vec::new();
     // True once we've sent a session-key request and are awaiting the passkey.
     let mut session_requested = false;
+    // When the outstanding session-key request was sent, so `reap.tick()` can
+    // abandon it if the response never arrives (round-16 fix, [research.md]
+    // Decision 8b) — without this, a dropped first response latches
+    // `session_requested` true forever for the connection, silently stalling
+    // every later SetFavoriteNode/RemoveFavoriteNode write behind a request
+    // that will never be retried.
+    let mut session_requested_at: Option<Instant> = None;
     // Whether we've queued the config.toml auto-apply on this connection.
     // Reset on disconnect so settings re-apply after a reconnect.
     let mut auto_applied = false;
@@ -770,6 +970,13 @@ async fn event_loop(
                 if pending_admin.as_ref().is_some_and(pending_reply_abandoned) {
                     warn!("meshtastic: clearing abandoned pending admin GET (no device response)");
                     pending_admin = None;
+                }
+                if session_requested
+                    && session_requested_at.is_some_and(|at| at.elapsed() > Duration::from_secs(30))
+                {
+                    warn!("meshtastic: session-key request abandoned (no device response) — will retry on next write");
+                    session_requested = false;
+                    session_requested_at = None;
                 }
             }
             event = client.recv() => match event {
@@ -788,21 +995,26 @@ async fn event_loop(
                         }
                     }
                     // Fail any deferred writes whose caller is waiting.
-                    for w in deferred_writes.drain(..) {
-                        let r = match w {
-                            DeferredWrite::Lora { reply, .. } => reply,
-                            DeferredWrite::Owner { reply, .. } => reply,
-                            DeferredWrite::Reboot { reply, .. } => reply,
-                            DeferredWrite::Device { .. }
-                            | DeferredWrite::Time
-                            | DeferredWrite::SetFixedPosition { .. }
-                            | DeferredWrite::RemoveFixedPosition => None,
-                        };
-                        if let Some(r) = r {
-                            let _ = r.send(Err("device disconnected".into()));
-                        }
-                    }
+                    //
+                    // BLOCKING fix, [research.md](research.md) Decision 8c: a
+                    // connection drop between a protect commit and its
+                    // deferred SetFavoriteNode write actually flushing would
+                    // otherwise silently and permanently lose that protect
+                    // for the life of the reconnect — decide_favourite
+                    // already committed local "Protected" state synchronously,
+                    // so the sender's next DM would see the terminal
+                    // AlreadyProtected outcome and nothing would ever retry.
+                    // Revert the local commit and re-arm pending-protect here,
+                    // mirroring flush_deferred_writes's own channel-saturation
+                    // revert (Decision 8d) for the other way this write can
+                    // fail to reach the radio. RemoveFavoriteNode is
+                    // deliberately left out — a dropped delete write has no
+                    // correctness consequence (Decision 12's best-effort
+                    // framing for that direction).
+                    discard_deferred_writes_on_disconnect(&mut deferred_writes, &host, &state);
                     session_requested = false;
+                    session_requested_at = None;
+                    last_session_passkey.clear();
                     auto_applied = false;
                     if will_retry {
                         info!("meshtastic: radio disconnected, will retry");
@@ -857,9 +1069,9 @@ async fn event_loop(
                                 &cmd_tx,
                                 node,
                                 &mut session_requested,
+                                &mut session_requested_at,
                                 &deferred_writes,
-                            )
-                            .await;
+                            );
                             auto_applied = true;
                         }
                     }
@@ -877,9 +1089,12 @@ async fn event_loop(
                                 node,
                                 &last_session_passkey,
                                 &mut deferred_writes,
+                                &host,
+                                &state,
                             )
                             .await;
                             session_requested = false;
+                            session_requested_at = None;
                         }
                     }
 
@@ -902,6 +1117,10 @@ async fn event_loop(
                             hop_limit,
                             want_ack,
                             &packet_counter,
+                            protected_contact_cap,
+                            &mut deferred_writes,
+                            &mut session_requested,
+                            &mut session_requested_at,
                         )
                         .await;
                     }
@@ -923,6 +1142,7 @@ async fn event_loop(
                             // Not connected yet → empty snapshot rather than an error.
                             MeshtasticAdminRequest::GetSnapshot { reply } => { let _ = reply.send(Ok(Default::default())); }
                             MeshtasticAdminRequest::Reboot { reply, .. } => { let _ = reply.send(Err(e)); }
+                            MeshtasticAdminRequest::RemoveFavoriteNode { reply, .. } => { let _ = reply.send(Err(e)); }
                         }
                     }
                     reject_no_num(req);
@@ -981,7 +1201,7 @@ async fn event_loop(
                         // Queue the write and request a session key. The write is
                         // sent (and `reply` completed) once the passkey arrives.
                         deferred_writes.push(DeferredWrite::Lora { lora, reply: Some(reply) });
-                        request_session_key(&cmd_tx, my_node_num, &mut session_requested, &deferred_writes).await;
+                        request_session_key(&cmd_tx, my_node_num, &mut session_requested, &mut session_requested_at, &deferred_writes);
                     }
                     MeshtasticAdminRequest::GetOwner { reply } => {
                         let rid = random_packet_id();
@@ -994,7 +1214,7 @@ async fn event_loop(
                     MeshtasticAdminRequest::SetOwner { long_name, short_name, reply } => {
                         let user = owner_user(long_name.as_deref(), short_name.as_deref());
                         deferred_writes.push(DeferredWrite::Owner { user, reply: Some(reply) });
-                        request_session_key(&cmd_tx, my_node_num, &mut session_requested, &deferred_writes).await;
+                        request_session_key(&cmd_tx, my_node_num, &mut session_requested, &mut session_requested_at, &deferred_writes);
                     }
                     MeshtasticAdminRequest::GetSecurity { reply } => {
                         let rid = random_packet_id();
@@ -1023,7 +1243,15 @@ async fn event_loop(
                             secs: seconds,
                             reply: Some(reply),
                         });
-                        request_session_key(&cmd_tx, my_node_num, &mut session_requested, &deferred_writes).await;
+                        request_session_key(&cmd_tx, my_node_num, &mut session_requested, &mut session_requested_at, &deferred_writes);
+                    }
+                    MeshtasticAdminRequest::RemoveFavoriteNode { node_num, reply } => {
+                        // Fire-and-forget, no correlated wire response (Decision
+                        // 8c's "Scope note") — `reply` confirms the write was
+                        // queued, not that the device applied it.
+                        deferred_writes.push(DeferredWrite::RemoveFavoriteNode { node_num });
+                        request_session_key(&cmd_tx, my_node_num, &mut session_requested, &mut session_requested_at, &deferred_writes);
+                        let _ = reply.send(Ok(()));
                     }
                 }
             },
@@ -1151,21 +1379,27 @@ fn enqueue_auto_apply(
 
 /// Request a session key from the device (to authorize queued writes), unless a
 /// request is already outstanding or there is nothing to write.
-async fn request_session_key(
+///
+/// Uses `try_send`, not an awaited send (specs/001-persist-mesh-contacts/
+/// research.md Decision 8's round-3 correction): this closes a blocking-send
+/// gap this feature's new callers hit on a hot path, and also benefits the
+/// existing `SetOwner`/`Reboot` callers.
+fn request_session_key(
     cmd_tx: &mpsc::Sender<proto::ToRadio>,
     node: u32,
     session_requested: &mut bool,
+    session_requested_at: &mut Option<Instant>,
     deferred: &[DeferredWrite],
 ) {
     if *session_requested || deferred.is_empty() {
         return;
     }
     if cmd_tx
-        .send(admin_get_session_key(node, random_packet_id()))
-        .await
+        .try_send(admin_get_session_key(node, random_packet_id()))
         .is_ok()
     {
         *session_requested = true;
+        *session_requested_at = Some(Instant::now());
     }
 }
 
@@ -1653,6 +1887,190 @@ fn make_client(
     }
 }
 
+// ── Contact protection ("Persist Mesh Contacts" feature) ───────────────────
+
+/// Eligibility gate for protection: an allow-list of person-device roles
+/// (specs/001-persist-mesh-contacts/data-model.md) — CLIENT (0), CLIENT_MUTE
+/// (1), CLIENT_HIDDEN (8), CLIENT_BASE (12) — never ROUTER (2),
+/// ROUTER_CLIENT (3), REPEATER (4), or ROUTER_LATE (11), per FR-003.
+fn is_meshtastic_person_role(role: u8) -> bool {
+    matches!(role, 0 | 1 | 8 | 12)
+}
+
+/// Build the eviction-exclusion prefix list for `try_protect_node`: every
+/// `node_num` with an active session right now (plus our own node, if
+/// known), resolved to its currently-known pubkey (real or synthetic) via
+/// `AdvertBus::pubkey_by_node_num`. Mirrors MeshCore's `try_protect_contact`
+/// building its own exclude list from active session prefixes plus
+/// `self_prefix` — adapted here because Meshtastic sessions are keyed purely
+/// by `node_num` and cache no pubkey locally the way MeshCore's do.
+fn eviction_exclude_prefixes(
+    host: &Arc<dyn Host>,
+    state: &Arc<Mutex<SessionState>>,
+    my_node_num: Option<u32>,
+) -> Vec<[u8; 6]> {
+    let active: Vec<u32> = {
+        let st = state.lock().expect("state mutex poisoned");
+        let mut nums: Vec<u32> = st.by_node.keys().copied().collect();
+        if let Some(n) = my_node_num {
+            if !nums.contains(&n) {
+                nums.push(n);
+            }
+        }
+        nums
+    };
+    active
+        .into_iter()
+        .filter_map(|n| host.advert_bus().pubkey_by_node_num(n))
+        .map(|pk| pk[..6].try_into().expect("pubkey is 32 bytes"))
+        .collect()
+}
+
+/// Attempt to protect `node_num`, gated by [`is_meshtastic_person_role`]. On
+/// success, queues the native `SetFavoriteNode` admin write (sent once a
+/// session passkey is available — see `flush_deferred_writes`) and requests
+/// a session key if one isn't already outstanding. Never blocks on the
+/// radio: the actual send is decoupled into `flush_deferred_writes`, so this
+/// function has no *radio* send of its own to revert on failure (unlike
+/// MeshCore's `try_protect_contact`, which sends immediately and so must
+/// revert inline) — see `crates/bbs-mesh/src/transport.rs`'s
+/// `try_protect_contact` for the MeshCore sibling this otherwise mirrors.
+#[allow(clippy::too_many_arguments)]
+fn try_protect_node(
+    host: &Arc<dyn Host>,
+    node_num: u32,
+    cmd_tx: &mpsc::Sender<proto::ToRadio>,
+    my_node_num: Option<u32>,
+    state: &Arc<Mutex<SessionState>>,
+    protected_contact_cap: usize,
+    deferred_writes: &mut Vec<DeferredWrite>,
+    session_requested: &mut bool,
+    session_requested_at: &mut Option<Instant>,
+) -> FavouriteOutcome {
+    // Round-25 handling, moved to run BEFORE any local commit is attempted
+    // (Phase 4 audit's Skeptic pass, round 2): my_node_num is not observed
+    // missing in practice (the connect-time MyInfo sync always precedes
+    // live text-packet traffic) but isn't structurally impossible. Without
+    // it there is no way to queue the deferred write, request a session
+    // key, or — for a ProtectedWithEviction outcome — send the evicted
+    // contact's radio-side removal at all. A prior version of this function
+    // called `mark_favourite_if_eligible_by_node_num` unconditionally and
+    // only reverted the *new* protect afterward on this branch: for a
+    // ProtectedWithEviction outcome that left the evicted victim's local
+    // unprotect committed with no way back and no radio removal ever sent
+    // — silently losing a real contact's protection for no gain (found by
+    // the audit's Skeptic pass). Checking first and never calling
+    // `decide_favourite` at all when `my_node_num` is unknown avoids the
+    // problem structurally instead of trying to partially undo it:
+    // `pending_protect` stays armed for a natural retry once my_node_num is
+    // presumably known, and nothing in AdvertBus is touched in the meantime.
+    let Some(my_node_num) = my_node_num else {
+        return FavouriteOutcome::NoRecordYet;
+    };
+
+    let exclude = eviction_exclude_prefixes(host, state, Some(my_node_num));
+    let outcome = host.advert_bus().mark_favourite_if_eligible_by_node_num(
+        node_num,
+        is_meshtastic_person_role,
+        protected_contact_cap,
+        &exclude,
+    );
+
+    match &outcome {
+        FavouriteOutcome::Protected(snapshot) => {
+            deferred_writes.push(DeferredWrite::SetFavoriteNode {
+                node_num,
+                expected_generation: snapshot.generation,
+            });
+            request_session_key(
+                cmd_tx,
+                my_node_num,
+                session_requested,
+                session_requested_at,
+                deferred_writes,
+            );
+        }
+        FavouriteOutcome::ProtectedWithEviction(snapshot, _evicted_pubkey, evicted_record) => {
+            deferred_writes.push(DeferredWrite::SetFavoriteNode {
+                node_num,
+                expected_generation: snapshot.generation,
+            });
+            request_session_key(
+                cmd_tx,
+                my_node_num,
+                session_requested,
+                session_requested_at,
+                deferred_writes,
+            );
+            // Radio-side removal for the evicted contact reuses the same
+            // Host method User Story 4's manual delete uses (research.md
+            // Decision 5b's "Radio-side removal... reuses Decision 12/12b's
+            // existing mechanism exactly" note). Detached, fire-and-forget —
+            // must never delay this function or its caller.
+            if let Some(evicted_node_num) = evicted_record.node_num {
+                let host = Arc::clone(host);
+                tokio::spawn(async move {
+                    if let Err(e) = host
+                        .admin_remove_meshtastic_favorite(evicted_node_num)
+                        .await
+                    {
+                        warn!(
+                            node_num = evicted_node_num,
+                            error = %e,
+                            "meshtastic: failed to clear favorite flag on evicted contact"
+                        );
+                    }
+                });
+            }
+        }
+        FavouriteOutcome::CapReached => {
+            warn!(
+                node_num,
+                "meshtastic: protected-contact cap reached — new sender not protected this message"
+            );
+        }
+        FavouriteOutcome::AlreadyProtected
+        | FavouriteOutcome::Ineligible
+        | FavouriteOutcome::NoRecordYet => {}
+    }
+
+    outcome
+}
+
+/// Attempt protection for `node_num` and update its pending-protect mark
+/// accordingly — shared by `dispatch_message`'s own first attempt and
+/// `handle_from_radio`'s/`handle_packet`'s `record_node_advert` retry hooks.
+#[allow(clippy::too_many_arguments)]
+fn attempt_protect_and_update_pending(
+    host: &Arc<dyn Host>,
+    node_num: u32,
+    cmd_tx: &mpsc::Sender<proto::ToRadio>,
+    my_node_num: Option<u32>,
+    state: &Arc<Mutex<SessionState>>,
+    protected_contact_cap: usize,
+    deferred_writes: &mut Vec<DeferredWrite>,
+    session_requested: &mut bool,
+    session_requested_at: &mut Option<Instant>,
+) {
+    let outcome = try_protect_node(
+        host,
+        node_num,
+        cmd_tx,
+        my_node_num,
+        state,
+        protected_contact_cap,
+        deferred_writes,
+        session_requested,
+        session_requested_at,
+    );
+    let mut st = state.lock().expect("state mutex poisoned");
+    if matches!(outcome, FavouriteOutcome::NoRecordYet) {
+        st.mark_pending_protect(node_num);
+    } else {
+        st.clear_pending_protect(node_num);
+    }
+}
+
 #[allow(clippy::too_many_arguments)]
 async fn handle_from_radio(
     msg: proto::FromRadio,
@@ -1666,6 +2084,10 @@ async fn handle_from_radio(
     hop_limit: u32,
     want_ack: bool,
     packet_counter: &AtomicU32,
+    protected_contact_cap: usize,
+    deferred_writes: &mut Vec<DeferredWrite>,
+    session_requested: &mut bool,
+    session_requested_at: &mut Option<Instant>,
 ) {
     match msg.payload_variant {
         Some(from_radio::PayloadVariant::MyInfo(my_info)) => {
@@ -1678,15 +2100,48 @@ async fn handle_from_radio(
         Some(from_radio::PayloadVariant::NodeInfo(node)) => {
             // If this is our own node, capture the current owner name so
             // apply-on-connect can skip a redundant (reboot-inducing) SetOwner.
-            {
+            let my_node_num = {
                 let mut st = state.lock().expect("state mutex poisoned");
                 if Some(node.num) == st.my_node_num {
                     if let Some(u) = &node.user {
                         st.device_owner = Some(u.clone());
                     }
                 }
+                st.my_node_num
+            };
+            let node_num = node.num;
+            // Genuine connect-time NodeDB sync — node.is_favorite carries a
+            // real device-reported bit (unlike the live self-announce path
+            // in handle_packet).
+            let identity_changed = record_node_advert(host, node, true);
+            // Round-10 fix (research.md Decision 2): node_num_index just
+            // corrected a stale mapping to a different pubkey (e.g. a
+            // re-flashed device) — re-arm pending-protect for the corrected
+            // identity so it isn't left unprotected until a second message
+            // arrives.
+            if identity_changed {
+                state
+                    .lock()
+                    .expect("state mutex poisoned")
+                    .mark_pending_protect(node_num);
             }
-            record_node_advert(host, node);
+            let pending = state
+                .lock()
+                .expect("state mutex poisoned")
+                .is_pending_protect(node_num);
+            if pending {
+                attempt_protect_and_update_pending(
+                    host,
+                    node_num,
+                    cmd_tx,
+                    my_node_num,
+                    state,
+                    protected_contact_cap,
+                    deferred_writes,
+                    session_requested,
+                    session_requested_at,
+                );
+            }
         }
         Some(from_radio::PayloadVariant::Config(cfg)) => {
             // Capture the device's current config from the sync stream so
@@ -1730,6 +2185,10 @@ async fn handle_from_radio(
                 hop_limit,
                 want_ack,
                 packet_counter,
+                protected_contact_cap,
+                deferred_writes,
+                session_requested,
+                session_requested_at,
             )
             .await;
         }
@@ -1743,25 +2202,66 @@ async fn handle_from_radio(
     }
 }
 
-fn record_node_advert(host: &Arc<dyn Host>, node: NodeInfo) {
-    let pubkey = node
-        .user
-        .as_ref()
-        .and_then(|u| <[u8; 32]>::try_from(u.public_key.as_slice()).ok())
+/// Record a Meshtastic node sighting as an `AdvertBus` advert.
+///
+/// `is_full_sync` distinguishes a genuine connect-time NodeDB sync (`true`,
+/// `node.is_favorite` carries a real device-reported bit) from an ordinary
+/// live `PORT_NODEINFO_APP` self-announce (`false`, no such bit exists on
+/// that path — see [`NodeInfo::is_favorite`]'s doc comment). Passing `false`
+/// here is only safe because the `is_favorite: Option<bool>` this computes
+/// gates whether `upsert_meshtastic_node` ever reads it at all: without this
+/// distinction, a protected node's own next routine self-announce would
+/// silently overwrite `flags` back to unprotected — deterministic behavior
+/// on ordinary background traffic every Meshtastic node generates on its own
+/// interval, not a rare race (specs/001-persist-mesh-contacts/research.md
+/// Decision 7's round-13 correction).
+///
+/// Returns `true` only if `node.num` already mapped to a *different* pubkey
+/// (a real identity change, e.g. a re-flashed device) — callers use this to
+/// know whether a pending-protect retry needs to be re-armed for the
+/// corrected identity (see [`AdvertBus::upsert_meshtastic_node`]). Returns
+/// `false`, and records nothing, if `node.user` is absent — never default an
+/// absent role to a false "confirmed CLIENT" role.
+fn record_node_advert(host: &Arc<dyn Host>, node: NodeInfo, is_full_sync: bool) -> bool {
+    let Some(user) = node.user.as_ref() else {
+        return false;
+    };
+
+    // Reject spoofed pubkeys — both the synthetic-namespace case (this
+    // repo's own pre-existing audit finding `meshtastic-44`, specs/001-
+    // persist-mesh-contacts/research.md Decision 2c: a peer broadcasting a
+    // crafted `public_key` equal to `synthetic_pubkey(victim_node_num)`)
+    // AND real-key replay (found by the Phase 4 hostile audit's Security
+    // persona: the synthetic-only check left a peer free to broadcast a
+    // VICTIM'S OWN genuine public_key under the attacker's node_num,
+    // silently overwriting `AdvertRecord.node_num` on the victim's real
+    // record and misdirecting any later eviction/removal command sent to
+    // "the owner of this pubkey" at the attacker's node instead of the
+    // victim's). A reported pubkey is only trusted if it is not
+    // synthetic-namespace AND (nobody currently owns it, or `node.num`
+    // itself already does) — any other already-claimed pubkey falls back to
+    // this node's own synthetic identity instead of adopting someone
+    // else's.
+    let pubkey = <[u8; 32]>::try_from(user.public_key.as_slice())
+        .ok()
+        .filter(|pk| pk[0..2] != *b"MT")
+        .filter(|pk| {
+            host.advert_bus()
+                .node_num_owning_pubkey(pk)
+                .is_none_or(|owner| owner == node.num)
+        })
         .unwrap_or_else(|| synthetic_pubkey(node.num));
 
-    let name = node
-        .user
-        .as_ref()
-        .map(|u| {
-            if u.long_name.is_empty() {
-                u.id.clone()
-            } else {
-                u.long_name.clone()
-            }
-        })
-        .filter(|s| !s.is_empty())
-        .unwrap_or_else(|| format_node_id(node.num));
+    let name = if user.long_name.is_empty() {
+        user.id.clone()
+    } else {
+        user.long_name.clone()
+    };
+    let name = if name.is_empty() {
+        format_node_id(node.num)
+    } else {
+        name
+    };
 
     let (lat_1e6, lon_1e6) = node
         .position
@@ -1776,16 +2276,28 @@ fn record_node_advert(host: &Arc<dyn Host>, node: NodeInfo) {
 
     // Record the device role (Config.DeviceConfig.Role) as the advert "type".
     // The web interprets this per-transport (a Meshtastic role, not a MeshCore
-    // advert type).
-    let role = node.user.as_ref().map(|u| u.role).unwrap_or(0);
-    host.advert_bus().upsert(
+    // advert type). Fail-closed, not fail-open: a malformed/adversarial role
+    // outside the known 0..=12 range must land outside the protection
+    // allow-list (255), not fold down to 0 (CLIENT, eligible) the way a plain
+    // `.clamp(0, u8::MAX as i32)` would — defeating the allow-list's
+    // fail-closed design for exactly the untrusted-broadcast-traffic threat
+    // model it exists for (round-9 fix).
+    let role = if (0..=12).contains(&user.role) {
+        user.role as u8
+    } else {
+        255
+    };
+
+    host.advert_bus().upsert_meshtastic_node(
         pubkey,
+        node.num,
         name,
-        role.clamp(0, u8::MAX as i32) as u8,
+        role,
         lat_1e6,
         lon_1e6,
+        is_full_sync.then_some(node.is_favorite),
         TRANSPORT_NAME,
-    );
+    )
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -1801,6 +2313,10 @@ async fn handle_packet(
     hop_limit: u32,
     want_ack: bool,
     packet_counter: &AtomicU32,
+    protected_contact_cap: usize,
+    deferred_writes: &mut Vec<DeferredWrite>,
+    session_requested: &mut bool,
+    session_requested_at: &mut Option<Instant>,
 ) {
     if let Some(mesh_packet::PayloadVariant::Decoded(data)) = &packet.payload_variant {
         if data.portnum == PORT_NODEINFO_APP {
@@ -1820,8 +2336,37 @@ async fn handle_packet(
                         position: None,
                         snr: packet.rx_snr,
                         last_heard: packet.rx_time,
+                        is_favorite: false,
                     };
-                    record_node_advert(host, node);
+                    let node_num = node.num;
+                    let my_node_num = state.lock().expect("state mutex poisoned").my_node_num;
+                    // Ordinary live self-announce, not a connect-time NodeDB
+                    // sync — carries no real is_favorite bit (see
+                    // NodeInfo::is_favorite's doc comment).
+                    let identity_changed = record_node_advert(host, node, false);
+                    if identity_changed {
+                        state
+                            .lock()
+                            .expect("state mutex poisoned")
+                            .mark_pending_protect(node_num);
+                    }
+                    let pending = state
+                        .lock()
+                        .expect("state mutex poisoned")
+                        .is_pending_protect(node_num);
+                    if pending {
+                        attempt_protect_and_update_pending(
+                            host,
+                            node_num,
+                            cmd_tx,
+                            my_node_num,
+                            state,
+                            protected_contact_cap,
+                            deferred_writes,
+                            session_requested,
+                            session_requested_at,
+                        );
+                    }
                 }
                 Err(e) => {
                     debug!(
@@ -1866,6 +2411,10 @@ async fn handle_packet(
         hop_limit,
         want_ack,
         packet_counter,
+        protected_contact_cap,
+        deferred_writes,
+        session_requested,
+        session_requested_at,
     )
     .await;
 }
@@ -1907,7 +2456,38 @@ async fn dispatch_message(
     hop_limit: u32,
     want_ack: bool,
     packet_counter: &AtomicU32,
+    protected_contact_cap: usize,
+    deferred_writes: &mut Vec<DeferredWrite>,
+    session_requested: &mut bool,
+    session_requested_at: &mut Option<Instant>,
 ) {
+    // Persist Mesh Contacts (research.md Decision 3): unconditionally mark
+    // pending first, then attempt protection immediately — unlike MeshCore,
+    // Meshtastic's node_num *is* the identity directly (no prefix-to-pubkey
+    // resolution gap to wait on), and dispatch_message/record_node_advert
+    // are serialized on this one task, so there is no cross-task race the
+    // way MeshCore's command_worker/event_loop split has (Decision 3's
+    // round-16 note) — the identical unconditional-mark-first wording is
+    // kept anyway for consistency between both transports' pending-tracking
+    // logic, and to avoid depending on that serialization guarantee holding
+    // forever.
+    let my_node_num = {
+        let mut st = state.lock().expect("state mutex poisoned");
+        st.mark_pending_protect(node_num);
+        st.my_node_num
+    };
+    attempt_protect_and_update_pending(
+        host,
+        node_num,
+        cmd_tx,
+        my_node_num,
+        state,
+        protected_contact_cap,
+        deferred_writes,
+        session_requested,
+        session_requested_at,
+    );
+
     let (session, is_new) = get_or_create_session(node_num, host, state).await;
 
     if is_new {
@@ -2252,5 +2832,859 @@ serial_port = "/dev/ttyAMA0"
             pki_encrypted: false,
         };
         assert_eq!(text_payload(&packet), Some("hello".to_owned()));
+    }
+
+    // ── Persist Mesh Contacts: User Story 2 (Meshtastic) ───────────────────
+    //
+    // Per research.md Decision 9, this crate has no wire-level fake-radio
+    // harness — these tests call dispatch_message/record_node_advert/
+    // handle_packet/try_protect_node directly with hand-built MeshPacket/
+    // NodeInfo values and bbs_plugin_api::testing::MockHost, observing
+    // cmd_tx's output and AdvertBus's state.
+
+    use bbs_plugin_api::testing::MockHost;
+
+    fn test_user(role: i32, public_key: Vec<u8>) -> User {
+        User {
+            id: "!test".into(),
+            long_name: "Test Node".into(),
+            short_name: "TN".into(),
+            role,
+            public_key,
+        }
+    }
+
+    fn nodeinfo_packet(from: u32, to: u32, user: User) -> MeshPacket {
+        use prost::Message as _;
+        MeshPacket {
+            from,
+            to,
+            channel: 0,
+            payload_variant: Some(mesh_packet::PayloadVariant::Decoded(Data {
+                portnum: PORT_NODEINFO_APP,
+                payload: user.encode_to_vec(),
+                want_response: false,
+                dest: 0,
+                source: 0,
+                request_id: 0,
+                reply_id: 0,
+            })),
+            id: 0,
+            rx_time: 0,
+            rx_snr: 0.0,
+            hop_limit: 0,
+            want_ack: false,
+            priority: 0,
+            rx_rssi: 0,
+            via_mqtt: false,
+            hop_start: 0,
+            public_key: Vec::new(),
+            pki_encrypted: false,
+        }
+    }
+
+    fn text_packet(from: u32, to: u32, text: &str) -> MeshPacket {
+        MeshPacket {
+            from,
+            to,
+            channel: 0,
+            payload_variant: Some(mesh_packet::PayloadVariant::Decoded(Data {
+                portnum: PORT_TEXT_MESSAGE_APP,
+                payload: text.as_bytes().to_vec(),
+                want_response: false,
+                dest: 0,
+                source: 0,
+                request_id: 0,
+                reply_id: 0,
+            })),
+            id: 0,
+            rx_time: 0,
+            rx_snr: 0.0,
+            hop_limit: 0,
+            want_ack: false,
+            priority: 0,
+            rx_rssi: 0,
+            via_mqtt: false,
+            hop_start: 0,
+            public_key: Vec::new(),
+            pki_encrypted: false,
+        }
+    }
+
+    /// Decode a `ToRadio` built by an admin wire-builder back into
+    /// `(to_node, AdminMessage)`, mirroring `proto::tests`' own decode
+    /// pattern.
+    fn decode_admin(msg: &proto::ToRadio) -> Option<(u32, AdminMessage)> {
+        use prost::Message as _;
+        let proto::to_radio::PayloadVariant::Packet(packet) = msg.payload_variant.clone()? else {
+            return None;
+        };
+        let mesh_packet::PayloadVariant::Decoded(data) = packet.payload_variant? else {
+            return None;
+        };
+        if data.portnum != PORT_ADMIN_APP {
+            return None;
+        }
+        AdminMessage::decode(data.payload.as_slice())
+            .ok()
+            .map(|a| (packet.to, a))
+    }
+
+    /// Bundles the plumbing every protection test needs: a `MockHost`, an
+    /// outbound channel, per-connection `SessionState`, and the
+    /// `event_loop`-local protection bookkeeping (`deferred_writes`,
+    /// `session_requested`, `session_requested_at`) that would otherwise
+    /// live inline in `event_loop`.
+    struct TestCtx {
+        host: Arc<dyn Host>,
+        cmd_tx: mpsc::Sender<proto::ToRadio>,
+        cmd_rx: mpsc::Receiver<proto::ToRadio>,
+        state: Arc<Mutex<SessionState>>,
+        deferred_writes: Vec<DeferredWrite>,
+        session_requested: bool,
+        session_requested_at: Option<Instant>,
+        packet_counter: AtomicU32,
+    }
+
+    impl TestCtx {
+        fn new() -> Self {
+            let mock = Arc::new(MockHost::new());
+            let host: Arc<dyn Host> = mock;
+            let (cmd_tx, cmd_rx) = mpsc::channel(16);
+            Self {
+                host,
+                cmd_tx,
+                cmd_rx,
+                state: Arc::new(Mutex::new(SessionState::default())),
+                deferred_writes: Vec::new(),
+                session_requested: false,
+                session_requested_at: None,
+                packet_counter: AtomicU32::new(1),
+            }
+        }
+
+        fn set_my_node_num(&self, n: u32) {
+            self.state.lock().expect("state mutex poisoned").my_node_num = Some(n);
+        }
+
+        async fn dispatch(&mut self, node_num: u32, text: &str, cap: usize) {
+            dispatch_message(
+                node_num,
+                text,
+                &self.host,
+                &self.cmd_tx,
+                &self.state,
+                None,
+                "welcome",
+                0,
+                200,
+                3,
+                false,
+                &self.packet_counter,
+                cap,
+                &mut self.deferred_writes,
+                &mut self.session_requested,
+                &mut self.session_requested_at,
+            )
+            .await;
+        }
+
+        async fn handle_packet(&mut self, packet: MeshPacket, cap: usize) {
+            handle_packet(
+                packet,
+                &self.host,
+                &self.cmd_tx,
+                &self.state,
+                None,
+                "welcome",
+                0,
+                200,
+                3,
+                false,
+                &self.packet_counter,
+                cap,
+                &mut self.deferred_writes,
+                &mut self.session_requested,
+                &mut self.session_requested_at,
+            )
+            .await;
+        }
+
+        fn try_protect(&mut self, node_num: u32, cap: usize) -> FavouriteOutcome {
+            let my_node_num = self.state.lock().expect("state mutex poisoned").my_node_num;
+            try_protect_node(
+                &self.host,
+                node_num,
+                &self.cmd_tx,
+                my_node_num,
+                &self.state,
+                cap,
+                &mut self.deferred_writes,
+                &mut self.session_requested,
+                &mut self.session_requested_at,
+            )
+        }
+
+        async fn flush(&mut self, node: u32, passkey: &[u8]) {
+            flush_deferred_writes(
+                &self.cmd_tx,
+                node,
+                passkey,
+                &mut self.deferred_writes,
+                &self.host,
+                &self.state,
+            )
+            .await;
+        }
+
+        fn drain_admin(&mut self) -> Vec<(u32, AdminMessage)> {
+            let mut out = Vec::new();
+            while let Ok(msg) = self.cmd_rx.try_recv() {
+                if let Some(decoded) = decode_admin(&msg) {
+                    out.push(decoded);
+                }
+            }
+            out
+        }
+    }
+
+    const CAP: usize = 100;
+
+    // T023: a set_favorite_node admin write is queued the first time a
+    // TextMessage from a CLIENT-role node is dispatched.
+    #[tokio::test]
+    async fn set_favorite_node_queued_on_first_dispatch_from_eligible_node() {
+        let mut ctx = TestCtx::new();
+        ctx.set_my_node_num(1);
+        let sender = 42;
+        ctx.handle_packet(nodeinfo_packet(sender, 1, test_user(0, Vec::new())), CAP)
+            .await;
+
+        // Route through handle_packet (the real wire-level entry point) with
+        // a hand-built text packet, rather than calling dispatch_message
+        // directly, exercising the full PORT_TEXT_MESSAGE_APP path.
+        ctx.handle_packet(text_packet(sender, 1, "hello"), CAP)
+            .await;
+
+        assert!(ctx
+            .host
+            .advert_bus()
+            .is_currently_favourited_by_node_num(sender));
+        assert!(matches!(
+            ctx.deferred_writes.as_slice(),
+            [DeferredWrite::SetFavoriteNode { node_num, .. }] if *node_num == sender
+        ));
+        assert!(ctx.session_requested);
+
+        // The GetSessionKey request was sent immediately (try_send).
+        let admin = ctx.drain_admin();
+        assert!(admin.iter().any(|(_, m)| matches!(
+            m.payload_variant,
+            Some(admin_message::PayloadVariant::GetConfigRequest(_))
+        )));
+
+        // Once a passkey is available, the deferred write actually flushes
+        // as a SetFavoriteNode(sender) admin command.
+        ctx.flush(1, b"passkey").await;
+        let admin = ctx.drain_admin();
+        assert!(admin.iter().any(|(to, m)| *to == 1
+            && matches!(
+                m.payload_variant,
+                Some(admin_message::PayloadVariant::SetFavoriteNode(n)) if n == sender
+            )));
+    }
+
+    // T024: a second message from an already-protected node_num does not
+    // queue a duplicate write.
+    #[tokio::test]
+    async fn second_message_from_protected_node_does_not_requeue() {
+        let mut ctx = TestCtx::new();
+        ctx.set_my_node_num(1);
+        let sender = 42;
+        ctx.handle_packet(nodeinfo_packet(sender, 1, test_user(0, Vec::new())), CAP)
+            .await;
+        ctx.dispatch(sender, "hello", CAP).await;
+        assert_eq!(ctx.deferred_writes.len(), 1);
+        ctx.deferred_writes.clear();
+
+        ctx.dispatch(sender, "hello again", CAP).await;
+        assert!(
+            ctx.deferred_writes.is_empty(),
+            "already-protected sender must not queue a duplicate write"
+        );
+    }
+
+    // T025: ROUTER/REPEATER/ROUTER_LATE never protected; CLIENT_MUTE/
+    // CLIENT_HIDDEN/CLIENT_BASE are eligible.
+    #[tokio::test]
+    async fn role_allow_list_matches_data_model() {
+        const INELIGIBLE: [i32; 3] = [2, 4, 11]; // ROUTER, REPEATER, ROUTER_LATE
+        const ELIGIBLE: [i32; 3] = [1, 8, 12]; // CLIENT_MUTE, CLIENT_HIDDEN, CLIENT_BASE
+
+        for (i, role) in INELIGIBLE.into_iter().enumerate() {
+            let mut ctx = TestCtx::new();
+            ctx.set_my_node_num(1);
+            let sender = 100 + i as u32;
+            ctx.handle_packet(nodeinfo_packet(sender, 1, test_user(role, Vec::new())), CAP)
+                .await;
+            ctx.dispatch(sender, "hello", CAP).await;
+            assert!(
+                !ctx.host
+                    .advert_bus()
+                    .is_currently_favourited_by_node_num(sender),
+                "role {role} must never be protected"
+            );
+        }
+
+        for (i, role) in ELIGIBLE.into_iter().enumerate() {
+            let mut ctx = TestCtx::new();
+            ctx.set_my_node_num(1);
+            let sender = 200 + i as u32;
+            ctx.handle_packet(nodeinfo_packet(sender, 1, test_user(role, Vec::new())), CAP)
+                .await;
+            ctx.dispatch(sender, "hello", CAP).await;
+            assert!(
+                ctx.host
+                    .advert_bus()
+                    .is_currently_favourited_by_node_num(sender),
+                "role {role} must be eligible"
+            );
+        }
+    }
+
+    // T026: a text message before any NodeInfo defers protection
+    // (NoRecordYet, pending_protect stays marked); a subsequent eligible
+    // NodeInfo then protects without a second message. A NodeInfo with
+    // user: None must not fabricate a false CLIENT record.
+    #[tokio::test]
+    async fn protection_deferred_until_role_known() {
+        let mut ctx = TestCtx::new();
+        ctx.set_my_node_num(1);
+        let sender = 42;
+
+        ctx.dispatch(sender, "hello", CAP).await;
+        assert!(!ctx
+            .host
+            .advert_bus()
+            .is_currently_favourited_by_node_num(sender));
+        assert!(ctx.state.lock().unwrap().is_pending_protect(sender));
+        assert!(ctx.deferred_writes.is_empty());
+
+        // A NodeInfo with no user must not fabricate a false CLIENT record.
+        let host = Arc::clone(&ctx.host);
+        let no_user = NodeInfo {
+            num: sender,
+            user: None,
+            position: None,
+            snr: 0.0,
+            last_heard: 0,
+            is_favorite: false,
+        };
+        assert!(!record_node_advert(&host, no_user, false));
+        assert!(host.advert_bus().pubkey_by_node_num(sender).is_none());
+
+        // The subsequent eligible NodeInfo protects without a second message.
+        ctx.handle_packet(nodeinfo_packet(sender, 1, test_user(0, Vec::new())), CAP)
+            .await;
+        assert!(ctx
+            .host
+            .advert_bus()
+            .is_currently_favourited_by_node_num(sender));
+        assert!(!ctx.state.lock().unwrap().is_pending_protect(sender));
+    }
+
+    // T027: try_protect_node (dispatch_message's first, synchronous step)
+    // commits and queues its write even with the outbound channel
+    // saturated — it must never block on the radio.
+    #[tokio::test]
+    async fn protect_commit_does_not_block_on_saturated_channel() {
+        let mut ctx = TestCtx::new();
+        ctx.set_my_node_num(1);
+        let sender = 42;
+        ctx.handle_packet(nodeinfo_packet(sender, 1, test_user(0, Vec::new())), CAP)
+            .await;
+        ctx.drain_admin(); // clear the NodeInfo path's own traffic, if any
+
+        // Saturate the channel (capacity 16, already holds nothing after the
+        // drain above — fill it completely).
+        for _ in 0..16 {
+            ctx.cmd_tx
+                .try_send(proto::admin_get_session_key(1, 0))
+                .expect("channel should have room");
+        }
+
+        let outcome = tokio::time::timeout(std::time::Duration::from_secs(2), async {
+            ctx.try_protect(sender, CAP)
+        })
+        .await
+        .expect("try_protect_node must not block on a saturated channel");
+
+        assert!(matches!(outcome, FavouriteOutcome::Protected(_)));
+        assert_eq!(ctx.deferred_writes.len(), 1);
+        // The session-key try_send failed (channel full) — session_requested
+        // correctly stays false rather than lying about an unsent request.
+        assert!(!ctx.session_requested);
+    }
+
+    // T028: a NodeInfo reporting is_favorite = true rehydrates the record as
+    // already-protected without the BBS ever sending set_favorite_node, and
+    // stalest_pubkey_excluding then excludes it.
+    #[tokio::test]
+    async fn protection_rehydrated_from_device_is_favorite() {
+        let host: Arc<dyn Host> = Arc::new(MockHost::new());
+        let favorited_num = 42;
+        let other_num = 43;
+
+        let favorited = NodeInfo {
+            num: favorited_num,
+            user: Some(test_user(0, Vec::new())),
+            position: None,
+            snr: 0.0,
+            last_heard: 0,
+            is_favorite: true,
+        };
+        assert!(!record_node_advert(&host, favorited, true));
+        assert!(host
+            .advert_bus()
+            .is_currently_favourited_by_node_num(favorited_num));
+
+        let other = NodeInfo {
+            num: other_num,
+            user: Some(test_user(0, Vec::new())),
+            position: None,
+            snr: 0.0,
+            last_heard: 0,
+            is_favorite: false,
+        };
+        assert!(!record_node_advert(&host, other, true));
+
+        // The favorited node must never be selected as an eviction victim.
+        let stalest = host
+            .advert_bus()
+            .stalest_pubkey_excluding(&[], "meshtastic");
+        assert_eq!(
+            stalest,
+            host.advert_bus().pubkey_by_node_num(other_num),
+            "the device-favorited node must be excluded from eviction"
+        );
+    }
+
+    // T028a (round-10 regression): a node_num reassigned to a different
+    // pubkey (e.g. a re-flashed device) is retried against the new identity
+    // without requiring a second message.
+    #[tokio::test]
+    async fn protection_recovers_after_node_num_reassignment() {
+        let mut ctx = TestCtx::new();
+        ctx.set_my_node_num(1);
+        let node_num = 42;
+
+        // First identity: ineligible role reaches a terminal (Ineligible)
+        // outcome, clearing pending_protect.
+        ctx.dispatch(node_num, "hello", CAP).await;
+        assert!(ctx.state.lock().unwrap().is_pending_protect(node_num));
+        ctx.handle_packet(
+            nodeinfo_packet(node_num, 1, test_user(2 /* ROUTER */, Vec::new())),
+            CAP,
+        )
+        .await;
+        assert!(!ctx.state.lock().unwrap().is_pending_protect(node_num));
+        assert!(!ctx
+            .host
+            .advert_bus()
+            .is_currently_favourited_by_node_num(node_num));
+
+        // Same node_num, a different (real, non-synthetic) pubkey, eligible
+        // role — record_node_advert must report identity_changed and
+        // re-arm pending-protect, protecting it without a second dispatch.
+        let new_pubkey = vec![7u8; 32];
+        ctx.handle_packet(
+            nodeinfo_packet(node_num, 1, test_user(0 /* CLIENT */, new_pubkey)),
+            CAP,
+        )
+        .await;
+        assert!(
+            ctx.host
+                .advert_bus()
+                .is_currently_favourited_by_node_num(node_num),
+            "the corrected identity must be protected without a second message"
+        );
+    }
+
+    // T028c (round-13 BLOCKING regression): an already-protected node's own
+    // ordinary live self-announce must not clobber its protected bit.
+    #[tokio::test]
+    async fn ordinary_self_announce_does_not_clear_protection() {
+        let mut ctx = TestCtx::new();
+        ctx.set_my_node_num(1);
+        let sender = 42;
+        ctx.handle_packet(nodeinfo_packet(sender, 1, test_user(0, Vec::new())), CAP)
+            .await;
+        ctx.dispatch(sender, "hello", CAP).await;
+        assert!(ctx
+            .host
+            .advert_bus()
+            .is_currently_favourited_by_node_num(sender));
+
+        // The same node's own ordinary live self-announce — is_full_sync is
+        // false on this path, so it must not read (or clobber with) a false
+        // is_favorite bit.
+        ctx.handle_packet(nodeinfo_packet(sender, 1, test_user(0, Vec::new())), CAP)
+            .await;
+        assert!(
+            ctx.host
+                .advert_bus()
+                .is_currently_favourited_by_node_num(sender),
+            "an ordinary self-announce must not clear the protected bit"
+        );
+    }
+
+    // T028d (round-15 regression, security-relevant): a NodeInfo whose
+    // public_key equals synthetic_pubkey(some_other_node_num) must not
+    // hijack that other node's record.
+    #[tokio::test]
+    async fn spoofed_synthetic_namespace_pubkey_is_rejected() {
+        let host: Arc<dyn Host> = Arc::new(MockHost::new());
+        let victim_num = 100;
+        let attacker_num = 200;
+
+        // The victim has a real record.
+        let victim = NodeInfo {
+            num: victim_num,
+            user: Some(test_user(0, Vec::new())),
+            position: None,
+            snr: 0.0,
+            last_heard: 0,
+            is_favorite: false,
+        };
+        record_node_advert(&host, victim, true);
+        let victim_key = host
+            .advert_bus()
+            .pubkey_by_node_num(victim_num)
+            .expect("victim record exists");
+
+        // The attacker broadcasts a public_key equal to the victim's own
+        // synthetic pubkey.
+        let attacker = NodeInfo {
+            num: attacker_num,
+            user: Some(test_user(0, victim_key.to_vec())),
+            position: None,
+            snr: 0.0,
+            last_heard: 0,
+            is_favorite: false,
+        };
+        record_node_advert(&host, attacker, true);
+
+        // The attacker must fall back to its own synthetic pubkey, never
+        // hijacking the victim's.
+        let attacker_key = host
+            .advert_bus()
+            .pubkey_by_node_num(attacker_num)
+            .expect("attacker record exists");
+        assert_ne!(attacker_key, victim_key);
+        assert_eq!(
+            host.advert_bus().pubkey_by_node_num(victim_num),
+            Some(victim_key),
+            "the victim's own mapping must be untouched"
+        );
+    }
+
+    // Phase 4 hostile-audit regression (Security persona): the
+    // synthetic-namespace check alone left real-key replay unguarded — an
+    // attacker broadcasting a VICTIM'S OWN genuine (non-synthetic)
+    // public_key under the attacker's node_num must not hijack the
+    // victim's record either.
+    #[tokio::test]
+    async fn spoofed_real_pubkey_replay_is_rejected() {
+        let host: Arc<dyn Host> = Arc::new(MockHost::new());
+        let victim_num = 100;
+        let attacker_num = 200;
+        let victim_real_key = vec![7u8; 32]; // not "MT"-prefixed
+
+        let victim = NodeInfo {
+            num: victim_num,
+            user: Some(test_user(0, victim_real_key.clone())),
+            position: None,
+            snr: 0.0,
+            last_heard: 0,
+            is_favorite: false,
+        };
+        record_node_advert(&host, victim, true);
+        let victim_key = host
+            .advert_bus()
+            .pubkey_by_node_num(victim_num)
+            .expect("victim record exists");
+        assert_eq!(victim_key.to_vec(), victim_real_key);
+
+        // The attacker broadcasts the victim's own real public_key under a
+        // different node_num.
+        let attacker = NodeInfo {
+            num: attacker_num,
+            user: Some(test_user(0, victim_real_key.clone())),
+            position: None,
+            snr: 0.0,
+            last_heard: 0,
+            is_favorite: false,
+        };
+        record_node_advert(&host, attacker, true);
+
+        // The attacker must fall back to its own synthetic pubkey, never
+        // hijacking the victim's real key or its record's node_num.
+        let attacker_key = host
+            .advert_bus()
+            .pubkey_by_node_num(attacker_num)
+            .expect("attacker record exists");
+        assert_ne!(attacker_key, victim_key);
+        assert_eq!(
+            host.advert_bus().pubkey_by_node_num(victim_num),
+            Some(victim_key),
+            "the victim's own mapping must be untouched"
+        );
+        assert_eq!(
+            host.advert_bus().node_num_owning_pubkey(&victim_key),
+            Some(victim_num),
+            "the victim's record must still point back at the victim's own node_num"
+        );
+    }
+
+    // Phase 4 hostile-audit regression (Hostile QA persona, round-25 leak;
+    // reordering per the Skeptic pass's round-2 finding): when my_node_num
+    // is unknown, try_protect_node must never attempt a local AdvertBus
+    // commit in the first place — checking my_node_num before calling
+    // decide_favourite avoids ever needing to partially undo a commit
+    // (a prior "commit then revert" version of this fix left a
+    // ProtectedWithEviction outcome's evicted victim permanently
+    // unprotected with no radio removal ever sent, since the revert path
+    // only undid the new protect — see the eviction-specific test below).
+    #[tokio::test]
+    async fn unknown_my_node_num_never_commits_a_local_protect() {
+        let mut ctx = TestCtx::new();
+        // Deliberately do NOT set my_node_num.
+        let sender = 42;
+        ctx.handle_packet(nodeinfo_packet(sender, 1, test_user(0, Vec::new())), CAP)
+            .await;
+
+        let outcome = ctx.try_protect(sender, CAP);
+        assert!(
+            matches!(outcome, FavouriteOutcome::NoRecordYet),
+            "unknown my_node_num must downgrade to NoRecordYet, not leak Protected"
+        );
+        assert!(
+            !ctx.host
+                .advert_bus()
+                .is_currently_favourited_by_node_num(sender),
+            "no local commit should have happened at all with my_node_num unknown"
+        );
+        assert!(ctx.deferred_writes.is_empty());
+
+        // A later retry, once my_node_num becomes known, must actually
+        // protect — not silently see AlreadyProtected forever.
+        ctx.set_my_node_num(1);
+        let outcome = ctx.try_protect(sender, CAP);
+        assert!(matches!(outcome, FavouriteOutcome::Protected(_)));
+        assert!(ctx
+            .host
+            .advert_bus()
+            .is_currently_favourited_by_node_num(sender));
+    }
+
+    // Phase 4 hostile-audit regression (Skeptic pass, round 2): with
+    // my_node_num unknown, a would-be ProtectedWithEviction outcome must
+    // leave the WOULD-BE-EVICTED victim's protection completely untouched —
+    // not evicted with no way back. try_protect_node must never even call
+    // decide_favourite (and therefore never commit anything, for either the
+    // new sender or the victim) until my_node_num is known.
+    #[tokio::test]
+    async fn unknown_my_node_num_does_not_evict_anyone_either() {
+        let mut ctx = TestCtx::new();
+        // Deliberately do NOT set my_node_num.
+        let victim = 42;
+        let newcomer = 43;
+
+        // Fill the cap of 1 with a legitimately protected victim, using a
+        // separate context where my_node_num IS known so the initial
+        // protect actually commits and queues.
+        ctx.set_my_node_num(1);
+        ctx.handle_packet(nodeinfo_packet(victim, 1, test_user(0, Vec::new())), 1)
+            .await;
+        assert!(matches!(
+            ctx.try_protect(victim, 1),
+            FavouriteOutcome::Protected(_)
+        ));
+        assert!(ctx
+            .host
+            .advert_bus()
+            .is_currently_favourited_by_node_num(victim));
+
+        // Now my_node_num becomes unknown again (e.g. a stale/racy call
+        // before a fresh MyInfo sync after reconnecting) and a new sender
+        // arrives that would otherwise trigger a cap-eviction of `victim`.
+        ctx.state.lock().unwrap().my_node_num = None;
+        ctx.handle_packet(nodeinfo_packet(newcomer, 1, test_user(0, Vec::new())), 1)
+            .await;
+        let outcome = ctx.try_protect(newcomer, 1);
+        assert!(matches!(outcome, FavouriteOutcome::NoRecordYet));
+
+        // Neither party's protection state changed: the newcomer isn't
+        // protected (expected), but critically the victim is STILL
+        // protected too — no eviction was attempted at all.
+        assert!(
+            !ctx.host
+                .advert_bus()
+                .is_currently_favourited_by_node_num(newcomer),
+            "the newcomer must not be protected"
+        );
+        assert!(
+            ctx.host
+                .advert_bus()
+                .is_currently_favourited_by_node_num(victim),
+            "the would-be-evicted victim must remain protected — no eviction may be \
+             attempted while my_node_num is unknown, since there would be no way to \
+             send its radio-side removal command"
+        );
+    }
+
+    // T031a (round-22 regression, Decision 8d): a channel-saturated
+    // SetFavoriteNode write reverts the local commit and re-arms
+    // pending-protect so a future message/advert retries.
+    #[tokio::test]
+    async fn channel_saturated_flush_reverts_protect_and_rearms_pending() {
+        let mut ctx = TestCtx::new();
+        ctx.set_my_node_num(1);
+        let sender = 42;
+        ctx.handle_packet(nodeinfo_packet(sender, 1, test_user(0, Vec::new())), CAP)
+            .await;
+
+        let outcome = ctx.try_protect(sender, CAP);
+        assert!(matches!(outcome, FavouriteOutcome::Protected(_)));
+        assert!(ctx
+            .host
+            .advert_bus()
+            .is_currently_favourited_by_node_num(sender));
+        assert_eq!(ctx.deferred_writes.len(), 1);
+
+        // Close the receiver so flush_deferred_writes's try_send fails.
+        ctx.cmd_rx.close();
+        ctx.flush(1, b"passkey").await;
+
+        assert!(
+            !ctx.host
+                .advert_bus()
+                .is_currently_favourited_by_node_num(sender),
+            "a failed flush must revert the local protect commit"
+        );
+        assert!(
+            ctx.state.lock().unwrap().is_pending_protect(sender),
+            "a failed flush must re-arm pending-protect for a future retry"
+        );
+    }
+
+    // T048b (round-23 regression, Decision 12c): a queued RemoveFavoriteNode
+    // write must be skipped, not sent, if a fresh re-protect for the same
+    // node lands before the write actually flushes — sending it anyway
+    // would silently undo the fresh protect, uncorrected until the next
+    // full resync.
+    //
+    // Phase 6 hostile-audit correction (Verifier pass): this proves the
+    // real, reachable scenario for Meshtastic's single-task event_loop —
+    // both decisions settle synchronously *before* flush() is ever called,
+    // since try_protect_node has no .await point and nothing else can run
+    // on this task concurrently. It does NOT prove the re-check re-reads
+    // live state on every loop iteration (vs. once before the whole drain)
+    // — that distinction is unreachable to test here because true mid-loop
+    // interleaving is structurally impossible on this architecture, unlike
+    // MeshCore's analogous check in crates/bbs-mesh/src/transport.rs, whose
+    // removal-processing and DM-processing genuinely run on separate tasks.
+    #[tokio::test]
+    async fn stale_removal_is_skipped_when_a_fresher_protect_landed() {
+        let mut ctx = TestCtx::new();
+        ctx.set_my_node_num(1);
+        let sender = 42;
+        ctx.handle_packet(nodeinfo_packet(sender, 1, test_user(0, Vec::new())), CAP)
+            .await;
+        assert!(matches!(
+            ctx.try_protect(sender, CAP),
+            FavouriteOutcome::Protected(_)
+        ));
+        ctx.deferred_writes.clear();
+        ctx.drain_admin();
+
+        // Simulate a manual delete (T046's handler): unprotect, then queue
+        // the native removal exactly as try_protect_node/T045 would.
+        let pubkey = ctx
+            .host
+            .advert_bus()
+            .pubkey_by_node_num(sender)
+            .expect("record exists");
+        assert!(ctx.host.advert_bus().unprotect(&pubkey).is_some());
+        ctx.deferred_writes
+            .push(DeferredWrite::RemoveFavoriteNode { node_num: sender });
+
+        // Before that removal write gets its turn in the drain loop, a
+        // fresh re-DM from the same node re-protects it.
+        assert!(matches!(
+            ctx.try_protect(sender, CAP),
+            FavouriteOutcome::Protected(_)
+        ));
+        assert!(ctx
+            .host
+            .advert_bus()
+            .is_currently_favourited_by_node_num(sender));
+
+        // The drain now carries both the stale RemoveFavoriteNode and the
+        // fresh SetFavoriteNode.
+        assert_eq!(ctx.deferred_writes.len(), 2);
+        ctx.flush(1, b"passkey").await;
+
+        assert!(
+            ctx.host
+                .advert_bus()
+                .is_currently_favourited_by_node_num(sender),
+            "the fresh protect must not be silently undone by the stale removal"
+        );
+        let admin = ctx.drain_admin();
+        assert!(
+            admin.iter().any(|(_, m)| matches!(
+                m.payload_variant,
+                Some(admin_message::PayloadVariant::SetFavoriteNode(n)) if n == sender
+            )),
+            "the fresh SetFavoriteNode must still have been sent"
+        );
+        assert!(
+            !admin.iter().any(|(_, m)| matches!(
+                m.payload_variant,
+                Some(admin_message::PayloadVariant::RemoveFavoriteNode(n)) if n == sender
+            )),
+            "the stale RemoveFavoriteNode must have been skipped, not sent"
+        );
+    }
+
+    // T036b (round-22 regression, Decision 8c): a disconnect before
+    // flush_deferred_writes ever runs reverts the local commit and re-arms
+    // pending-protect the same way a channel-saturated flush does.
+    #[tokio::test]
+    async fn disconnect_before_flush_reverts_protect_and_rearms_pending() {
+        let mut ctx = TestCtx::new();
+        ctx.set_my_node_num(1);
+        let sender = 42;
+        ctx.handle_packet(nodeinfo_packet(sender, 1, test_user(0, Vec::new())), CAP)
+            .await;
+
+        let outcome = ctx.try_protect(sender, CAP);
+        assert!(matches!(outcome, FavouriteOutcome::Protected(_)));
+        assert_eq!(ctx.deferred_writes.len(), 1);
+
+        discard_deferred_writes_on_disconnect(&mut ctx.deferred_writes, &ctx.host, &ctx.state);
+
+        assert!(
+            !ctx.host
+                .advert_bus()
+                .is_currently_favourited_by_node_num(sender),
+            "a disconnect before flush must revert the local protect commit"
+        );
+        assert!(
+            ctx.state.lock().unwrap().is_pending_protect(sender),
+            "a disconnect before flush must re-arm pending-protect for a future retry"
+        );
+        assert!(ctx.deferred_writes.is_empty());
     }
 }

--- a/crates/bbs-meshtastic/src/lib.rs
+++ b/crates/bbs-meshtastic/src/lib.rs
@@ -13,7 +13,7 @@ use std::{
         atomic::{AtomicU32, Ordering},
         Arc, Mutex,
     },
-    time::{Duration, Instant},
+    time::Duration,
 };
 
 use async_trait::async_trait;
@@ -27,6 +27,10 @@ use bbs_plugin_api::{
 use prost::Message as _;
 use serde::{Deserialize, Serialize};
 use tokio::sync::{mpsc, watch};
+// tokio's Instant (not std's) so the ~30s session-key timeout respects
+// `tokio::time::pause`/`advance` under `#[tokio::test(start_paused = true)]`
+// — see the session_key_request_abandoned_after_30s_permits_a_fresh_request test.
+use tokio::time::Instant;
 use tracing::{debug, info, warn};
 
 use bbs_plugin_api::MeshtasticAdminRequest;
@@ -971,9 +975,7 @@ async fn event_loop(
                     warn!("meshtastic: clearing abandoned pending admin GET (no device response)");
                     pending_admin = None;
                 }
-                if session_requested
-                    && session_requested_at.is_some_and(|at| at.elapsed() > Duration::from_secs(30))
-                {
+                if session_requested && session_key_request_abandoned(session_requested_at) {
                     warn!("meshtastic: session-key request abandoned (no device response) — will retry on next write");
                     session_requested = false;
                     session_requested_at = None;
@@ -1375,6 +1377,14 @@ fn enqueue_auto_apply(
             deferred.push(DeferredWrite::Owner { user, reply: None });
         }
     }
+}
+
+/// True once an outstanding session-key request has gone unanswered for more
+/// than 30s — the device is presumed gone (or the response was lost), so
+/// `event_loop`'s reap tick clears the flag and lets the next write attempt
+/// issue a fresh request rather than waiting forever.
+fn session_key_request_abandoned(session_requested_at: Option<Instant>) -> bool {
+    session_requested_at.is_some_and(|at| at.elapsed() > Duration::from_secs(30))
 }
 
 /// Request a session key from the device (to authorize queued writes), unless a
@@ -2783,6 +2793,7 @@ fn format_node_id(node_num: u32) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::proto::CONFIG_TYPE_SESSIONKEY;
 
     #[test]
     fn default_config_is_disabled_but_serial_ready() {
@@ -3049,6 +3060,116 @@ serial_port = "/dev/ttyAMA0"
     }
 
     const CAP: usize = 100;
+
+    // T035a: a session-key request that never gets a device response must
+    // not permanently wedge future writes — event_loop's reap tick clears it
+    // after ~30s so the next write attempt issues a fresh request. Uses
+    // `#[tokio::test(start_paused = true)]` + `tokio::time::advance` rather
+    // than a real 30s sleep, which `session_key_request_abandoned`'s use of
+    // `tokio::time::Instant` (not `std::time::Instant`) makes possible.
+    //
+    // IMPORTANT SCOPE NOTE: this test does NOT drive `event_loop`'s real
+    // `reap.tick()` select arm (event_loop is only ever spawned from
+    // `start()`, which needs a live connection — no test harness drives it
+    // directly). It calls `session_key_request_abandoned` — the real
+    // extracted predicate, so the 30s threshold itself IS shared/tested —
+    // but then manually reproduces the reap arm's own two-line state reset
+    // (`session_requested = false; session_requested_at = None;`) rather
+    // than exercising that reset through the real code path. If a future
+    // edit changes what the real reap arm does on abandonment (e.g. also
+    // reverting a deferred write, the way the disconnect handler already
+    // does), this test can keep passing while providing zero coverage of
+    // that change. Closing this gap for real needs the same wire-level
+    // fake-radio harness this crate deliberately doesn't have (research.md
+    // Decision 9) — see T035b.
+    #[tokio::test(start_paused = true)]
+    async fn session_key_request_abandoned_after_30s_permits_a_fresh_request() {
+        let mut ctx = TestCtx::new();
+        ctx.deferred_writes.push(DeferredWrite::SetFavoriteNode {
+            node_num: 42,
+            expected_generation: 1,
+        });
+
+        request_session_key(
+            &ctx.cmd_tx,
+            42,
+            &mut ctx.session_requested,
+            &mut ctx.session_requested_at,
+            &ctx.deferred_writes,
+        );
+        assert!(ctx.session_requested);
+        assert!(ctx.session_requested_at.is_some());
+        assert!(!session_key_request_abandoned(ctx.session_requested_at));
+        let first = ctx.drain_admin();
+        assert_eq!(first.len(), 1);
+        assert!(matches!(
+            first[0].1.payload_variant,
+            Some(admin_message::PayloadVariant::GetConfigRequest(v)) if v == CONFIG_TYPE_SESSIONKEY
+        ));
+
+        // While the first request is still outstanding, a second attempt is
+        // a no-op — request_session_key's own `if *session_requested { return }`
+        // guard, unrelated to the timeout this test targets.
+        request_session_key(
+            &ctx.cmd_tx,
+            42,
+            &mut ctx.session_requested,
+            &mut ctx.session_requested_at,
+            &ctx.deferred_writes,
+        );
+        assert!(ctx.drain_admin().is_empty());
+
+        // No response ever arrives. Advance past the ~30s abandonment
+        // threshold used by event_loop's reap.tick() arm.
+        tokio::time::advance(Duration::from_secs(31)).await;
+        assert!(session_key_request_abandoned(ctx.session_requested_at));
+
+        // Reproduce exactly what the reap.tick() arm does on abandonment.
+        ctx.session_requested = false;
+        ctx.session_requested_at = None;
+
+        // A subsequent protect/delete attempt (any caller of
+        // request_session_key) now issues a genuinely fresh request rather
+        // than silently declining forever.
+        request_session_key(
+            &ctx.cmd_tx,
+            42,
+            &mut ctx.session_requested,
+            &mut ctx.session_requested_at,
+            &ctx.deferred_writes,
+        );
+        assert!(ctx.session_requested);
+        let second = ctx.drain_admin();
+        assert_eq!(
+            second.len(),
+            1,
+            "timeout must not permanently wedge session-key requests"
+        );
+        assert!(matches!(
+            second[0].1.payload_variant,
+            Some(admin_message::PayloadVariant::GetConfigRequest(v)) if v == CONFIG_TYPE_SESSIONKEY
+        ));
+    }
+
+    #[test]
+    fn session_key_request_abandoned_is_false_when_nothing_was_ever_requested() {
+        assert!(!session_key_request_abandoned(None));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn session_key_request_abandoned_boundary_is_strictly_greater_than_30s() {
+        let requested_at = Some(Instant::now());
+        tokio::time::advance(Duration::from_secs(30)).await;
+        assert!(
+            !session_key_request_abandoned(requested_at),
+            "exactly 30s elapsed must not yet count as abandoned — the real check is `>`, not `>=`"
+        );
+        tokio::time::advance(Duration::from_millis(1)).await;
+        assert!(
+            session_key_request_abandoned(requested_at),
+            "one tick past 30s must count as abandoned"
+        );
+    }
 
     // T023: a set_favorite_node admin write is queued the first time a
     // TextMessage from a CLIENT-role node is dispatched.

--- a/crates/bbs-meshtastic/src/proto.rs
+++ b/crates/bbs-meshtastic/src/proto.rs
@@ -183,6 +183,13 @@ pub struct NodeInfo {
     pub snr: f32,
     #[prost(fixed32, tag = "5")]
     pub last_heard: u32,
+    /// Whether the device's own NodeDB currently favorites this node (exempts
+    /// it from database-full eviction). Only meaningful on a genuine
+    /// connect-time NodeDB sync — a live `PORT_NODEINFO_APP` self-announce
+    /// carries no such bit; see `record_node_advert`'s `is_full_sync`
+    /// parameter for how callers must gate reading this field.
+    #[prost(bool, tag = "10")]
+    pub is_favorite: bool,
 }
 
 /// Meshtastic node owner/user info (`mesh.proto User`).
@@ -202,7 +209,8 @@ pub struct User {
     pub short_name: String,
     /// Device role (`Config.DeviceConfig.Role`): 0=CLIENT, 1=CLIENT_MUTE,
     /// 2=ROUTER, 3=ROUTER_CLIENT, 4=REPEATER, 5=TRACKER, 6=SENSOR, 7=TAK,
-    /// 8=CLIENT_HIDDEN, 9=LOST_AND_FOUND, 10=TAK_TRACKER, 11=ROUTER_LATE.
+    /// 8=CLIENT_HIDDEN, 9=LOST_AND_FOUND, 10=TAK_TRACKER, 11=ROUTER_LATE,
+    /// 12=CLIENT_BASE.
     #[prost(int32, tag = "7")]
     pub role: i32,
     /// Node's Curve25519 public key (32 bytes), broadcast on the mesh for PKC DMs.
@@ -334,7 +342,10 @@ pub struct SecurityConfig {
 /// response and the client must echo it back in SET commands within 300 s.
 #[derive(Clone, PartialEq, Message)]
 pub struct AdminMessage {
-    #[prost(oneof = "admin_message::PayloadVariant", tags = "3, 4, 5, 6, 32, 34")]
+    #[prost(
+        oneof = "admin_message::PayloadVariant",
+        tags = "3, 4, 5, 6, 32, 34, 39, 40"
+    )]
     pub payload_variant: Option<admin_message::PayloadVariant>,
     /// Replay-attack guard — echo back in all SET commands.
     #[prost(bytes = "vec", tag = "101")]
@@ -376,6 +387,31 @@ pub mod admin_message {
         /// Update a config section.
         #[prost(message, tag = "34")]
         SetConfig(super::MtConfig),
+        /// Favorite a node (exempt it from NodeDB eviction on the device).
+        /// Payload: the node number to favorite. Write-only — added to the
+        /// decode-routing `tags` list on `AdminMessage` (above) defensively,
+        /// since nothing in this codebase currently needs to decode it back
+        /// out. Tag confirmed against a vendored copy of upstream
+        /// `admin.proto` — see `.audit/repros/admin.proto` (T028b).
+        #[prost(uint32, tag = "39")]
+        SetFavoriteNode(u32),
+        /// Un-favorite a node (clear the flag that exempts it from NodeDB
+        /// eviction). Payload: the node number to un-favorite. Write-only —
+        /// added to the decode-routing `tags` list on `AdminMessage` (above)
+        /// defensively, since nothing in this codebase currently needs to
+        /// decode it back out. **Correction**: an earlier version of this
+        /// comment claimed this "matches the existing write-only variants
+        /// above" — false as written: `SetFixedPosition`/`RemoveFixedPosition`/
+        /// `SetTimeOnly`/`RebootSeconds` (tags 41/42/43/97) are write-only
+        /// too but are *not* in that tags list (a real, pre-existing decode
+        /// gap this addition doesn't introduce and isn't positioned to fix).
+        /// This variant (tag 40) is deliberately included, unlike those. See
+        /// specs/001-persist-mesh-contacts/research.md Decision 12 for the
+        /// removal mechanism this serves. Tag confirmed against a vendored
+        /// copy of upstream `admin.proto` — see `.audit/repros/admin.proto`
+        /// (T028b); no longer resting on live-fetch citations alone.
+        #[prost(uint32, tag = "40")]
+        RemoveFavoriteNode(u32),
     }
 }
 
@@ -660,6 +696,45 @@ pub fn admin_remove_fixed_position(
     )
 }
 
+/// Build a `SetFavoriteNode` admin command (favorite `node_num` on the
+/// connected radio's own NodeDB, exempting it from database-full eviction),
+/// echoing back the session passkey. No-reply, no reboot — see
+/// [`admin_message::PayloadVariant::SetFavoriteNode`].
+pub fn admin_set_favorite_node(
+    to_node: u32,
+    request_id: u32,
+    node_num: u32,
+    session_passkey: Vec<u8>,
+) -> ToRadio {
+    admin_packet(
+        to_node,
+        request_id,
+        AdminMessage {
+            payload_variant: Some(admin_message::PayloadVariant::SetFavoriteNode(node_num)),
+            session_passkey,
+        },
+    )
+}
+
+/// Build a `RemoveFavoriteNode` admin command (un-favorite `node_num` on the
+/// connected radio's own NodeDB), echoing back the session passkey. No-reply,
+/// no reboot — see [`admin_message::PayloadVariant::RemoveFavoriteNode`].
+pub fn admin_remove_favorite_node(
+    to_node: u32,
+    request_id: u32,
+    node_num: u32,
+    session_passkey: Vec<u8>,
+) -> ToRadio {
+    admin_packet(
+        to_node,
+        request_id,
+        AdminMessage {
+            payload_variant: Some(admin_message::PayloadVariant::RemoveFavoriteNode(node_num)),
+            session_passkey,
+        },
+    )
+}
+
 /// Build a `RebootSeconds` admin command (reboot the node after `secs`),
 /// echoing back the session passkey. On reboot the firmware re-broadcasts its
 /// NodeInfo, which is how neighbours re-acquire the node.
@@ -729,5 +804,29 @@ mod tests {
         };
         assert_eq!(data.portnum, PORT_TEXT_MESSAGE_APP);
         assert_eq!(data.payload, b"H");
+    }
+
+    /// The new `remove_favorite_node` (tag 40) admin variant round-trips
+    /// through prost's own encode/decode, and echoes the session passkey —
+    /// self-consistency of this repo's own wire model, not a claim about
+    /// upstream firmware compatibility (see the field's own doc comment for
+    /// that residual risk).
+    #[test]
+    fn remove_favorite_node_round_trips_and_carries_passkey() {
+        let msg = admin_remove_favorite_node(0xAABB_CCDD, 7, 424_242, vec![1, 2, 3, 4]);
+        let Some(to_radio::PayloadVariant::Packet(packet)) = msg.payload_variant else {
+            panic!("expected packet");
+        };
+        let Some(mesh_packet::PayloadVariant::Decoded(data)) = packet.payload_variant else {
+            panic!("expected decoded payload");
+        };
+        assert_eq!(data.portnum, PORT_ADMIN_APP);
+
+        let decoded = AdminMessage::decode(data.payload.as_slice()).unwrap();
+        assert_eq!(decoded.session_passkey, vec![1, 2, 3, 4]);
+        assert_eq!(
+            decoded.payload_variant,
+            Some(admin_message::PayloadVariant::RemoveFavoriteNode(424_242))
+        );
     }
 }

--- a/crates/bbs-meshtastic/src/session.rs
+++ b/crates/bbs-meshtastic/src/session.rs
@@ -9,6 +9,9 @@ use bbs_plugin_api::SessionId;
 
 const WORKFLOW_REPLY_DEDUP_SECS: u64 = 10;
 const MESSAGE_DEDUP_SECS: u64 = 10;
+/// Mirrors `bbs_mesh::session::PENDING_PROTECT_TTL_SECS` — see that
+/// constant's doc comment for the adversary-resistance rationale.
+const PENDING_PROTECT_TTL_SECS: u64 = 86_400; // 24 hours
 
 #[derive(Debug)]
 pub struct SessionEntry {
@@ -42,6 +45,12 @@ pub struct SessionState {
     pub device_config: Option<crate::proto::DeviceConfig>,
     pub by_node: HashMap<u32, SessionEntry>,
     pub by_session: HashMap<SessionId, u32>,
+    /// `node_num`s currently awaiting a contact-protection decision — mirrors
+    /// `bbs_mesh::session::SessionState::pending_protect` (see [`Self::mark_pending_protect`]).
+    /// Unlike MeshCore's prefix-to-pubkey gap, Meshtastic needs no identity
+    /// resolution step here: `node_num` is always known directly from
+    /// `packet.from`.
+    pending_protect: HashMap<u32, Instant>,
 }
 
 impl SessionState {
@@ -67,12 +76,47 @@ impl SessionState {
     }
 
     pub fn remove_by_node(&mut self, node_num: u32) -> Option<SessionId> {
+        self.pending_protect.remove(&node_num);
         if let Some(entry) = self.by_node.remove(&node_num) {
             self.by_session.remove(&entry.session_id);
             Some(entry.session_id)
         } else {
             None
         }
+    }
+
+    /// Mark `node_num` as pending a contact-protection decision — an
+    /// unconditional insert, idempotent regardless of whether it was already
+    /// pending (see research.md Decision 3's round-21 correction, mirrored
+    /// here for consistency with MeshCore even though Meshtastic's
+    /// `dispatch_message`/`record_node_advert` are serialized on one task and
+    /// don't currently need it — see T037's own note). Sweeps entries older
+    /// than `PENDING_PROTECT_TTL_SECS` first — lazy, O(n) over the (small,
+    /// TTL-bounded) pending set, no separate timer needed.
+    pub fn mark_pending_protect(&mut self, node_num: u32) {
+        self.mark_pending_protect_at(node_num, Instant::now());
+    }
+
+    /// [`Self::mark_pending_protect`] with an injectable `now`, so the TTL
+    /// sweep is unit-testable without sleeping for real hours.
+    fn mark_pending_protect_at(&mut self, node_num: u32, now: Instant) {
+        let ttl = Duration::from_secs(PENDING_PROTECT_TTL_SECS);
+        self.pending_protect
+            .retain(|_, inserted_at| now.saturating_duration_since(*inserted_at) < ttl);
+        self.pending_protect.insert(node_num, now);
+    }
+
+    /// Clear `node_num`'s pending-protect mark — called once a protection
+    /// attempt reaches a terminal outcome (`Protected`, `ProtectedWithEviction`,
+    /// `AlreadyProtected`, `Ineligible`, or `CapReached`).
+    pub fn clear_pending_protect(&mut self, node_num: u32) {
+        self.pending_protect.remove(&node_num);
+    }
+
+    /// Return `true` if `node_num` is currently marked as pending a
+    /// contact-protection decision.
+    pub fn is_pending_protect(&self, node_num: u32) -> bool {
+        self.pending_protect.contains_key(&node_num)
     }
 
     pub fn node_for_session(&self, session: SessionId) -> Option<u32> {
@@ -123,5 +167,72 @@ impl SessionState {
             entry.last_message = Some((text.to_owned(), Instant::now()));
         }
         false
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const NODE: u32 = 0x1234_5678;
+
+    #[test]
+    fn pending_protect_marks_and_clears() {
+        let mut st = SessionState::default();
+        assert!(!st.is_pending_protect(NODE));
+        st.mark_pending_protect(NODE);
+        assert!(st.is_pending_protect(NODE));
+        st.clear_pending_protect(NODE);
+        assert!(!st.is_pending_protect(NODE));
+    }
+
+    #[test]
+    fn pending_protect_mark_is_idempotent_and_reentrant() {
+        let mut st = SessionState::default();
+        let other = NODE.wrapping_add(1);
+
+        st.mark_pending_protect(NODE);
+        st.mark_pending_protect(NODE);
+        assert!(st.is_pending_protect(NODE));
+
+        st.mark_pending_protect(other);
+        st.clear_pending_protect(other);
+        assert!(!st.is_pending_protect(other));
+        assert!(st.is_pending_protect(NODE));
+    }
+
+    #[test]
+    fn pending_protect_ttl_sweeps_stale_entries() {
+        let mut st = SessionState::default();
+        let other = NODE.wrapping_add(1);
+        let third = NODE.wrapping_add(2);
+
+        let t0 = Instant::now();
+        st.mark_pending_protect_at(NODE, t0);
+
+        let inside = t0 + Duration::from_secs(PENDING_PROTECT_TTL_SECS - 1);
+        st.mark_pending_protect_at(other, inside);
+        assert!(
+            st.is_pending_protect(NODE),
+            "still inside the TTL window — must not be swept"
+        );
+
+        let outside = t0 + Duration::from_secs(PENDING_PROTECT_TTL_SECS + 1);
+        st.mark_pending_protect_at(third, outside);
+        assert!(
+            !st.is_pending_protect(NODE),
+            "older than the TTL — must be swept on the next insert"
+        );
+        assert!(st.is_pending_protect(other));
+        assert!(st.is_pending_protect(third));
+    }
+
+    #[test]
+    fn remove_by_node_clears_pending_protect() {
+        let mut st = SessionState::default();
+        st.mark_pending_protect(NODE);
+        assert!(st.is_pending_protect(NODE));
+        st.remove_by_node(NODE);
+        assert!(!st.is_pending_protect(NODE));
     }
 }

--- a/crates/bbs-plugin-api/src/advert.rs
+++ b/crates/bbs-plugin-api/src/advert.rs
@@ -12,6 +12,25 @@
 //!
 //! `BbsHost` owns the single `Arc<AdvertBus>` instance and hands it
 //! out via [`Host::advert_bus`](crate::Host::advert_bus).
+//!
+//! ## Contact protection ("Persist Mesh Contacts" feature)
+//!
+//! A record can additionally be marked *protected* (MeshCore: "favourite";
+//! Meshtastic: "favorite") once its owner has DMed the BBS — see
+//! `specs/001-persist-mesh-contacts/` for the full design. Protection state
+//! lives entirely on [`AdvertRecord`] (no new persistent storage); it is
+//! rehydrated from each platform's own wire data on reconnect rather than
+//! surviving a BBS restart on its own. [`AdvertBus::mark_favourite_if_eligible`]
+//! and [`AdvertBus::mark_favourite_if_eligible_by_node_num`] are the sole
+//! entry points that transition a record to protected — both atomically
+//! enforce a per-transport cap, evicting the oldest-protected, currently
+//! session-inactive contact to make room for a newly-eligible one once the
+//! cap is reached (`specs/001-persist-mesh-contacts/research.md` Decision 5b).
+//!
+//! This module is the foundational storage layer for that feature.
+//! `crates/bbs-mesh` wires it into MeshCore's DM-dispatch path (see
+//! `try_protect_contact` in `crates/bbs-mesh/src/transport.rs`); Meshtastic's
+//! equivalent wiring lands in a later phase.
 
 use std::collections::HashMap;
 use std::sync::Mutex;
@@ -20,17 +39,30 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use serde::{Deserialize, Serialize};
 use tokio::sync::broadcast;
 
+/// How long after a local protect/unprotect transition the transition itself
+/// is trusted over conflicting incoming wire data or eviction-selection
+/// criteria — long enough to comfortably cover LoRa's slow airtime and any
+/// resync race, short enough that a genuine later external change (via the
+/// platform's own tools) still eventually takes effect.
+///
+/// See `specs/001-persist-mesh-contacts/research.md` Decision 7a/12a.
+pub const PROTECT_GRACE_SECS: u64 = 300;
+
 // ── AdvertRecord ──────────────────────────────────────────────────────────────
 
 /// A single mesh node advertisement, captured from the air.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct AdvertRecord {
     /// Full 32-byte public key, hex-encoded.
     pub pubkey_hex: String,
     /// Human-readable node name. Empty if only a short (pubkey-only) advert
     /// has been received so far.
     pub name: String,
-    /// MeshCore advertisement type byte. `0` = unknown / short-advert only.
+    /// Node/eligibility type byte. On MeshCore this is the wire `adv_type`
+    /// byte (chat/person vs. repeater/room-server). On Meshtastic,
+    /// `record_node_advert` stores the node's `User.role` value here instead
+    /// — the web interprets this per-transport. `0` = unknown / short-advert
+    /// only.
     pub adv_type: u8,
     /// GPS latitude in decimal degrees (`0.0` if not reported).
     pub lat: f64,
@@ -43,9 +75,224 @@ pub struct AdvertRecord {
     /// Name of the transport this advert was heard on (e.g. `"meshcore"`,
     /// `"meshtastic"`). Identifies which radio network the node belongs to.
     pub transport: String,
+
+    /// `true` once a frame carrying real per-contact detail (not just a bare
+    /// pubkey/short advert) has been seen. This is the transport-agnostic
+    /// gate [`AdvertBus::mark_favourite_if_eligible`] checks before ever
+    /// protecting a record — a record can't be protected from a short advert
+    /// alone.
+    pub has_full_record: bool,
+    /// Protection bits. On MeshCore this caches the device's **full**
+    /// `Contact.flags` byte (bit 0 = protected/favourited; upper bits are
+    /// real, firmware-meaningful per-contact flags the BBS preserves but
+    /// never interprets). On Meshtastic this is synthetic, always `0` or `1`
+    /// (`is_favorite as u8`).
+    pub flags: u8,
+    /// Unix-seconds timestamp set whenever this record transitions to
+    /// protected. While within [`PROTECT_GRACE_SECS`] of now, readers must
+    /// treat the record as protected even if `flags` bit 0 has not (yet)
+    /// been confirmed by a device sync, and writers must not let incoming
+    /// wire data lower it.
+    pub protected_at: Option<u64>,
+    /// Unix-seconds timestamp set whenever this record transitions to
+    /// unprotected (manual delete or automatic cap eviction). Mirrors
+    /// `protected_at`'s grace-window protection in the opposite direction —
+    /// guards against a failed/dropped radio-side removal being silently
+    /// undone by the next routine device sync.
+    pub unprotected_at: Option<u64>,
+    /// Meshtastic node number; `None` for MeshCore records. Needed to
+    /// dispatch Meshtastic's native favourite/removal admin commands, which
+    /// address nodes by number rather than by pubkey.
+    pub node_num: Option<u32>,
+    /// MeshCore only; `0` for Meshtastic records. Cached from
+    /// `Contact.last_advert_timestamp` (a required wire field with no
+    /// `Default`), validated the same way `upsert_with_timestamp` validates
+    /// device-reported timestamps.
+    pub last_advert_timestamp: u32,
+    /// MeshCore only; `0` for Meshtastic records. The device's own
+    /// `Contact.lastmod`, re-sent unchanged when protecting.
+    pub lastmod: u32,
+    /// MeshCore only; empty for Meshtastic records. Cached routing path from
+    /// the last full `Contact`/`NewAdvert` frame, replayed as-is when
+    /// protecting (sending "unknown" instead would unconditionally reset the
+    /// device's working route — see research.md Decision 1).
+    pub out_path: Vec<u8>,
+    /// MeshCore only. `-1` (0xFF) = unknown/no path.
+    pub out_path_len: i8,
+    /// Plain counter, incremented under the bus's lock on every `flags`
+    /// bit-0 transition (protect, unprotect, or reverted protect). The
+    /// compare-and-swap discriminant [`AdvertBus::revert_protect`] and
+    /// friends use to avoid clobbering a different, later transition on the
+    /// same record — unix-seconds timestamps are not collision-safe or
+    /// guaranteed monotonic enough for that purpose.
+    pub generation: u64,
+}
+
+impl AdvertRecord {
+    /// Whether this record is currently protected, applying the same
+    /// grace-window rule every other reader in this module uses (`flags`
+    /// bit 0, OR a still-live `protected_at` — see
+    /// [`AdvertBus::is_currently_favourited`]). Exposed so callers outside
+    /// this module (e.g. the web admin API) that already hold a cloned
+    /// `AdvertRecord` from [`AdvertBus::list`] don't have to re-implement
+    /// this logic against the raw bit alone, which would silently disagree
+    /// with [`AdvertBus::list_protected`]'s own filter during an active
+    /// grace window (found by the Phase 5 hostile audit).
+    pub fn is_currently_protected(&self) -> bool {
+        is_effectively_protected(self, unix_now_u64())
+    }
+}
+
+/// Build a fresh, unprotected, not-yet-fully-known record.
+fn new_record(pubkey: [u8; 32], now: i64, transport: &str) -> AdvertRecord {
+    AdvertRecord {
+        pubkey_hex: hex_encode(&pubkey),
+        name: String::new(),
+        adv_type: 0,
+        lat: 0.0,
+        lon: 0.0,
+        first_seen_secs: now,
+        last_seen_secs: now,
+        transport: transport.to_owned(),
+        has_full_record: false,
+        flags: 0,
+        protected_at: None,
+        unprotected_at: None,
+        node_num: None,
+        last_advert_timestamp: 0,
+        lastmod: 0,
+        out_path: Vec::new(),
+        out_path_len: -1,
+        generation: 0,
+    }
+}
+
+/// Whether `record` should currently be treated as protected — the bit
+/// itself, OR'd with a still-live protect grace window (so a just-issued,
+/// not-yet-device-confirmed protect can't be undone by a stale inbound sync
+/// racing it). Used everywhere protection status is *read* (eviction
+/// exclusion, cap counting, `AlreadyProtected` checks, TOCTOU re-checks) —
+/// never a bare `flags & 1 != 0` check on its own.
+fn is_effectively_protected(record: &AdvertRecord, now: u64) -> bool {
+    record.flags & 1 != 0 || record.protected_at.is_some_and(|t| within_grace(t, now))
+}
+
+/// Merge an incoming wire-reported protected bit against local grace-window
+/// state, for writers (`upsert_contact`/`upsert_meshtastic_node`) syncing
+/// fresh device data. Whichever of `protected_at`/`unprotected_at` is more
+/// recent and still live wins; if neither is live, the incoming bit is
+/// trusted as-is. See research.md Decision 12a's round-17 correction — this
+/// is a single order-independent comparison, not two sequential checks.
+fn merge_protected_bit(
+    incoming_bit: bool,
+    protected_at: Option<u64>,
+    unprotected_at: Option<u64>,
+    now: u64,
+) -> bool {
+    let p = protected_at.filter(|&t| within_grace(t, now));
+    let u = unprotected_at.filter(|&t| within_grace(t, now));
+    match (p, u) {
+        (Some(p), Some(u)) => p >= u,
+        (Some(_), None) => true,
+        (None, Some(_)) => false,
+        (None, None) => incoming_bit,
+    }
+}
+
+fn within_grace(t: u64, now: u64) -> bool {
+    now.saturating_sub(t) < PROTECT_GRACE_SECS
+}
+
+fn prefix6(pubkey: &[u8; 32]) -> [u8; 6] {
+    pubkey[..6].try_into().expect("pubkey is 32 bytes")
+}
+
+// ── Protection decision types ───────────────────────────────────────────────
+
+/// Result of attempting to protect a record via
+/// [`AdvertBus::mark_favourite_if_eligible`] /
+/// [`AdvertBus::mark_favourite_if_eligible_by_node_num`].
+#[derive(Debug, Clone, PartialEq)]
+pub enum FavouriteOutcome {
+    /// Just transitioned to protected — send the outbound protect frame
+    /// built from this snapshot.
+    Protected(FavouriteSnapshot),
+    /// Transitioned to protected AND evicted a different, existing protected
+    /// record to make room (the per-transport cap was reached). The caller
+    /// must send both the new protect frame (from the first `FavouriteSnapshot`)
+    /// and the evicted record's native removal command. The evicted record's
+    /// raw pubkey is carried explicitly as the second field (not just
+    /// `AdvertRecord.pubkey_hex`, which isn't decodable back into wire bytes)
+    /// precisely so the caller can dispatch that removal without needing to
+    /// already know it; the `AdvertRecord` itself is the third field, carried
+    /// for its `transport`/`node_num` (Meshtastic removal needs `node_num`,
+    /// not the pubkey).
+    ProtectedWithEviction(FavouriteSnapshot, [u8; 32], Box<AdvertRecord>),
+    /// Already protected before this call — nothing to do, and the caller
+    /// must NOT retry later (there is nothing more that will ever change
+    /// this outcome).
+    AlreadyProtected,
+    /// Cached record exists and is ineligible (wrong adv_type/role) —
+    /// nothing to do, and the caller must NOT retry later.
+    Ineligible,
+    /// No cached record yet, or `has_full_record` is false — nothing to do
+    /// YET, but the caller SHOULD retry once more data arrives (this is the
+    /// only outcome that should ever cause a caller to mark an identity
+    /// pending).
+    NoRecordYet,
+    /// The per-transport protected-contact cap was reached and no eviction
+    /// candidate remained after excluding active-session and
+    /// within-grace-window records. Terminal for this message, like
+    /// `Ineligible` — not retried via a pending-protect mechanism. The
+    /// caller SHOULD log a distinct warning.
+    CapReached,
+}
+
+/// A snapshot of the data needed to build an outbound protect frame,
+/// captured atomically at the moment a record transitions to protected.
+#[derive(Debug, Clone, PartialEq)]
+pub struct FavouriteSnapshot {
+    /// Full 32-byte public key of the now-protected record.
+    pub pubkey: [u8; 32],
+    /// The record's cached name, at the moment of protection.
+    pub name: String,
+    /// The record's `adv_type`/role byte, at the moment of protection.
+    pub adv_type: u8,
+    /// Cached GPS latitude in decimal degrees.
+    pub lat: f64,
+    /// Cached GPS longitude in decimal degrees.
+    pub lon: f64,
+    /// MeshCore only; `0` on Meshtastic. Cached `Contact.last_advert_timestamp`.
+    pub last_advert_timestamp: u32,
+    /// MeshCore only; `0` on Meshtastic. Cached `Contact.lastmod`.
+    pub lastmod: u32,
+    /// MeshCore only; empty on Meshtastic. Cached routing path, replayed as-is.
+    pub out_path: Vec<u8>,
+    /// MeshCore only. Cached path length; `-1` means unknown.
+    pub out_path_len: i8,
+    /// The record's full flags byte after the protect bit was set —
+    /// preserves any non-protect bits the device had already set.
+    pub flags: u8,
+    /// Unix-seconds timestamp this protect transition set.
+    pub protected_at: u64,
+    /// The record's generation counter after this protect transition — the
+    /// compare-and-swap token a later revert must match exactly.
+    pub generation: u64,
 }
 
 // ── AdvertBus ─────────────────────────────────────────────────────────────────
+
+/// Storage backing an [`AdvertBus`], unified under one lock so the record
+/// map and the Meshtastic `node_num` reverse index can never be observed or
+/// mutated out of sync with each other.
+struct AdvertBusInner {
+    records: HashMap<[u8; 32], AdvertRecord>,
+    /// Meshtastic only: `node_num -> pubkey`, since `record_node_advert`
+    /// keys records by the node's real pubkey when known (falling back to a
+    /// synthetic one only otherwise) and `try_protect_node` only ever has
+    /// `node_num` to look up with.
+    node_num_index: HashMap<u32, [u8; 32]>,
+}
 
 /// Shared bus: stores received adverts and routes send-advert requests.
 ///
@@ -59,7 +306,7 @@ pub struct AdvertRecord {
 ///   [`request_send`](AdvertBus::request_send) when the sysop hits the
 ///   "send advert" button.
 pub struct AdvertBus {
-    records: Mutex<HashMap<[u8; 32], AdvertRecord>>,
+    inner: Mutex<AdvertBusInner>,
     send_tx: broadcast::Sender<bool>,
 }
 
@@ -72,7 +319,10 @@ impl Default for AdvertBus {
 impl std::fmt::Debug for AdvertBus {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("AdvertBus")
-            .field("record_count", &self.records.lock().map_or(0, |r| r.len()))
+            .field(
+                "record_count",
+                &self.inner.lock().map_or(0, |i| i.records.len()),
+            )
             .finish_non_exhaustive()
     }
 }
@@ -82,7 +332,10 @@ impl AdvertBus {
     pub fn new() -> Self {
         let (send_tx, _) = broadcast::channel(8);
         Self {
-            records: Mutex::new(HashMap::new()),
+            inner: Mutex::new(AdvertBusInner {
+                records: HashMap::new(),
+                node_num_index: HashMap::new(),
+            }),
             send_tx,
         }
     }
@@ -102,17 +355,11 @@ impl AdvertBus {
         let now = unix_now();
         let lat = gps_lat as f64 / 1_000_000.0;
         let lon = gps_lon as f64 / 1_000_000.0;
-        let mut records = self.records.lock().expect("advert bus poisoned");
-        let entry = records.entry(pubkey).or_insert_with(|| AdvertRecord {
-            pubkey_hex: hex_encode(&pubkey),
-            name: String::new(),
-            adv_type: 0,
-            lat: 0.0,
-            lon: 0.0,
-            first_seen_secs: now,
-            last_seen_secs: now,
-            transport: transport.to_owned(),
-        });
+        let mut inner = self.inner.lock().expect("advert bus poisoned");
+        let entry = inner
+            .records
+            .entry(pubkey)
+            .or_insert_with(|| new_record(pubkey, now, transport));
         entry.name = name;
         entry.adv_type = adv_type;
         entry.lat = lat;
@@ -146,31 +393,14 @@ impl AdvertBus {
         transport: &str,
     ) {
         let now = unix_now();
-        // Accept only plausible Unix timestamps. Devices without a synced RTC
-        // report seconds-since-boot which are tiny (→ dates near 1970); devices
-        // with a misconfigured clock can exceed the current time by years.
-        // 2020-01-01 UTC is a safe floor — no BBS contact predates MeshCore.
-        // 5-minute ceiling fudge tolerates minor clock skew between devices.
-        const MIN_PLAUSIBLE_TS: i64 = 1_577_836_800; // 2020-01-01 00:00:00 UTC
-        const CLOCK_FUDGE_SECS: i64 = 300; // 5 minutes
-        let last_seen =
-            if device_last_seen >= MIN_PLAUSIBLE_TS && device_last_seen <= now + CLOCK_FUDGE_SECS {
-                device_last_seen
-            } else {
-                now
-            };
+        let last_seen = plausible_timestamp(device_last_seen, now);
         let lat = gps_lat as f64 / 1_000_000.0;
         let lon = gps_lon as f64 / 1_000_000.0;
-        let mut records = self.records.lock().expect("advert bus poisoned");
-        let entry = records.entry(pubkey).or_insert_with(|| AdvertRecord {
-            pubkey_hex: hex_encode(&pubkey),
-            name: String::new(),
-            adv_type: 0,
-            lat: 0.0,
-            lon: 0.0,
-            first_seen_secs: now,
-            last_seen_secs: last_seen,
-            transport: transport.to_owned(),
+        let mut inner = self.inner.lock().expect("advert bus poisoned");
+        let entry = inner.records.entry(pubkey).or_insert_with(|| {
+            let mut r = new_record(pubkey, now, transport);
+            r.last_seen_secs = last_seen;
+            r
         });
         entry.name = name;
         entry.adv_type = adv_type;
@@ -190,52 +420,437 @@ impl AdvertBus {
     /// name, type, or location. Creates a minimal stub if unseen.
     pub fn upsert_short(&self, pubkey: [u8; 32], transport: &str) {
         let now = unix_now();
-        let mut records = self.records.lock().expect("advert bus poisoned");
-        records
+        let mut inner = self.inner.lock().expect("advert bus poisoned");
+        inner
+            .records
             .entry(pubkey)
             .and_modify(|e| {
                 e.last_seen_secs = now;
                 e.transport = transport.to_owned();
             })
-            .or_insert_with(|| AdvertRecord {
-                pubkey_hex: hex_encode(&pubkey),
-                name: String::new(),
-                adv_type: 0,
-                lat: 0.0,
-                lon: 0.0,
-                first_seen_secs: now,
-                last_seen_secs: now,
-                transport: transport.to_owned(),
-            });
+            .or_insert_with(|| new_record(pubkey, now, transport));
+    }
+
+    /// Insert or update a full MeshCore contact record — the sole ingest path
+    /// for `Contact`/`NewAdvert` frames, replacing `upsert`/`upsert_with_timestamp`
+    /// for those two call sites (which carry per-contact detail `upsert`
+    /// itself never captured: cached flags, routing path, device timestamps).
+    ///
+    /// Sets `has_full_record = true`. `flags` is the device's own full
+    /// `Contact.flags` byte (not just bit 0) — the bus preserves whatever
+    /// non-protect bits the device has set, merging only bit 0 against local
+    /// grace-window state so a racing stale sync can't silently revert an
+    /// unconfirmed local protect (or resurrect a just-deleted contact).
+    #[allow(clippy::too_many_arguments)]
+    pub fn upsert_contact(
+        &self,
+        pubkey: [u8; 32],
+        name: String,
+        adv_type: u8,
+        gps_lat: i32,
+        gps_lon: i32,
+        device_last_seen: i64,
+        flags: u8,
+        last_advert_timestamp: u32,
+        lastmod: u32,
+        out_path: Vec<u8>,
+        out_path_len: i8,
+        transport: &str,
+    ) {
+        let now = unix_now();
+        let now_u64 = now.max(0) as u64;
+        let last_seen = plausible_timestamp(device_last_seen, now);
+        let lat = gps_lat as f64 / 1_000_000.0;
+        let lon = gps_lon as f64 / 1_000_000.0;
+        let mut inner = self.inner.lock().expect("advert bus poisoned");
+        let already_existed = inner.records.contains_key(&pubkey);
+        let entry = inner
+            .records
+            .entry(pubkey)
+            .or_insert_with(|| new_record(pubkey, now, transport));
+        entry.name = name;
+        entry.adv_type = adv_type;
+        entry.lat = lat;
+        entry.lon = lon;
+        entry.transport = transport.to_owned();
+        if last_seen > entry.last_seen_secs {
+            entry.last_seen_secs = last_seen;
+        }
+        entry.has_full_record = true;
+        // Same plausibility clamp as `last_seen_secs` above — a device
+        // without a synced RTC reports this as boot-relative (near-zero)
+        // too, and it shares the same wire origin (Decision 4a).
+        entry.last_advert_timestamp =
+            plausible_timestamp(i64::from(last_advert_timestamp), now) as u32;
+        entry.lastmod = lastmod;
+        entry.out_path = out_path;
+        entry.out_path_len = out_path_len;
+
+        let previous_bit = entry.flags & 1 != 0;
+        let incoming_bit = flags & 1 != 0;
+        let merged_bit = merge_protected_bit(
+            incoming_bit,
+            entry.protected_at,
+            entry.unprotected_at,
+            now_u64,
+        );
+        entry.flags = (flags & !1) | u8::from(merged_bit);
+        if merged_bit != previous_bit {
+            entry.generation += 1;
+            // Found by audit (round-4, phase4 hostile QA persona — the same
+            // gap exists here as in upsert_meshtastic_node, see that
+            // function's matching comment for the full round-2 fix
+            // explanation): mirror protect_record/unprotect_locked's own
+            // field-setting, but ONLY on a brand-new record's first-ever
+            // sync (Decision 7 rehydration), never on an already-tracked
+            // record's later merge-driven flip — doing it unconditionally
+            // (round-1 fix) accidentally granted passive device reports a
+            // grace-window priority they were never meant to have.
+            if !already_existed && merged_bit {
+                entry.protected_at = Some(now_u64);
+                entry.unprotected_at = None;
+            } else if !already_existed {
+                entry.protected_at = None;
+                entry.unprotected_at = Some(now_u64);
+            }
+        }
+    }
+
+    /// Insert or update a full Meshtastic node record — the sole ingest path
+    /// for `record_node_advert`. Also records the `node_num -> pubkey`
+    /// mapping used by the `*_by_node_num` methods below, in the same lock
+    /// scope as the record update.
+    ///
+    /// `is_favorite`: `Some(v)` applies the same grace-window merge
+    /// `upsert_contact` uses (only the connect-time full-sync path has a
+    /// genuine device-reported bit); `None` leaves `flags` untouched
+    /// entirely (the live `PORT_NODEINFO_APP` path carries no such bit —
+    /// passing `Some(false)` there would silently un-protect a node on its
+    /// own next routine self-announce).
+    ///
+    /// Returns `true` only if `node_num` already mapped to a *different*
+    /// pubkey (a real identity change, e.g. a re-flashed device) — not the
+    /// ordinary first-sighting or same-pubkey-reupserted cases. Callers use
+    /// this to know whether a pending-protect retry needs to be re-armed for
+    /// the corrected identity.
+    #[allow(clippy::too_many_arguments)]
+    pub fn upsert_meshtastic_node(
+        &self,
+        pubkey: [u8; 32],
+        node_num: u32,
+        name: String,
+        role: u8,
+        gps_lat: i32,
+        gps_lon: i32,
+        is_favorite: Option<bool>,
+        transport: &str,
+    ) -> bool {
+        let now = unix_now();
+        let now_u64 = now.max(0) as u64;
+        let lat = gps_lat as f64 / 1_000_000.0;
+        let lon = gps_lon as f64 / 1_000_000.0;
+        let mut inner = self.inner.lock().expect("advert bus poisoned");
+
+        let identity_changed = matches!(
+            inner.node_num_index.get(&node_num),
+            Some(existing) if *existing != pubkey
+        );
+        inner.node_num_index.insert(node_num, pubkey);
+
+        let already_existed = inner.records.contains_key(&pubkey);
+        let entry = inner
+            .records
+            .entry(pubkey)
+            .or_insert_with(|| new_record(pubkey, now, transport));
+        entry.name = name;
+        entry.adv_type = role;
+        entry.lat = lat;
+        entry.lon = lon;
+        entry.transport = transport.to_owned();
+        entry.last_seen_secs = now;
+        entry.has_full_record = true;
+        entry.node_num = Some(node_num);
+
+        if let Some(is_favorite) = is_favorite {
+            let previous_bit = entry.flags & 1 != 0;
+            let merged_bit = merge_protected_bit(
+                is_favorite,
+                entry.protected_at,
+                entry.unprotected_at,
+                now_u64,
+            );
+            entry.flags = u8::from(merged_bit);
+            if merged_bit != previous_bit {
+                entry.generation += 1;
+                // Found by audit (round-4, phase4 hostile QA persona,
+                // .audit/persist-mesh-contacts-2026-09-02-phase4/repros/
+                // rehydrated_favorite_eviction_order_repro): mirror
+                // protect_record/unprotect_locked's own field-setting —
+                // but ONLY on a brand-new record's first-ever sync
+                // (Decision 7 rehydration, e.g. right after a BBS restart),
+                // never on an already-tracked record's later merge-driven
+                // flip. Round-2 fix (Phase 4 audit's Skeptic pass, executed
+                // repro): setting these unconditionally on every flip
+                // accidentally grants an ordinary passive device report a
+                // fresh `PROTECT_GRACE_SECS` grace-window priority it was
+                // never meant to have — a second, genuinely fresher
+                // contradicting report from the SAME device shortly after
+                // would then be silently discarded by `merge_protected_bit`,
+                // contradicting Decision 12a's "a genuine later external
+                // change still eventually takes effect." Without this
+                // `already_existed` gate, a device-rehydrated favorite's
+                // `protected_at` stays `None` forever instead, so
+                // `decide_favourite`'s eviction-candidate
+                // `min_by_key(|r| r.protected_at.unwrap_or(0))` treats it as
+                // the OLDEST protected record — making a long-standing,
+                // device-confirmed favorite the FIRST thing evicted once the
+                // cap is reached, backwards from intent.
+                if !already_existed && merged_bit {
+                    entry.protected_at = Some(now_u64);
+                    entry.unprotected_at = None;
+                } else if !already_existed {
+                    entry.protected_at = None;
+                    entry.unprotected_at = Some(now_u64);
+                }
+            }
+        }
+
+        identity_changed
+    }
+
+    /// Attempt to protect a MeshCore record by pubkey, enforcing the
+    /// per-transport protected-contact cap.
+    ///
+    /// `is_eligible` classifies `adv_type` (chat/person vs. repeater/room
+    /// on MeshCore, device role on Meshtastic). `protected_cap` is the
+    /// configured maximum number of simultaneously-protected contacts for
+    /// this record's transport. `exclude_prefixes` (6-byte pubkey prefixes)
+    /// names contacts with an active BBS session right now — never chosen
+    /// as an eviction candidate, mirroring
+    /// [`stalest_pubkey_excluding`](Self::stalest_pubkey_excluding)'s own
+    /// exclusion contract.
+    ///
+    /// See [`FavouriteOutcome`] for the full outcome contract, and
+    /// `specs/001-persist-mesh-contacts/research.md` Decisions 0 and 5b for
+    /// the underlying design.
+    pub fn mark_favourite_if_eligible(
+        &self,
+        pubkey: [u8; 32],
+        is_eligible: impl Fn(u8) -> bool,
+        protected_cap: usize,
+        exclude_prefixes: &[[u8; 6]],
+    ) -> FavouriteOutcome {
+        let mut inner = self.inner.lock().expect("advert bus poisoned");
+        decide_favourite(
+            &mut inner,
+            pubkey,
+            is_eligible,
+            protected_cap,
+            exclude_prefixes,
+        )
+    }
+
+    /// The Meshtastic, `node_num`-keyed sibling of
+    /// [`mark_favourite_if_eligible`](Self::mark_favourite_if_eligible) —
+    /// resolves `node_num` to a pubkey via the reverse index under the same
+    /// lock (never re-acquiring it), then delegates to the identical
+    /// decision logic. `try_protect_node` MUST call this rather than the
+    /// pubkey-keyed method directly: a node with a real Curve25519 key is
+    /// stored under that key, not `synthetic_pubkey(node_num)`, so a naive
+    /// direct lookup would see "no record" for the common case.
+    pub fn mark_favourite_if_eligible_by_node_num(
+        &self,
+        node_num: u32,
+        is_eligible: impl Fn(u8) -> bool,
+        protected_cap: usize,
+        exclude_prefixes: &[[u8; 6]],
+    ) -> FavouriteOutcome {
+        let mut inner = self.inner.lock().expect("advert bus poisoned");
+        let Some(&pubkey) = inner.node_num_index.get(&node_num) else {
+            return FavouriteOutcome::NoRecordYet;
+        };
+        decide_favourite(
+            &mut inner,
+            pubkey,
+            is_eligible,
+            protected_cap,
+            exclude_prefixes,
+        )
+    }
+
+    /// Clear local protected state for `pubkey` — a manual delete (sysop
+    /// action) or the caller's own choice to stop treating this contact as
+    /// permanent. Sets `unprotected_at` (guards against a stale device sync
+    /// silently re-raising the bit before the radio applies a native
+    /// removal). Returns the pre-clear record (needed by the caller to know
+    /// which native removal command to send), or `None` if the pubkey is
+    /// unknown or was already unprotected.
+    ///
+    /// Does not touch the radio — sending the native removal command is the
+    /// caller's responsibility.
+    pub fn unprotect(&self, pubkey: &[u8; 32]) -> Option<AdvertRecord> {
+        let mut inner = self.inner.lock().expect("advert bus poisoned");
+        let now = unix_now_u64();
+        unprotect_locked(&mut inner, pubkey, now)
+    }
+
+    /// Revert a local protect commit that never actually reached the radio
+    /// (a synchronously-detected send failure, or a connection dropping
+    /// before a queued write could flush) — clears `flags` bit 0 and
+    /// `protected_at`, but only if `record.generation` still equals
+    /// `expected_generation`, so a different, later protect on the same
+    /// pubkey is never clobbered. A no-op if the pubkey is unknown or the
+    /// generation has since moved on.
+    pub fn revert_protect(&self, pubkey: &[u8; 32], expected_generation: u64) {
+        let mut inner = self.inner.lock().expect("advert bus poisoned");
+        revert_protect_locked(&mut inner, pubkey, expected_generation);
+    }
+
+    /// The Meshtastic, `node_num`-keyed sibling of
+    /// [`revert_protect`](Self::revert_protect).
+    pub fn revert_protect_by_node_num(&self, node_num: u32, expected_generation: u64) {
+        let mut inner = self.inner.lock().expect("advert bus poisoned");
+        let Some(&pubkey) = inner.node_num_index.get(&node_num) else {
+            return;
+        };
+        revert_protect_locked(&mut inner, &pubkey, expected_generation);
+    }
+
+    /// Fresh re-check of whether `pubkey` is currently protected, applying
+    /// the same grace-window rule every other reader uses. Used immediately
+    /// before sending a native removal command (radio-side eviction or
+    /// delete) to close the TOCTOU window between selecting/deciding on a
+    /// removal and actually sending it — a concurrently-landed protect for
+    /// the same identity must not be silently undone.
+    pub fn is_currently_favourited(&self, pubkey: &[u8; 32]) -> bool {
+        let inner = self.inner.lock().expect("advert bus poisoned");
+        let now = unix_now_u64();
+        inner
+            .records
+            .get(pubkey)
+            .is_some_and(|r| is_effectively_protected(r, now))
+    }
+
+    /// Return the `node_num` that currently owns `pubkey` in the reverse
+    /// index, if any — the inverse of [`pubkey_by_node_num`](Self::pubkey_by_node_num).
+    ///
+    /// Meshtastic's `record_node_advert` uses this to reject identity
+    /// hijacking: a reported real (non-synthetic) `public_key` that already
+    /// belongs to a *different* `node_num` is treated as spoofed the same
+    /// way a synthetic-namespace collision already is (found by audit —
+    /// the original synthetic-namespace-only check left real-key replay
+    /// unguarded: an attacker broadcasting a victim's genuine public key
+    /// under their own `node_num` would otherwise overwrite the victim's
+    /// `AdvertRecord.node_num`, corrupting which physical device a later
+    /// eviction/removal command targets).
+    pub fn node_num_owning_pubkey(&self, pubkey: &[u8; 32]) -> Option<u32> {
+        let inner = self.inner.lock().expect("advert bus poisoned");
+        inner.records.get(pubkey).and_then(|r| r.node_num)
+    }
+
+    /// The Meshtastic, `node_num`-keyed sibling of
+    /// [`is_currently_favourited`](Self::is_currently_favourited).
+    pub fn is_currently_favourited_by_node_num(&self, node_num: u32) -> bool {
+        let inner = self.inner.lock().expect("advert bus poisoned");
+        let now = unix_now_u64();
+        inner
+            .node_num_index
+            .get(&node_num)
+            .and_then(|pk| inner.records.get(pk))
+            .is_some_and(|r| is_effectively_protected(r, now))
+    }
+
+    /// Resolve `node_num` to its currently-known full 32-byte pubkey (real
+    /// Curve25519 key, or `synthetic_pubkey(node_num)` if none has been
+    /// reported yet), via the same reverse index
+    /// [`mark_favourite_if_eligible_by_node_num`](Self::mark_favourite_if_eligible_by_node_num)
+    /// uses. Meshtastic's `try_protect_node` needs this to build a correct
+    /// eviction-exclusion prefix list from its active sessions' `node_num`s
+    /// (`crates/bbs-meshtastic/src/lib.rs`) — a session's own pubkey isn't
+    /// cached locally the way MeshCore's is, since Meshtastic sessions are
+    /// keyed purely by `node_num`.
+    pub fn pubkey_by_node_num(&self, node_num: u32) -> Option<[u8; 32]> {
+        let inner = self.inner.lock().expect("advert bus poisoned");
+        inner.node_num_index.get(&node_num).copied()
     }
 
     /// Return all records sorted by `last_seen_secs` descending (newest first).
     pub fn list(&self) -> Vec<AdvertRecord> {
-        let records = self.records.lock().expect("advert bus poisoned");
-        let mut v: Vec<_> = records.values().cloned().collect();
+        let inner = self.inner.lock().expect("advert bus poisoned");
+        let mut v: Vec<_> = inner.records.values().cloned().collect();
         v.sort_by_key(|r| std::cmp::Reverse(r.last_seen_secs));
         v
     }
 
-    /// Return the full 32-byte public key of the least-recently-seen contact
-    /// whose key prefix (first 6 bytes) does not appear in `exclude_prefixes`.
+    /// [`list`](Self::list), filtered to currently-protected records — backs
+    /// the web UI's "Contacts" view (as distinct from "Discovered Contacts",
+    /// which shows everything via `list`).
+    pub fn list_protected(&self) -> Vec<AdvertRecord> {
+        let inner = self.inner.lock().expect("advert bus poisoned");
+        let now = unix_now_u64();
+        let mut v: Vec<_> = inner
+            .records
+            .values()
+            .filter(|r| is_effectively_protected(r, now))
+            .cloned()
+            .collect();
+        v.sort_by_key(|r| std::cmp::Reverse(r.last_seen_secs));
+        v
+    }
+
+    /// Return the full 32-byte public key of the least-recently-seen,
+    /// currently-unprotected contact whose key prefix (first 6 bytes) does
+    /// not appear in `exclude_prefixes`, restricted to `transport`.
     ///
-    /// Used by the mesh transport to pick a stale contact for eviction when
-    /// the radio's contact table is full (`ContactsFull` push): the caller
-    /// can then send `RemoveContact` for the returned key to free a table slot.
+    /// Used by each transport's own `ContactsFull`-equivalent handler to
+    /// pick a stale contact for eviction when the radio's contact table is
+    /// full: the caller can then send a native removal for the returned key
+    /// to free a table slot. Never returns a protected record (protection
+    /// exists specifically to survive this kind of eviction) or one from a
+    /// different transport (`AdvertBus` is shared across both, keyed by
+    /// pubkey/synthetic-pubkey in the same map).
     ///
-    /// Returns `None` if the bus is empty or all contacts match an excluded
-    /// prefix (e.g. all known contacts have active BBS sessions).
-    pub fn stalest_pubkey_excluding(&self, exclude_prefixes: &[[u8; 6]]) -> Option<[u8; 32]> {
-        let records = self.records.lock().expect("advert bus poisoned");
-        records
+    /// Returns `None` if nothing on `transport` is both non-excluded and
+    /// currently unprotected.
+    pub fn stalest_pubkey_excluding(
+        &self,
+        exclude_prefixes: &[[u8; 6]],
+        transport: &str,
+    ) -> Option<[u8; 32]> {
+        let inner = self.inner.lock().expect("advert bus poisoned");
+        let now = unix_now_u64();
+        inner
+            .records
             .iter()
-            .filter(|(pubkey, _)| {
-                let prefix: [u8; 6] = pubkey[..6].try_into().expect("pubkey is 32 bytes");
-                !exclude_prefixes.contains(&prefix)
+            .filter(|(pubkey, rec)| {
+                rec.transport == transport
+                    && !exclude_prefixes.contains(&prefix6(pubkey))
+                    && !is_effectively_protected(rec, now)
             })
             .min_by_key(|(_, rec)| rec.last_seen_secs)
             .map(|(pubkey, _)| *pubkey)
+    }
+
+    /// Diagnostic query for `transport`'s `ContactsFull`-equivalent handler:
+    /// `true` only if there is at least one non-excluded record on
+    /// `transport` and every one of them is currently protected — i.e. the
+    /// specific reason [`stalest_pubkey_excluding`](Self::stalest_pubkey_excluding)
+    /// returned `None` was "all favourited," distinct from "nothing known"
+    /// or "everything session-excluded." Never changes eviction behavior.
+    pub fn all_remaining_favourited(&self, exclude_prefixes: &[[u8; 6]], transport: &str) -> bool {
+        let inner = self.inner.lock().expect("advert bus poisoned");
+        let now = unix_now_u64();
+        let mut saw_any = false;
+        for (pubkey, rec) in inner.records.iter() {
+            if rec.transport != transport || exclude_prefixes.contains(&prefix6(pubkey)) {
+                continue;
+            }
+            saw_any = true;
+            if !is_effectively_protected(rec, now) {
+                return false;
+            }
+        }
+        saw_any
     }
 
     /// Look up the human-readable node name for a given 6-byte key prefix.
@@ -243,8 +858,9 @@ impl AdvertBus {
     /// Returns `None` if the prefix is not in the bus or if its name field is
     /// empty (i.e. only a short advert has been received so far).
     pub fn name_by_prefix(&self, prefix: &[u8; 6]) -> Option<String> {
-        let records = self.records.lock().expect("advert bus poisoned");
-        records
+        let inner = self.inner.lock().expect("advert bus poisoned");
+        inner
+            .records
             .iter()
             .find(|(pubkey, _)| pubkey[..6] == *prefix)
             .and_then(|(_, r)| {
@@ -256,12 +872,65 @@ impl AdvertBus {
             })
     }
 
-    /// Remove all records from the bus.
+    /// Look up the full 32-byte public key for a given 6-byte key prefix,
+    /// restricted to `transport` (the bus is shared across both transports'
+    /// pubkey/synthetic-pubkey spaces in the same map, so an unscoped lookup
+    /// risks resolving a session on one transport to a record from the
+    /// other).
     ///
-    /// Useful when a sysop wants to flush stale data without restarting the
-    /// BBS (e.g. after correcting device clocks or clearing old contacts).
-    pub fn clear(&self) {
-        self.records.lock().expect("advert bus poisoned").clear();
+    /// Seeds a brand-new session's cached full pubkey from an already-known
+    /// `AdvertBus` record, so a sender whose full contact record predates
+    /// their first-ever DM to the BBS is still protectable on that first
+    /// message rather than only from the second one onward. Called from
+    /// MeshCore's `get_or_create_session` (both its new-session slow path
+    /// and its stale-session-refresh path — see
+    /// `crates/bbs-mesh/src/transport.rs`); Meshtastic's equivalent call
+    /// site lands in a later phase.
+    pub fn full_pubkey_by_prefix(&self, prefix: &[u8; 6], transport: &str) -> Option<[u8; 32]> {
+        let inner = self.inner.lock().expect("advert bus poisoned");
+        inner
+            .records
+            .iter()
+            .find(|(pubkey, rec)| pubkey[..6] == *prefix && rec.transport == transport)
+            .map(|(pubkey, _)| *pubkey)
+    }
+
+    /// Remove all *unprotected* records from the bus — protected records
+    /// (`flags & 1 != 0`) survive this call, along with their `node_num`
+    /// mappings.
+    ///
+    /// Useful when a sysop wants to flush stale, never-messaged discovered
+    /// contacts without restarting the BBS (e.g. after correcting device
+    /// clocks). **BLOCKING fix, round 19**: an earlier version of this
+    /// method (`clear()`) unconditionally wiped the *entire* bus, including
+    /// every currently-protected contact's `flags`/`protected_at`/
+    /// `has_full_record`/`node_num` — directly violating FR-007's "once
+    /// protected, stays protected" guarantee, since "Contacts" and
+    /// "Discovered Contacts" share this same storage. The BBS's own
+    /// `ContactsFull` eviction handler would then see a just-wiped
+    /// protected contact as an ordinary, evictable candidate and could
+    /// issue a real removal against it before the next full resync
+    /// rehydrates the bit — the exact repeater-flood/`ContactsFull` failure
+    /// this feature exists to survive, self-inflicted by a pre-existing
+    /// maintenance button (see specs/001-persist-mesh-contacts/research.md
+    /// Decision 14).
+    ///
+    /// Returns the number of records removed, for callers that want to
+    /// report it (e.g. an audit-log entry).
+    pub fn clear_unprotected(&self) -> usize {
+        let mut inner = self.inner.lock().expect("advert bus poisoned");
+        let now = unix_now_u64();
+        let to_remove: Vec<[u8; 32]> = inner
+            .records
+            .iter()
+            .filter(|(_, r)| !is_effectively_protected(r, now))
+            .map(|(pk, _)| *pk)
+            .collect();
+        for pk in &to_remove {
+            inner.records.remove(pk);
+        }
+        inner.node_num_index.retain(|_, pk| !to_remove.contains(pk));
+        to_remove.len()
     }
 
     /// Subscribe to send-advert requests from the web UI.
@@ -282,12 +951,191 @@ impl AdvertBus {
     }
 }
 
+// ── Protection decision core (lock already held) ────────────────────────────
+
+/// The actual protect-or-not decision, callable while holding a single
+/// already-acquired lock on `AdvertBusInner` — no separate check-then-act
+/// sequence, so there is no window for a concurrent caller to observe or
+/// create an inconsistent intermediate state.
+fn decide_favourite(
+    inner: &mut AdvertBusInner,
+    pubkey: [u8; 32],
+    is_eligible: impl Fn(u8) -> bool,
+    protected_cap: usize,
+    exclude_prefixes: &[[u8; 6]],
+) -> FavouriteOutcome {
+    let now = unix_now_u64();
+
+    let (has_full_record, effectively_protected, adv_type, transport) = {
+        let Some(record) = inner.records.get(&pubkey) else {
+            return FavouriteOutcome::NoRecordYet;
+        };
+        (
+            record.has_full_record,
+            is_effectively_protected(record, now),
+            record.adv_type,
+            record.transport.clone(),
+        )
+    };
+
+    if !has_full_record {
+        return FavouriteOutcome::NoRecordYet;
+    }
+    if effectively_protected {
+        return FavouriteOutcome::AlreadyProtected;
+    }
+    // `is_eligible` is caller-supplied and runs while `inner`'s lock is held;
+    // a panicking classifier must not poison the whole bus (every reader
+    // uses `.expect("advert bus poisoned")` with no recovery). Safe to catch
+    // here specifically: nothing in `inner` has been mutated yet at this
+    // point, so a caught panic leaves no partially-applied state behind.
+    let eligible =
+        match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| is_eligible(adv_type))) {
+            Ok(eligible) => eligible,
+            Err(_) => return FavouriteOutcome::Ineligible,
+        };
+    if !eligible {
+        return FavouriteOutcome::Ineligible;
+    }
+
+    // A cap of 0 means "never protect on this transport" — never attempt an
+    // evict-to-make-room here, or a single already-protected record would
+    // perpetually be evicted and replaced, capping at 1 instead of 0.
+    if protected_cap == 0 {
+        return FavouriteOutcome::CapReached;
+    }
+
+    let protected_count = inner
+        .records
+        .values()
+        .filter(|r| r.transport == transport && is_effectively_protected(r, now))
+        .count();
+
+    if protected_count < protected_cap {
+        return FavouriteOutcome::Protected(protect_record(inner, pubkey, now));
+    }
+
+    // Cap reached: find the oldest-protected, currently-evictable candidate
+    // on the same transport (never the record we're about to protect,
+    // never an active session, never something protected too recently to
+    // safely evict).
+    let victim_pubkey = inner
+        .records
+        .iter()
+        .filter(|(pk, r)| {
+            **pk != pubkey
+                && r.transport == transport
+                && is_effectively_protected(r, now)
+                && !exclude_prefixes.contains(&prefix6(pk))
+                && !r.protected_at.is_some_and(|t| within_grace(t, now))
+        })
+        .min_by_key(|(_, r)| r.protected_at.unwrap_or(0))
+        .map(|(pk, _)| *pk);
+
+    let Some(victim_pubkey) = victim_pubkey else {
+        return FavouriteOutcome::CapReached;
+    };
+
+    let victim_before = unprotect_locked(inner, &victim_pubkey, now)
+        .expect("victim_pubkey was just selected from currently-protected records");
+
+    let snapshot = protect_record(inner, pubkey, now);
+    FavouriteOutcome::ProtectedWithEviction(snapshot, victim_pubkey, Box::new(victim_before))
+}
+
+/// Transition `pubkey`'s record to protected (caller has already confirmed
+/// it exists, is eligible, and there is room for it) and return the
+/// snapshot needed to build the outbound protect frame. Always succeeds —
+/// callers wrap the result in the appropriate `FavouriteOutcome` variant
+/// themselves rather than this function returning one, so there is no
+/// spurious non-`Protected` case for a caller to (mis)handle after it may
+/// have already committed an eviction.
+fn protect_record(inner: &mut AdvertBusInner, pubkey: [u8; 32], now: u64) -> FavouriteSnapshot {
+    let record = inner
+        .records
+        .get_mut(&pubkey)
+        .expect("caller already confirmed this record exists");
+    record.flags |= 1;
+    record.protected_at = Some(now);
+    record.unprotected_at = None;
+    record.generation += 1;
+    FavouriteSnapshot {
+        pubkey,
+        name: record.name.clone(),
+        adv_type: record.adv_type,
+        lat: record.lat,
+        lon: record.lon,
+        last_advert_timestamp: record.last_advert_timestamp,
+        lastmod: record.lastmod,
+        out_path: record.out_path.clone(),
+        out_path_len: record.out_path_len,
+        flags: record.flags,
+        protected_at: now,
+        generation: record.generation,
+    }
+}
+
+/// Clear protected state for `pubkey` if it is currently (effectively)
+/// protected; returns the pre-clear record. `None` if unknown or already
+/// unprotected. Shared by [`AdvertBus::unprotect`] (manual delete) and
+/// [`decide_favourite`]'s own cap-eviction path — one clearing
+/// implementation, not two.
+fn unprotect_locked(
+    inner: &mut AdvertBusInner,
+    pubkey: &[u8; 32],
+    now: u64,
+) -> Option<AdvertRecord> {
+    let record = inner.records.get_mut(pubkey)?;
+    if !is_effectively_protected(record, now) {
+        return None;
+    }
+    let before = record.clone();
+    record.flags &= !1;
+    record.protected_at = None;
+    record.unprotected_at = Some(now);
+    record.generation += 1;
+    Some(before)
+}
+
+fn revert_protect_locked(inner: &mut AdvertBusInner, pubkey: &[u8; 32], expected_generation: u64) {
+    if let Some(record) = inner.records.get_mut(pubkey) {
+        if record.generation == expected_generation {
+            record.flags &= !1;
+            record.protected_at = None;
+            record.generation += 1;
+        }
+    }
+}
+
 // ── Helpers ───────────────────────────────────────────────────────────────────
+
+// Accept only plausible Unix timestamps. Devices without a synced RTC
+// report seconds-since-boot which are tiny (→ dates near 1970); devices
+// with a misconfigured clock can exceed the current time by years.
+// 2020-01-01 UTC is a safe floor — no BBS contact predates MeshCore.
+// 5-minute ceiling fudge tolerates minor clock skew between devices.
+const MIN_PLAUSIBLE_TS: i64 = 1_577_836_800; // 2020-01-01 00:00:00 UTC
+const CLOCK_FUDGE_SECS: i64 = 300; // 5 minutes
+
+/// Validate a device-reported timestamp, falling back to `now` if implausible.
+fn plausible_timestamp(device_reported: i64, now: i64) -> i64 {
+    if device_reported >= MIN_PLAUSIBLE_TS && device_reported <= now + CLOCK_FUDGE_SECS {
+        device_reported
+    } else {
+        now
+    }
+}
 
 fn unix_now() -> i64 {
     SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .map_or(0, |d| d.as_secs() as i64)
+}
+
+fn unix_now_u64() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_or(0, |d| d.as_secs())
 }
 
 fn hex_encode(bytes: &[u8]) -> String {
@@ -310,6 +1158,14 @@ mod tests {
         SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .map_or(0, |d| d.as_secs() as i64)
+    }
+
+    fn always_eligible(_adv_type: u8) -> bool {
+        true
+    }
+
+    fn never_eligible(_adv_type: u8) -> bool {
+        false
     }
 
     /// A device timestamp of 0 (unset) falls back to wall-clock time.
@@ -376,14 +1232,41 @@ mod tests {
         assert_eq!(ts, plausible, "plausible ts should be stored unchanged");
     }
 
-    /// `clear()` empties the bus.
+    /// `clear_unprotected()` empties the bus of unprotected records.
     #[test]
-    fn clear_empties_bus() {
+    fn clear_unprotected_empties_bus_of_unprotected_records() {
         let bus = AdvertBus::new();
         bus.upsert(dummy_key(5), "E".into(), 1, 0, 0, "meshcore");
         assert_eq!(bus.list().len(), 1);
-        bus.clear();
+        bus.clear_unprotected();
         assert_eq!(bus.list().len(), 0);
+    }
+
+    /// T038d (round-19 BLOCKING fix): a protected record must survive
+    /// `clear_unprotected()` — the whole point of the rename from `clear()`.
+    #[test]
+    fn clear_unprotected_preserves_protected_records() {
+        let bus = AdvertBus::new();
+        let protected_key = dummy_key(112);
+        let unprotected_key = dummy_key(113);
+        seed_meshcore_contact(&bus, protected_key);
+        seed_meshcore_contact(&bus, unprotected_key);
+        assert!(matches!(
+            bus.mark_favourite_if_eligible(protected_key, always_eligible, 350, &[]),
+            FavouriteOutcome::Protected(_)
+        ));
+
+        bus.clear_unprotected();
+
+        assert!(
+            bus.is_currently_favourited(&protected_key),
+            "a protected record must survive clear_unprotected()"
+        );
+        assert_eq!(
+            bus.list().len(),
+            1,
+            "the unprotected record must be removed, leaving only the protected one"
+        );
     }
 
     /// `stalest_pubkey_excluding` returns the oldest contact not in the exclusion list.
@@ -426,7 +1309,7 @@ mod tests {
         );
 
         let excluded_prefix: [u8; 6] = excluded_key[..6].try_into().unwrap();
-        let result = bus.stalest_pubkey_excluding(&[excluded_prefix]);
+        let result = bus.stalest_pubkey_excluding(&[excluded_prefix], "meshcore");
 
         assert_eq!(
             result,
@@ -442,14 +1325,39 @@ mod tests {
         let key = dummy_key(11);
         bus.upsert(key, "A".into(), 1, 0, 0, "meshcore");
         let prefix: [u8; 6] = key[..6].try_into().unwrap();
-        assert_eq!(bus.stalest_pubkey_excluding(&[prefix]), None);
+        assert_eq!(bus.stalest_pubkey_excluding(&[prefix], "meshcore"), None);
     }
 
     /// An empty bus returns `None`.
     #[test]
     fn stalest_pubkey_excluding_empty_bus_returns_none() {
         let bus = AdvertBus::new();
-        assert_eq!(bus.stalest_pubkey_excluding(&[]), None);
+        assert_eq!(bus.stalest_pubkey_excluding(&[], "meshcore"), None);
+    }
+
+    /// `stalest_pubkey_excluding` never returns a record from the other transport,
+    /// and never returns a protected record.
+    #[test]
+    fn stalest_pubkey_excluding_is_transport_and_protection_scoped() {
+        let bus = AdvertBus::new();
+        let meshcore_key = dummy_key(50);
+        let meshtastic_key = dummy_key(51);
+        seed_meshcore_contact(&bus, meshcore_key);
+        bus.upsert_meshtastic_node(meshtastic_key, 1, "MT".into(), 0, 0, 0, None, "meshtastic");
+
+        assert_eq!(
+            bus.stalest_pubkey_excluding(&[], "meshcore"),
+            Some(meshcore_key)
+        );
+        assert_eq!(
+            bus.stalest_pubkey_excluding(&[], "meshtastic"),
+            Some(meshtastic_key)
+        );
+
+        // Protect the meshcore contact — it must stop being a candidate.
+        let outcome = bus.mark_favourite_if_eligible(meshcore_key, always_eligible, 350, &[]);
+        assert!(matches!(outcome, FavouriteOutcome::Protected(_)));
+        assert_eq!(bus.stalest_pubkey_excluding(&[], "meshcore"), None);
     }
 
     /// The transport name is stored and surfaced via `list()`.
@@ -469,5 +1377,838 @@ mod tests {
             bus.list().iter().any(|r| r.transport == "meshtastic"),
             "short advert should carry its transport"
         );
+    }
+
+    /// T038a: `list_protected()` returns only currently-protected records,
+    /// as a subset of `list()`.
+    #[test]
+    fn list_protected_returns_only_protected_records() {
+        let bus = AdvertBus::new();
+        let protected_key = dummy_key(115);
+        let unprotected_key = dummy_key(116);
+        seed_meshcore_contact(&bus, protected_key);
+        bus.upsert(unprotected_key, "U".into(), 1, 0, 0, "meshcore");
+        assert!(matches!(
+            bus.mark_favourite_if_eligible(protected_key, always_eligible, 350, &[]),
+            FavouriteOutcome::Protected(_)
+        ));
+
+        assert_eq!(bus.list().len(), 2);
+        let protected = bus.list_protected();
+        assert_eq!(protected.len(), 1);
+        assert_eq!(protected[0].pubkey_hex, hex_encode(&protected_key));
+    }
+
+    /// Phase 5 hostile-audit regression (Extractor pass): `AdvertRecord::
+    /// is_currently_protected` must agree with `list_protected()`'s own
+    /// filter for the same record, so a caller reading via plain `list()`
+    /// (e.g. the web admin API's "Discovered Contacts" view) can't disagree
+    /// with what `list_protected()` ("Contacts") reports for the identical
+    /// record.
+    #[test]
+    fn advert_record_is_currently_protected_matches_list_protected() {
+        let bus = AdvertBus::new();
+        let protected_key = dummy_key(117);
+        let unprotected_key = dummy_key(118);
+        seed_meshcore_contact(&bus, protected_key);
+        bus.upsert(unprotected_key, "U".into(), 1, 0, 0, "meshcore");
+        assert!(matches!(
+            bus.mark_favourite_if_eligible(protected_key, always_eligible, 350, &[]),
+            FavouriteOutcome::Protected(_)
+        ));
+
+        let all = bus.list();
+        let protected_record = all
+            .iter()
+            .find(|r| r.pubkey_hex == hex_encode(&protected_key))
+            .unwrap();
+        let unprotected_record = all
+            .iter()
+            .find(|r| r.pubkey_hex == hex_encode(&unprotected_key))
+            .unwrap();
+        assert!(protected_record.is_currently_protected());
+        assert!(!unprotected_record.is_currently_protected());
+    }
+
+    // ── FavouriteOutcome / decide_favourite ─────────────────────────────────
+
+    fn seed_meshcore_contact(bus: &AdvertBus, key: [u8; 32]) {
+        bus.upsert_contact(
+            key,
+            "Test".into(),
+            1, // eligible adv_type
+            0,
+            0,
+            now_secs(),
+            0b0000_0110, // non-zero upper bits, to confirm they survive protection
+            0,
+            0,
+            Vec::new(),
+            -1,
+            "meshcore",
+        );
+    }
+
+    /// Push `key`'s `protected_at` back outside `PROTECT_GRACE_SECS`, so
+    /// tests can simulate "protected a while ago" without actually sleeping.
+    /// White-box access to `AdvertBus::inner` — valid since `mod tests` is a
+    /// child of this module.
+    fn backdate_protected_at(bus: &AdvertBus, key: &[u8; 32]) {
+        let mut inner = bus.inner.lock().expect("advert bus poisoned");
+        let record = inner.records.get_mut(key).expect("record must exist");
+        assert!(record.protected_at.is_some(), "record must be protected");
+        record.protected_at = Some(unix_now_u64().saturating_sub(PROTECT_GRACE_SECS + 1));
+    }
+
+    /// [`backdate_protected_at`]'s sibling for `unprotected_at`, so tests can
+    /// simulate "unprotected a while ago" without sleeping.
+    fn backdate_unprotected_at(bus: &AdvertBus, key: &[u8; 32]) {
+        let mut inner = bus.inner.lock().expect("advert bus poisoned");
+        let record = inner.records.get_mut(key).expect("record must exist");
+        assert!(
+            record.unprotected_at.is_some(),
+            "record must be unprotected"
+        );
+        record.unprotected_at = Some(unix_now_u64().saturating_sub(PROTECT_GRACE_SECS + 1));
+    }
+
+    #[test]
+    fn no_record_yet_before_full_record() {
+        let bus = AdvertBus::new();
+        let key = dummy_key(60);
+        bus.upsert_short(key, "meshcore");
+        assert_eq!(
+            bus.mark_favourite_if_eligible(key, always_eligible, 350, &[]),
+            FavouriteOutcome::NoRecordYet
+        );
+    }
+
+    #[test]
+    fn unknown_pubkey_is_no_record_yet() {
+        let bus = AdvertBus::new();
+        assert_eq!(
+            bus.mark_favourite_if_eligible(dummy_key(61), always_eligible, 350, &[]),
+            FavouriteOutcome::NoRecordYet
+        );
+    }
+
+    #[test]
+    fn ineligible_record_is_never_protected() {
+        let bus = AdvertBus::new();
+        let key = dummy_key(62);
+        seed_meshcore_contact(&bus, key);
+        assert_eq!(
+            bus.mark_favourite_if_eligible(key, never_eligible, 350, &[]),
+            FavouriteOutcome::Ineligible
+        );
+    }
+
+    #[test]
+    fn protects_eligible_full_record_preserving_upper_flag_bits() {
+        let bus = AdvertBus::new();
+        let key = dummy_key(63);
+        seed_meshcore_contact(&bus, key);
+        let outcome = bus.mark_favourite_if_eligible(key, always_eligible, 350, &[]);
+        let FavouriteOutcome::Protected(snapshot) = outcome else {
+            panic!("expected Protected, got {outcome:?}");
+        };
+        assert_eq!(snapshot.flags & 1, 1, "protect bit must be set");
+        assert_eq!(
+            snapshot.flags & 0b0000_0110,
+            0b0000_0110,
+            "device's own upper flag bits must survive protection"
+        );
+        assert!(bus.is_currently_favourited(&key));
+    }
+
+    #[test]
+    fn already_protected_is_not_reprotected() {
+        let bus = AdvertBus::new();
+        let key = dummy_key(64);
+        seed_meshcore_contact(&bus, key);
+        assert!(matches!(
+            bus.mark_favourite_if_eligible(key, always_eligible, 350, &[]),
+            FavouriteOutcome::Protected(_)
+        ));
+        assert_eq!(
+            bus.mark_favourite_if_eligible(key, always_eligible, 350, &[]),
+            FavouriteOutcome::AlreadyProtected
+        );
+    }
+
+    #[test]
+    fn cap_reached_evicts_oldest_protected_contact() {
+        let bus = AdvertBus::new();
+        let old_key = dummy_key(70);
+        let new_key = dummy_key(71);
+        seed_meshcore_contact(&bus, old_key);
+        seed_meshcore_contact(&bus, new_key);
+
+        let outcome = bus.mark_favourite_if_eligible(old_key, always_eligible, 1, &[]);
+        assert!(matches!(outcome, FavouriteOutcome::Protected(_)));
+        backdate_protected_at(&bus, &old_key);
+
+        let outcome = bus.mark_favourite_if_eligible(new_key, always_eligible, 1, &[]);
+        let FavouriteOutcome::ProtectedWithEviction(snapshot, evicted_pubkey, evicted) = outcome
+        else {
+            panic!("expected ProtectedWithEviction, got {outcome:?}");
+        };
+        assert_eq!(snapshot.pubkey, new_key);
+        assert_eq!(evicted_pubkey, old_key);
+        assert_eq!(evicted.pubkey_hex, hex_encode(&old_key));
+        assert!(bus.is_currently_favourited(&new_key));
+        assert!(!bus.is_currently_favourited(&old_key));
+    }
+
+    #[test]
+    fn cap_reached_skips_active_session_and_grace_window_candidates() {
+        let bus = AdvertBus::new();
+        let session_key = dummy_key(72);
+        let fresh_key = dummy_key(73);
+        let evictable_key = dummy_key(74);
+        let new_key = dummy_key(75);
+        seed_meshcore_contact(&bus, session_key);
+        seed_meshcore_contact(&bus, fresh_key);
+        seed_meshcore_contact(&bus, evictable_key);
+        seed_meshcore_contact(&bus, new_key);
+
+        // Protect three contacts, filling a cap of 3.
+        assert!(matches!(
+            bus.mark_favourite_if_eligible(evictable_key, always_eligible, 3, &[]),
+            FavouriteOutcome::Protected(_)
+        ));
+        assert!(matches!(
+            bus.mark_favourite_if_eligible(session_key, always_eligible, 3, &[]),
+            FavouriteOutcome::Protected(_)
+        ));
+        assert!(matches!(
+            bus.mark_favourite_if_eligible(fresh_key, always_eligible, 3, &[]),
+            FavouriteOutcome::Protected(_)
+        ));
+        // Age session_key and evictable_key out of their own grace windows —
+        // only fresh_key stays "just protected." session_key must still be
+        // skipped (active session); evictable_key is the sole valid target.
+        backdate_protected_at(&bus, &session_key);
+        backdate_protected_at(&bus, &evictable_key);
+
+        let session_prefix: [u8; 6] = session_key[..6].try_into().unwrap();
+        // fresh_key was *just* protected, so it's within PROTECT_GRACE_SECS;
+        // session_key is excluded as an active session — only evictable_key
+        // (protected first, so oldest) remains a valid candidate.
+        let outcome =
+            bus.mark_favourite_if_eligible(new_key, always_eligible, 3, &[session_prefix]);
+        let FavouriteOutcome::ProtectedWithEviction(_, evicted_pubkey, evicted) = outcome else {
+            panic!("expected ProtectedWithEviction, got {outcome:?}");
+        };
+        assert_eq!(evicted_pubkey, evictable_key);
+        assert_eq!(evicted.pubkey_hex, hex_encode(&evictable_key));
+        assert!(bus.is_currently_favourited(&session_key));
+        assert!(bus.is_currently_favourited(&fresh_key));
+    }
+
+    #[test]
+    fn cap_reached_with_nothing_evictable_returns_cap_reached() {
+        let bus = AdvertBus::new();
+        let session_key = dummy_key(76);
+        let new_key = dummy_key(77);
+        seed_meshcore_contact(&bus, session_key);
+        seed_meshcore_contact(&bus, new_key);
+
+        assert!(matches!(
+            bus.mark_favourite_if_eligible(session_key, always_eligible, 1, &[]),
+            FavouriteOutcome::Protected(_)
+        ));
+
+        let session_prefix: [u8; 6] = session_key[..6].try_into().unwrap();
+        let outcome =
+            bus.mark_favourite_if_eligible(new_key, always_eligible, 1, &[session_prefix]);
+        assert_eq!(outcome, FavouriteOutcome::CapReached);
+        assert!(!bus.is_currently_favourited(&new_key));
+        // The session-excluded contact must remain untouched.
+        assert!(bus.is_currently_favourited(&session_key));
+    }
+
+    /// Audit regression (2026-09-02, finding M5): a cap of exactly 0 must
+    /// mean "never protect," not "cap at 1 via evict-and-reprotect."
+    #[test]
+    fn zero_cap_never_protects_even_via_eviction() {
+        let bus = AdvertBus::new();
+        let already_protected = dummy_key(103);
+        let new_key = dummy_key(104);
+        seed_meshcore_contact(&bus, already_protected);
+        seed_meshcore_contact(&bus, new_key);
+
+        // Get one contact protected under a normal cap first...
+        assert!(matches!(
+            bus.mark_favourite_if_eligible(already_protected, always_eligible, 1, &[]),
+            FavouriteOutcome::Protected(_)
+        ));
+        backdate_protected_at(&bus, &already_protected);
+
+        // ...then confirm a cap of 0 refuses to evict it to make room for
+        // a new contact (the pre-fix behavior would have evicted
+        // `already_protected` and protected `new_key` instead, capping at
+        // 1 rather than 0).
+        assert_eq!(
+            bus.mark_favourite_if_eligible(new_key, always_eligible, 0, &[]),
+            FavouriteOutcome::CapReached
+        );
+        assert!(bus.is_currently_favourited(&already_protected));
+        assert!(!bus.is_currently_favourited(&new_key));
+    }
+
+    /// Audit regression (2026-09-02, finding H1): a panicking `is_eligible`
+    /// closure must not poison the bus — every other call must keep working
+    /// afterward.
+    #[test]
+    fn panicking_is_eligible_does_not_poison_the_bus() {
+        let bus = AdvertBus::new();
+        let key = dummy_key(105);
+        seed_meshcore_contact(&bus, key);
+
+        let outcome = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            bus.mark_favourite_if_eligible(key, |_| panic!("boom"), 350, &[])
+        }));
+        assert!(
+            outcome.is_ok(),
+            "a panicking classifier must not unwind out of mark_favourite_if_eligible"
+        );
+        assert_eq!(outcome.unwrap(), FavouriteOutcome::Ineligible);
+
+        // The bus must still be fully usable — not poisoned.
+        let FavouriteOutcome::Protected(snapshot) =
+            bus.mark_favourite_if_eligible(key, always_eligible, 350, &[])
+        else {
+            panic!("expected Protected — the bus should not have been poisoned by the panic above");
+        };
+        assert_eq!(snapshot.pubkey, key);
+        assert_eq!(snapshot.flags & 1, 1);
+        assert!(bus.is_currently_favourited(&key));
+    }
+
+    /// Audit regression (2026-09-02, finding M4): a device-sync merge that
+    /// actually changes the protected bit must bump `generation` too, not
+    /// just `flags` — otherwise a `revert_protect`/`revert_protect_by_node_num`
+    /// generation token from before the sync could still match after it.
+    #[test]
+    fn device_sync_bumps_generation_when_it_changes_the_bit() {
+        let bus = AdvertBus::new();
+        let key = dummy_key(106);
+        seed_meshcore_contact(&bus, key);
+        let FavouriteOutcome::Protected(snapshot) =
+            bus.mark_favourite_if_eligible(key, always_eligible, 350, &[])
+        else {
+            panic!("expected Protected");
+        };
+        let generation_after_protect = snapshot.generation;
+        backdate_protected_at(&bus, &key);
+
+        // A resync now genuinely reporting unprotected (well outside the
+        // grace window) must both clear the bit AND advance generation.
+        bus.upsert_contact(
+            key,
+            "Test".into(),
+            1,
+            0,
+            0,
+            now_secs(),
+            0,
+            0,
+            0,
+            Vec::new(),
+            -1,
+            "meshcore",
+        );
+        assert!(!bus.is_currently_favourited(&key));
+
+        // A revert carrying the OLD (pre-sync) generation must now be a
+        // no-op — the sync already changed state out from under it.
+        bus.revert_protect(&key, generation_after_protect);
+        assert!(
+            !bus.is_currently_favourited(&key),
+            "a stale-generation revert must not resurrect a state the device sync already changed"
+        );
+
+        // A fresh protect must succeed normally afterward.
+        assert!(matches!(
+            bus.mark_favourite_if_eligible(key, always_eligible, 350, &[]),
+            FavouriteOutcome::Protected(_)
+        ));
+    }
+
+    /// Phase 4 hostile-audit regression (Hostile QA persona, executed
+    /// repro): a device-rehydrated favorite (Decision 7 — the device's own
+    /// full-record sync already reports it as favorited, so `upsert_contact`
+    /// merges the bit without ever going through `decide_favourite`/
+    /// `protect_record`) must get a real `protected_at`, not `None`. Before
+    /// the fix, `None` sorted as the *oldest possible* eviction candidate
+    /// (`unwrap_or(0)`), making a long-standing, device-confirmed favorite
+    /// the FIRST thing evicted once the cap is reached — backwards from a
+    /// FIFO-by-`protected_at` eviction policy's intent, and defeating
+    /// FR-007's "protection survives a restart" guarantee under cap
+    /// pressure specifically.
+    #[test]
+    fn device_rehydrated_favorite_gets_a_protected_at_not_treated_as_ancient() {
+        let bus = AdvertBus::new();
+        let rehydrated_key = dummy_key(108);
+        let older_key = dummy_key(109);
+        let new_key = dummy_key(110);
+
+        // `older_key` is protected the normal way, then backdated so it is
+        // genuinely the oldest protection.
+        seed_meshcore_contact(&bus, older_key);
+        assert!(matches!(
+            bus.mark_favourite_if_eligible(older_key, always_eligible, 2, &[]),
+            FavouriteOutcome::Protected(_)
+        ));
+        backdate_protected_at(&bus, &older_key);
+
+        // `rehydrated_key` becomes protected purely via a device-reported
+        // favorite bit on its first-ever sync (e.g. right after a BBS
+        // restart) — decide_favourite/protect_record are never called.
+        bus.upsert_contact(
+            rehydrated_key,
+            "Rehydrated".into(),
+            1,
+            0,
+            0,
+            now_secs(),
+            1, // flags bit 0 set: device reports this contact as favorited
+            0,
+            0,
+            Vec::new(),
+            -1,
+            "meshcore",
+        );
+        assert!(bus.is_currently_favourited(&rehydrated_key));
+
+        let rehydrated_record = bus
+            .list()
+            .into_iter()
+            .find(|r| r.pubkey_hex == hex_encode(&rehydrated_key))
+            .expect("rehydrated record exists");
+        assert!(
+            rehydrated_record.protected_at.is_some(),
+            "a device-rehydrated favorite must get a real protected_at, not None"
+        );
+
+        // Cap is now full (2/2). A third contact must evict the genuinely
+        // older `older_key`, not the just-rehydrated `rehydrated_key`.
+        seed_meshcore_contact(&bus, new_key);
+        let outcome = bus.mark_favourite_if_eligible(new_key, always_eligible, 2, &[]);
+        let FavouriteOutcome::ProtectedWithEviction(_, evicted_pubkey, _) = outcome else {
+            panic!("expected ProtectedWithEviction, got {outcome:?}");
+        };
+        assert_eq!(
+            evicted_pubkey, older_key,
+            "the genuinely older protection must be evicted, not the just-rehydrated favorite"
+        );
+    }
+
+    /// Phase 4 hostile-audit regression (Skeptic pass, executed repro,
+    /// overturning the round-1 version of the fix above): a merge-driven
+    /// bit flip on an ALREADY-TRACKED record (not a brand-new,
+    /// just-rehydrated one) must NOT plant a `protected_at`/`unprotected_at`
+    /// grace-window token — doing so would let an ordinary passive device
+    /// report silently grant itself 5 minutes of immunity from the very
+    /// next, genuinely fresher contradicting report from the same device,
+    /// contradicting Decision 12a's "a genuine later external change still
+    /// eventually takes effect."
+    #[test]
+    fn passive_resync_flip_on_existing_record_grants_no_grace_window() {
+        let bus = AdvertBus::new();
+        let key = dummy_key(111);
+        seed_meshcore_contact(&bus, key); // record already exists, unprotected
+
+        // The device reports this contact favorited (no local protect() call
+        // involved at all — purely a passive resync).
+        bus.upsert_contact(
+            key,
+            "Test".into(),
+            1,
+            0,
+            0,
+            now_secs(),
+            1,
+            0,
+            0,
+            Vec::new(),
+            -1,
+            "meshcore",
+        );
+        assert!(bus.is_currently_favourited(&key));
+
+        // Moments later (still well inside PROTECT_GRACE_SECS), the SAME
+        // device reports it unfavorited again. This must take effect
+        // immediately — it must not be discarded as "too soon after a
+        // recent protect."
+        bus.upsert_contact(
+            key,
+            "Test".into(),
+            1,
+            0,
+            0,
+            now_secs(),
+            0,
+            0,
+            0,
+            Vec::new(),
+            -1,
+            "meshcore",
+        );
+        assert!(
+            !bus.is_currently_favourited(&key),
+            "a fresher passive resync must not be discarded by a grace window \
+             the previous passive resync should never have been granted"
+        );
+    }
+
+    /// Audit regression (2026-09-02, finding M3): `clear()` must also drop
+    /// stale `node_num_index` entries, not just `records`. Updated for
+    /// T038d's `clear()` → `clear_unprotected()` rename/refilter: the
+    /// record here is deliberately left unprotected, since a protected
+    /// one's index entry is now expected to survive (see
+    /// `clear_unprotected_preserves_protected_records`).
+    #[test]
+    fn clear_unprotected_also_clears_node_num_index_for_removed_records() {
+        let bus = AdvertBus::new();
+        let key = dummy_key(107);
+        bus.upsert_meshtastic_node(key, 55, "MT".into(), 0, 0, 0, None, "meshtastic");
+
+        bus.clear_unprotected();
+
+        // With the index cleared, a lookup by the old node_num must find
+        // nothing at all — not resolve to a dangling pubkey.
+        assert_eq!(
+            bus.mark_favourite_if_eligible_by_node_num(55, always_eligible, 350, &[]),
+            FavouriteOutcome::NoRecordYet
+        );
+    }
+
+    /// T038d: a protected record's `node_num_index` entry must also survive
+    /// `clear_unprotected()`, not just its `records` entry.
+    #[test]
+    fn clear_unprotected_preserves_protected_node_num_index_entry() {
+        let bus = AdvertBus::new();
+        let key = dummy_key(114);
+        bus.upsert_meshtastic_node(key, 56, "MT".into(), 0, 0, 0, None, "meshtastic");
+        assert!(matches!(
+            bus.mark_favourite_if_eligible_by_node_num(56, always_eligible, 350, &[]),
+            FavouriteOutcome::Protected(_)
+        ));
+
+        bus.clear_unprotected();
+
+        assert!(
+            bus.is_currently_favourited_by_node_num(56),
+            "a protected node's node_num lookup must still resolve after clear_unprotected()"
+        );
+    }
+
+    /// Audit regression (2026-09-02, finding H2): `upsert_contact`'s
+    /// `last_advert_timestamp` must reject implausible device timestamps
+    /// the same way `last_seen_secs` already does — this field was
+    /// previously assigned unvalidated.
+    #[test]
+    fn upsert_contact_validates_last_advert_timestamp_too() {
+        let bus = AdvertBus::new();
+        let key = dummy_key(108);
+        let now = now_secs();
+
+        bus.upsert_contact(
+            key,
+            "Test".into(),
+            1,
+            0,
+            0,
+            now, // device_last_seen: plausible
+            0,
+            3600, // last_advert_timestamp: boot-relative, implausible
+            0,
+            Vec::new(),
+            -1,
+            "meshcore",
+        );
+
+        let record = bus
+            .list()
+            .into_iter()
+            .find(|r| r.pubkey_hex == hex_encode(&key))
+            .unwrap();
+        let ts = i64::from(record.last_advert_timestamp);
+        assert!(
+            ts >= now - 2 && ts <= now + 2,
+            "boot-relative last_advert_timestamp should have fallen back to now, got {ts}"
+        );
+    }
+
+    /// T010: `upsert_contact` applies the same device-timestamp plausibility
+    /// validation `upsert_with_timestamp` does — boot-relative and
+    /// far-future values are rejected in favor of wall-clock time.
+    #[test]
+    fn upsert_contact_rejects_implausible_device_timestamps() {
+        let bus = AdvertBus::new();
+        let boot_relative_key = dummy_key(100);
+        let far_future_key = dummy_key(101);
+        let now = now_secs();
+
+        bus.upsert_contact(
+            boot_relative_key,
+            "BootRelative".into(),
+            1,
+            0,
+            0,
+            3600, // 1 hour after epoch — clearly a boot-relative value
+            0,
+            0,
+            0,
+            Vec::new(),
+            -1,
+            "meshcore",
+        );
+        bus.upsert_contact(
+            far_future_key,
+            "FarFuture".into(),
+            1,
+            0,
+            0,
+            4_000_000_000, // ~year 2096
+            0,
+            0,
+            0,
+            Vec::new(),
+            -1,
+            "meshcore",
+        );
+
+        let by_key: std::collections::HashMap<String, i64> = bus
+            .list()
+            .into_iter()
+            .map(|r| (r.pubkey_hex.clone(), r.last_seen_secs))
+            .collect();
+
+        let boot_ts = by_key[&hex_encode(&boot_relative_key)];
+        let future_ts = by_key[&hex_encode(&far_future_key)];
+        assert!(
+            boot_ts >= now - 2 && boot_ts <= now + 2,
+            "boot-relative device timestamp should have fallen back to now"
+        );
+        assert!(
+            future_ts >= now - 2 && future_ts <= now + 2,
+            "far-future device timestamp should have fallen back to now"
+        );
+    }
+
+    /// T010a (research.md Decision 7a): a stale inbound sync racing an
+    /// unconfirmed local protect must not let eviction-exclusion see the
+    /// contact as unprotected during the grace window — and must go back to
+    /// trusting the wire data once that window has genuinely elapsed.
+    #[test]
+    fn stale_sync_does_not_defeat_eviction_exclusion_during_grace_window() {
+        let bus = AdvertBus::new();
+        let key = dummy_key(102);
+        seed_meshcore_contact(&bus, key);
+        assert!(matches!(
+            bus.mark_favourite_if_eligible(key, always_eligible, 350, &[]),
+            FavouriteOutcome::Protected(_)
+        ));
+
+        // A resync frame reporting the pre-protect (unfavourited) state
+        // arrives before the device has actually applied our write.
+        bus.upsert_contact(
+            key,
+            "Test".into(),
+            1,
+            0,
+            0,
+            now_secs(),
+            0, // reports unprotected
+            0,
+            0,
+            Vec::new(),
+            -1,
+            "meshcore",
+        );
+
+        // Still within PROTECT_GRACE_SECS: eviction must still exclude it,
+        // and a second DM must not trigger a redundant re-protect.
+        assert_eq!(bus.stalest_pubkey_excluding(&[], "meshcore"), None);
+        assert_eq!(
+            bus.mark_favourite_if_eligible(key, always_eligible, 350, &[]),
+            FavouriteOutcome::AlreadyProtected
+        );
+
+        // Once the grace window has genuinely elapsed, the device's report
+        // becomes authoritative again — a further sync now actually clears it.
+        backdate_protected_at(&bus, &key);
+        bus.upsert_contact(
+            key,
+            "Test".into(),
+            1,
+            0,
+            0,
+            now_secs(),
+            0,
+            0,
+            0,
+            Vec::new(),
+            -1,
+            "meshcore",
+        );
+        assert_eq!(
+            bus.stalest_pubkey_excluding(&[], "meshcore"),
+            Some(key),
+            "past the grace window, the device's own unfavourited report should take effect"
+        );
+    }
+
+    /// Phase 4 hostile-audit regression (Verifier, claim phase4A-6): the
+    /// `DeferredWrite::RemoveFavoriteNode`/`RemoveFavoriteNode` doc comments
+    /// cite `stale_sync_does_not_defeat_eviction_exclusion_during_grace_window`
+    /// as covering "a lost removal write, then a stale device sync
+    /// re-adopting favorited state" — but that test only exercises the
+    /// PROTECT-side grace window (a lost protect surviving a stale
+    /// unfavourited resync), not this, the opposite direction: a local
+    /// `unprotect()` whose native removal write never reached the radio,
+    /// followed by a device resync that still reports the old favorited
+    /// state. This test exercises that direction directly, closing the gap
+    /// the doc comment's citation overstated.
+    #[test]
+    fn lost_removal_write_lets_stale_favorited_resync_re_adopt_after_grace_window() {
+        let bus = AdvertBus::new();
+        let key = dummy_key(103);
+        seed_meshcore_contact(&bus, key);
+        assert!(matches!(
+            bus.mark_favourite_if_eligible(key, always_eligible, 350, &[]),
+            FavouriteOutcome::Protected(_)
+        ));
+
+        // The caller unprotects locally (e.g. eviction, or a manual
+        // delete) — the native removal write to the radio is assumed lost
+        // (channel full, or a disconnect before it flushed).
+        assert!(bus.unprotect(&key).is_some());
+        assert!(!bus.is_currently_favourited(&key));
+
+        // Still within the grace window: a resync still reporting the old
+        // favorited state must NOT re-adopt it (the local unprotect wins).
+        bus.upsert_contact(
+            key,
+            "Test".into(),
+            1,
+            0,
+            0,
+            now_secs(),
+            1, // device still reports favorited — hasn't applied our removal yet
+            0,
+            0,
+            Vec::new(),
+            -1,
+            "meshcore",
+        );
+        assert!(
+            !bus.is_currently_favourited(&key),
+            "within the grace window, the local unprotect must not be silently reversed"
+        );
+
+        // Once the grace window has genuinely elapsed, the device's report
+        // becomes authoritative again — this is Decision 12a's disclosed,
+        // accepted tradeoff, not a bug: a permanent latch would block
+        // legitimate external re-favoriting.
+        backdate_unprotected_at(&bus, &key);
+        bus.upsert_contact(
+            key,
+            "Test".into(),
+            1,
+            0,
+            0,
+            now_secs(),
+            1,
+            0,
+            0,
+            Vec::new(),
+            -1,
+            "meshcore",
+        );
+        assert!(
+            bus.is_currently_favourited(&key),
+            "past the grace window, a stale-but-still-favorited device report re-adopts protection"
+        );
+    }
+
+    #[test]
+    fn revert_protect_undoes_matching_generation_only() {
+        let bus = AdvertBus::new();
+        let key = dummy_key(80);
+        seed_meshcore_contact(&bus, key);
+        let outcome = bus.mark_favourite_if_eligible(key, always_eligible, 350, &[]);
+        let FavouriteOutcome::Protected(snapshot) = outcome else {
+            panic!("expected Protected");
+        };
+
+        // A stale revert (wrong generation) must not touch a newer state.
+        bus.revert_protect(&key, snapshot.generation.wrapping_sub(1));
+        assert!(bus.is_currently_favourited(&key));
+
+        // The matching generation reverts it.
+        bus.revert_protect(&key, snapshot.generation);
+        assert!(!bus.is_currently_favourited(&key));
+    }
+
+    #[test]
+    fn mark_favourite_by_node_num_resolves_through_reverse_index() {
+        let bus = AdvertBus::new();
+        let key = dummy_key(90);
+        bus.upsert_meshtastic_node(key, 42, "MT".into(), 0, 0, 0, None, "meshtastic");
+        let outcome = bus.mark_favourite_if_eligible_by_node_num(42, always_eligible, 100, &[]);
+        assert!(matches!(outcome, FavouriteOutcome::Protected(_)));
+        assert!(bus.is_currently_favourited_by_node_num(42));
+        assert_eq!(
+            bus.mark_favourite_if_eligible_by_node_num(999, always_eligible, 100, &[]),
+            FavouriteOutcome::NoRecordYet
+        );
+    }
+
+    #[test]
+    fn pubkey_by_node_num_resolves_through_reverse_index() {
+        let bus = AdvertBus::new();
+        let key = dummy_key(91);
+        assert_eq!(bus.pubkey_by_node_num(43), None);
+        bus.upsert_meshtastic_node(key, 43, "MT".into(), 0, 0, 0, None, "meshtastic");
+        assert_eq!(bus.pubkey_by_node_num(43), Some(key));
+        assert_eq!(bus.pubkey_by_node_num(999), None);
+    }
+
+    #[test]
+    fn unprotect_clears_state_and_is_idempotent() {
+        let bus = AdvertBus::new();
+        let key = dummy_key(91);
+        seed_meshcore_contact(&bus, key);
+        assert!(matches!(
+            bus.mark_favourite_if_eligible(key, always_eligible, 350, &[]),
+            FavouriteOutcome::Protected(_)
+        ));
+
+        let unprotected = bus.unprotect(&key);
+        assert!(unprotected.is_some());
+        assert!(!bus.is_currently_favourited(&key));
+
+        // A second unprotect finds nothing left to clear.
+        assert!(bus.unprotect(&key).is_none());
+    }
+
+    #[test]
+    fn all_remaining_favourited_distinguishes_reasons() {
+        let bus = AdvertBus::new();
+        assert!(!bus.all_remaining_favourited(&[], "meshcore"));
+
+        let key = dummy_key(92);
+        seed_meshcore_contact(&bus, key);
+        assert!(!bus.all_remaining_favourited(&[], "meshcore"));
+
+        assert!(matches!(
+            bus.mark_favourite_if_eligible(key, always_eligible, 350, &[]),
+            FavouriteOutcome::Protected(_)
+        ));
+        assert!(bus.all_remaining_favourited(&[], "meshcore"));
     }
 }

--- a/crates/bbs-plugin-api/src/host.rs
+++ b/crates/bbs-plugin-api/src/host.rs
@@ -45,6 +45,15 @@ pub enum MeshKeyRequest {
         /// One-shot channel to deliver the result back to the caller.
         reply: tokio::sync::oneshot::Sender<Result<(), String>>,
     },
+    /// Remove a contact from the device's own contact table — the native
+    /// removal half of the "Persist Mesh Contacts" delete/eviction flow
+    /// (`specs/001-persist-mesh-contacts/research.md` Decision 12).
+    RemoveContact {
+        /// Full 32-byte public key of the contact to remove.
+        pubkey: [u8; 32],
+        /// One-shot channel to deliver the result back to the caller.
+        reply: tokio::sync::oneshot::Sender<Result<(), String>>,
+    },
 }
 
 /// Request sent from [`Host`] to the Meshtastic transport's admin channel.
@@ -92,6 +101,18 @@ pub enum MeshtasticAdminRequest {
     Reboot {
         /// Seconds until reboot.
         seconds: i32,
+        /// One-shot channel to deliver the result back to the caller.
+        reply: tokio::sync::oneshot::Sender<Result<(), String>>,
+    },
+    /// Un-favorite a node — the native removal half of the "Persist Mesh
+    /// Contacts" delete/eviction flow
+    /// (`specs/001-persist-mesh-contacts/research.md` Decision 12). No-reply
+    /// on the wire (fire-and-forget, mirroring `set_favorite_node`), but this
+    /// admin-request variant still carries a `reply` so the caller can be
+    /// told the write was queued (or why it couldn't be).
+    RemoveFavoriteNode {
+        /// The Meshtastic node number to un-favorite.
+        node_num: u32,
         /// One-shot channel to deliver the result back to the caller.
         reply: tokio::sync::oneshot::Sender<Result<(), String>>,
     },
@@ -529,6 +550,23 @@ pub trait Host: Send + Sync {
         Err(HostError::NotSupported("admin_apply_mesh_radio".into()))
     }
 
+    /// Remove a contact from the connected MeshCore device's own contact
+    /// table. Best-effort, fire-and-forget on the wire — a failure here does
+    /// not undo the caller's own local `AdvertBus::unprotect`, which already
+    /// took effect before this was called (see
+    /// `specs/001-persist-mesh-contacts/research.md` Decision 12). If the
+    /// wire write itself is lost, though, a later device sync reporting the
+    /// contact as still-favourited *can* silently re-protect it once
+    /// `AdvertBus`'s grace window has elapsed — a disclosed, time-bounded
+    /// tradeoff (Decision 12a), not a claim that a lost write has zero
+    /// downstream effect.
+    async fn admin_remove_meshcore_contact(&self, pubkey: [u8; 32]) -> Result<(), HostError> {
+        let _ = pubkey;
+        Err(HostError::NotSupported(
+            "admin_remove_meshcore_contact".into(),
+        ))
+    }
+
     /// Register the Meshtastic transport's admin command channel.
     fn register_meshtastic_admin_ops(
         &self,
@@ -591,6 +629,23 @@ pub trait Host: Send + Sync {
     async fn admin_reboot_meshtastic(&self, seconds: i32) -> Result<(), HostError> {
         let _ = seconds;
         Err(HostError::NotSupported("admin_reboot_meshtastic".into()))
+    }
+
+    /// Un-favorite a node on the connected Meshtastic radio's own NodeDB.
+    /// Best-effort, fire-and-forget on the wire — a failure here does not
+    /// undo the caller's own local `AdvertBus::unprotect`, which already
+    /// took effect before this was called (see
+    /// `specs/001-persist-mesh-contacts/research.md` Decision 12). If the
+    /// wire write itself is lost, though, a later device sync reporting the
+    /// node as still-favorited *can* silently re-protect it once
+    /// `AdvertBus`'s grace window has elapsed — a disclosed, time-bounded
+    /// tradeoff (Decision 12a), not a claim that a lost write has zero
+    /// downstream effect.
+    async fn admin_remove_meshtastic_favorite(&self, node_num: u32) -> Result<(), HostError> {
+        let _ = node_num;
+        Err(HostError::NotSupported(
+            "admin_remove_meshtastic_favorite".into(),
+        ))
     }
 
     // ── Mesh node credentials ────────────────────────────────────────────────────

--- a/crates/bbs-plugin-api/src/lib.rs
+++ b/crates/bbs-plugin-api/src/lib.rs
@@ -56,7 +56,7 @@ pub use admin::{
     DeliverySampleRecord, MeshRadioParams, MeshtasticDeviceSnapshot, MeshtasticLoRaConfig,
     MeshtasticOwnerInfo, MeshtasticSecurityInfo,
 };
-pub use advert::{AdvertBus, AdvertRecord};
+pub use advert::{AdvertBus, AdvertRecord, FavouriteOutcome, FavouriteSnapshot};
 pub use command::{Command, Response, Secret};
 pub use error::{HostError, PluginError, TransportError};
 pub use event::{DomainEvent, MessageRecipient, Notification, NotifyOutcome};

--- a/crates/bbs-plugin-api/src/testing.rs
+++ b/crates/bbs-plugin-api/src/testing.rs
@@ -77,6 +77,15 @@ struct MockHostState {
     /// Artificial delay applied inside `process_command` before recording and
     /// responding, to exercise slow-host / backpressure paths. Zero by default.
     process_delay: Duration,
+    /// Every `admin_remove_meshcore_contact` call, in order — lets tests
+    /// verify the *correct* pubkey was passed, not just that a removal
+    /// error was swallowed (both the argument and whether it was called at
+    /// all are otherwise invisible to a caller that only inspects the HTTP
+    /// response, since this feature's own admin actions are best-effort).
+    removed_meshcore_contacts: Vec<[u8; 32]>,
+    /// Every `admin_remove_meshtastic_favorite` call, in order — same
+    /// rationale as `removed_meshcore_contacts`.
+    removed_meshtastic_favorites: Vec<u32>,
 }
 
 #[derive(Debug, Clone)]
@@ -117,6 +126,8 @@ impl MockHost {
                 default_response: Response::Text("(unscripted)".to_owned()),
                 commands_received: Vec::new(),
                 process_delay: Duration::ZERO,
+                removed_meshcore_contacts: Vec::new(),
+                removed_meshtastic_favorites: Vec::new(),
             }),
             events: tx,
             advert_bus: Arc::new(AdvertBus::new()),
@@ -194,6 +205,26 @@ impl MockHost {
         event: DomainEvent,
     ) -> Result<usize, broadcast::error::SendError<DomainEvent>> {
         self.events.send(event)
+    }
+
+    /// Every `admin_remove_meshcore_contact` pubkey passed so far, in order.
+    #[must_use]
+    pub fn removed_meshcore_contacts(&self) -> Vec<[u8; 32]> {
+        self.state
+            .lock()
+            .expect("mock poisoned")
+            .removed_meshcore_contacts
+            .clone()
+    }
+
+    /// Every `admin_remove_meshtastic_favorite` node_num passed so far, in order.
+    #[must_use]
+    pub fn removed_meshtastic_favorites(&self) -> Vec<u32> {
+        self.state
+            .lock()
+            .expect("mock poisoned")
+            .removed_meshtastic_favorites
+            .clone()
     }
 }
 
@@ -275,6 +306,34 @@ impl Host for MockHost {
 
     fn advert_bus(&self) -> Arc<AdvertBus> {
         Arc::clone(&self.advert_bus)
+    }
+
+    /// Records the pubkey and succeeds, unlike the trait's default
+    /// `NotSupported` body — so tests exercising a delete/removal flow can
+    /// assert the *correct* pubkey was actually passed via
+    /// [`MockHost::removed_meshcore_contacts`], not just that a removal
+    /// error was silently swallowed by a caller that only inspects the
+    /// HTTP-visible outcome (found by the Phase 6 hostile audit's Hostile
+    /// QA persona: the default `NotSupported` body made two removal tests
+    /// pass for the wrong reason).
+    async fn admin_remove_meshcore_contact(&self, pubkey: [u8; 32]) -> Result<(), HostError> {
+        self.state
+            .lock()
+            .expect("mock poisoned")
+            .removed_meshcore_contacts
+            .push(pubkey);
+        Ok(())
+    }
+
+    /// [`admin_remove_meshcore_contact`](Self::admin_remove_meshcore_contact)'s
+    /// Meshtastic sibling.
+    async fn admin_remove_meshtastic_favorite(&self, node_num: u32) -> Result<(), HostError> {
+        self.state
+            .lock()
+            .expect("mock poisoned")
+            .removed_meshtastic_favorites
+            .push(node_num);
+        Ok(())
     }
 }
 

--- a/crates/bbs-plugin-api/src/testing.rs
+++ b/crates/bbs-plugin-api/src/testing.rs
@@ -41,7 +41,7 @@ use crate::error::HostError;
 use crate::event::DomainEvent;
 use crate::identity::{SessionId, Username};
 use crate::permissions::{PermissionCtx, PermissionLevel};
-use crate::Host;
+use crate::{Host, MeshKeyRequest};
 
 /// Type alias for a command-matcher predicate. A boxed `Fn` so
 /// matchers can capture state.
@@ -86,6 +86,15 @@ struct MockHostState {
     /// Every `admin_remove_meshtastic_favorite` call, in order — same
     /// rationale as `removed_meshcore_contacts`.
     removed_meshtastic_favorites: Vec<u32>,
+    /// The MeshCore transport's key-ops channel, captured by
+    /// `register_mesh_key_ops` when a real transport (e.g. `MeshTransport`)
+    /// registers itself against this mock during a test. `None` until then.
+    /// Exposed via [`MockHost::mesh_key_tx`] so a test can send a
+    /// `MeshKeyRequest` (e.g. `RemoveContact`) directly into the transport's
+    /// own `key_rx` handler — the same channel `BbsHost::admin_remove_meshcore_contact`
+    /// routes through in production, unlike this mock's own short-circuiting
+    /// override of that method (which never touches this channel at all).
+    mesh_key_tx: Option<tokio::sync::mpsc::Sender<MeshKeyRequest>>,
 }
 
 #[derive(Debug, Clone)]
@@ -128,6 +137,7 @@ impl MockHost {
                 process_delay: Duration::ZERO,
                 removed_meshcore_contacts: Vec::new(),
                 removed_meshtastic_favorites: Vec::new(),
+                mesh_key_tx: None,
             }),
             events: tx,
             advert_bus: Arc::new(AdvertBus::new()),
@@ -226,6 +236,22 @@ impl MockHost {
             .removed_meshtastic_favorites
             .clone()
     }
+
+    /// The MeshCore transport's key-ops channel, if a real transport has
+    /// called `register_mesh_key_ops` against this mock (e.g. after
+    /// `MeshTransport::start`). Lets a test drive `key_rx`'s handler
+    /// directly — send a `MeshKeyRequest` here and await its `reply` —
+    /// exercising the real transport-level TOCTOU re-checks that this
+    /// mock's own `admin_remove_meshcore_contact` override bypasses
+    /// entirely (it short-circuits and never touches this channel).
+    #[must_use]
+    pub fn mesh_key_tx(&self) -> Option<tokio::sync::mpsc::Sender<MeshKeyRequest>> {
+        self.state
+            .lock()
+            .expect("mock poisoned")
+            .mesh_key_tx
+            .clone()
+    }
 }
 
 #[async_trait]
@@ -306,6 +332,14 @@ impl Host for MockHost {
 
     fn advert_bus(&self) -> Arc<AdvertBus> {
         Arc::clone(&self.advert_bus)
+    }
+
+    /// Stores the sender, unlike the trait's default no-op body — so a test
+    /// starting a real transport (e.g. `MeshTransport::start`) against this
+    /// mock can retrieve it via [`MockHost::mesh_key_tx`] and drive the
+    /// transport's `key_rx` handler directly.
+    fn register_mesh_key_ops(&self, sender: tokio::sync::mpsc::Sender<MeshKeyRequest>) {
+        self.state.lock().expect("mock poisoned").mesh_key_tx = Some(sender);
     }
 
     /// Records the pubkey and succeeds, unlike the trait's default

--- a/crates/bbs-web/src/lib.rs
+++ b/crates/bbs-web/src/lib.rs
@@ -621,6 +621,8 @@ fn build_router(state: Arc<AppState>) -> Router {
         .route("/adverts", get(api_adverts))
         .route("/adverts", delete(api_adverts_clear))
         .route("/adverts/send", post(api_adverts_send))
+        .route("/contacts", get(api_contacts))
+        .route("/contacts/:pubkey", delete(api_delete_contact))
         .route("/sessions", get(api_list_sessions))
         .route("/sessions/:id", delete(api_kill_session))
         .route("/users", get(api_list_users))
@@ -1117,34 +1119,160 @@ struct AdvertResponse {
     lat: f64,
     lon: f64,
     transport: String,
+    protected: bool,
 }
 
+fn to_advert_response(r: bbs_plugin_api::AdvertRecord) -> AdvertResponse {
+    let protected = r.is_currently_protected();
+    AdvertResponse {
+        ts: r.last_seen_secs,
+        pubkey: r.pubkey_hex,
+        name: r.name,
+        adv_type: r.adv_type,
+        type_name: adv_type_name(&r.transport, r.adv_type).to_owned(),
+        lat: r.lat,
+        lon: r.lon,
+        protected,
+        transport: r.transport,
+    }
+}
+
+/// `GET /api/v1/adverts` — "Discovered Contacts": every record the bus has
+/// ever seen, protected or not.
 async fn api_adverts(State(state): State<Arc<AppState>>) -> impl IntoResponse {
     let records = state.host.advert_bus().list();
-    let out: Vec<AdvertResponse> = records
-        .into_iter()
-        .map(|r| AdvertResponse {
-            ts: r.last_seen_secs,
-            pubkey: r.pubkey_hex,
-            name: r.name,
-            adv_type: r.adv_type,
-            type_name: adv_type_name(&r.transport, r.adv_type).to_owned(),
-            lat: r.lat,
-            lon: r.lon,
-            transport: r.transport,
-        })
-        .collect();
+    let out: Vec<AdvertResponse> = records.into_iter().map(to_advert_response).collect();
     Json(out)
 }
 
-/// `DELETE /api/v1/adverts` — flush all in-memory advert records.
+/// `GET /api/v1/contacts` — "Contacts": only currently-protected records.
+async fn api_contacts(State(state): State<Arc<AppState>>) -> impl IntoResponse {
+    let records = state.host.advert_bus().list_protected();
+    let out: Vec<AdvertResponse> = records.into_iter().map(to_advert_response).collect();
+    Json(out)
+}
+
+/// Decode a hex pubkey (as emitted by `AdvertResponse.pubkey`, always
+/// lowercase, though this function itself accepts either case since
+/// `is_ascii_hexdigit`/`from_str_radix` both do) back into the raw 32 bytes
+/// `AdvertBus` keys records by. `None` for anything not exactly 64 valid
+/// hex characters.
+fn decode_pubkey_hex(s: &str) -> Option<[u8; 32]> {
+    // `u8::from_str_radix` accepts a leading `+` for unsigned types (e.g.
+    // "+1" parses as 1), which isn't a hex digit — reject anything that
+    // isn't purely `[0-9a-fA-F]` up front (found by audit) so this
+    // function's contract ("64 valid hex characters") actually holds.
+    if s.len() != 64 || !s.bytes().all(|b| b.is_ascii_hexdigit()) {
+        return None;
+    }
+    let mut out = [0u8; 32];
+    for (i, chunk) in s.as_bytes().chunks(2).enumerate() {
+        let byte_str = std::str::from_utf8(chunk).ok()?;
+        out[i] = u8::from_str_radix(byte_str, 16).ok()?;
+    }
+    Some(out)
+}
+
+/// `DELETE /api/v1/contacts/:pubkey` — manually delete a single protected
+/// contact.
 ///
-/// Useful after correcting device clocks or clearing stale contacts.
-/// The bus repopulates automatically as adverts arrive or on the next
-/// BBS reconnect (which triggers a fresh `GetContacts` scan).
-async fn api_adverts_clear(State(state): State<Arc<AppState>>) -> impl IntoResponse {
-    state.host.advert_bus().clear();
-    axum::http::StatusCode::NO_CONTENT
+/// Clears local protection immediately (`AdvertBus::unprotect`) and
+/// best-effort attempts the matching native radio-side removal for the
+/// record's transport. A removal failure is logged but does not fail the
+/// request — the local unprotect has already succeeded, matching this
+/// feature's existing best-effort framing for the delete direction
+/// (specs/001-persist-mesh-contacts/research.md Decision 12). Aide access
+/// required (permission level >= 50) — a new precedent for this crate
+/// (Decision 11).
+async fn api_delete_contact(
+    State(state): State<Arc<AppState>>,
+    Extension(caller): Extension<CurrentUser>,
+    Path(pubkey_hex): Path<String>,
+) -> Response {
+    if caller.permission_level < 50 {
+        return (
+            StatusCode::FORBIDDEN,
+            Json(json_error("aide access required")),
+        )
+            .into_response();
+    }
+    let Some(pubkey) = decode_pubkey_hex(&pubkey_hex) else {
+        return (StatusCode::BAD_REQUEST, Json(json_error("invalid pubkey"))).into_response();
+    };
+    let Some(record) = state.host.advert_bus().unprotect(&pubkey) else {
+        return (
+            StatusCode::NOT_FOUND,
+            Json(json_error("contact not found or not protected")),
+        )
+            .into_response();
+    };
+
+    // Use the record's own canonical (always-lowercase, `hex_encode`-produced)
+    // pubkey_hex for logging/audit rather than the raw path param, whose
+    // casing a caller controls (found by the Phase 6 hostile audit).
+    let canonical_pubkey_hex = &record.pubkey_hex;
+
+    let removal_result = if record.transport == "meshtastic" {
+        match record.node_num {
+            Some(node_num) => state.host.admin_remove_meshtastic_favorite(node_num).await,
+            None => Err(HostError::NotSupported(
+                "meshtastic contact has no node_num on record".into(),
+            )),
+        }
+    } else {
+        state.host.admin_remove_meshcore_contact(pubkey).await
+    };
+    if let Err(e) = removal_result {
+        warn!(pubkey = %canonical_pubkey_hex, transport = %record.transport, "native contact removal failed: {e}");
+    }
+
+    let actor_str = format!("web:{}", caller.username);
+    if let Err(e) = state
+        .host
+        .admin_write_audit(
+            &actor_str,
+            "delete_contact",
+            Some(canonical_pubkey_hex),
+            None,
+        )
+        .await
+    {
+        warn!("audit write failed: {e}");
+    }
+
+    StatusCode::NO_CONTENT.into_response()
+}
+
+/// `DELETE /api/v1/adverts` — flush unprotected in-memory advert records.
+///
+/// Useful after correcting device clocks or clearing stale, never-messaged
+/// discovered contacts. Protected contacts (visible in `GET /api/v1/contacts`)
+/// survive this call — see `AdvertBus::clear_unprotected`'s own doc comment
+/// for why. The bus repopulates automatically as adverts arrive or on the
+/// next BBS reconnect (which triggers a fresh `GetContacts` scan). Sysop-only
+/// — this previously had no permission check at all.
+async fn api_adverts_clear(
+    State(state): State<Arc<AppState>>,
+    Extension(caller): Extension<CurrentUser>,
+) -> Response {
+    if caller.permission_level < 100 {
+        return (StatusCode::FORBIDDEN, Json(json_error("sysop required"))).into_response();
+    }
+    let removed = state.host.advert_bus().clear_unprotected();
+    let actor_str = format!("web:{}", caller.username);
+    if let Err(e) = state
+        .host
+        .admin_write_audit(
+            &actor_str,
+            "clear_unprotected_adverts",
+            None,
+            Some(&format!("{removed} record(s) removed")),
+        )
+        .await
+    {
+        warn!("audit write failed: {e}");
+    }
+    StatusCode::NO_CONTENT.into_response()
 }
 
 /// Human-readable advert "type", interpreted per transport.
@@ -1179,6 +1307,7 @@ fn meshtastic_role_name(role: u8) -> &'static str {
         9 => "lost_and_found",
         10 => "tak_tracker",
         11 => "router_late",
+        12 => "client_base",
         _ => "unknown",
     }
 }
@@ -4012,5 +4141,396 @@ async fn api_plugin_logs(
     match registry.get_logs(&name, q.lines.min(500)).await {
         Ok(lines) => Json(serde_json::json!({ "lines": lines })).into_response(),
         Err(e) => registry_err(e),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bbs_plugin_api::testing::MockHost;
+
+    fn test_state() -> (Arc<AppState>, Arc<MockHost>) {
+        let mock = Arc::new(MockHost::new());
+        let host: Arc<dyn Host> = mock.clone();
+        let state = Arc::new(AppState::new(host, WebConfig::default()));
+        (state, mock)
+    }
+
+    fn sysop() -> CurrentUser {
+        CurrentUser {
+            username: "sysop".into(),
+            permission_level: 100,
+        }
+    }
+
+    fn regular_user() -> CurrentUser {
+        CurrentUser {
+            username: "alice".into(),
+            permission_level: 10,
+        }
+    }
+
+    async fn body_json(response: Response) -> serde_json::Value {
+        let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("reading response body");
+        serde_json::from_slice(&bytes).expect("response body is valid JSON")
+    }
+
+    fn dummy_key(n: u8) -> [u8; 32] {
+        let mut k = [0u8; 32];
+        k[0] = n;
+        k
+    }
+
+    // T039b: api_adverts's `protected` field reflects AdvertRecord.flags bit 0.
+    #[tokio::test]
+    async fn api_adverts_reports_protected_field() {
+        let (state, mock) = test_state();
+        let bus = mock.advert_bus();
+        let protected_key = dummy_key(1);
+        let unprotected_key = dummy_key(2);
+        bus.upsert_contact(
+            protected_key,
+            "Protected".into(),
+            1,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            Vec::new(),
+            -1,
+            "meshcore",
+        );
+        bus.upsert(unprotected_key, "Unprotected".into(), 1, 0, 0, "meshcore");
+        assert!(matches!(
+            bus.mark_favourite_if_eligible(protected_key, |_| true, 350, &[]),
+            bbs_plugin_api::FavouriteOutcome::Protected(_)
+        ));
+
+        let resp = api_adverts(State(state)).await.into_response();
+        let body = body_json(resp).await;
+        let entries = body.as_array().expect("array response");
+        assert_eq!(entries.len(), 2);
+
+        let by_name: std::collections::HashMap<&str, bool> = entries
+            .iter()
+            .map(|e| {
+                (
+                    e["name"].as_str().unwrap(),
+                    e["protected"].as_bool().unwrap(),
+                )
+            })
+            .collect();
+        assert_eq!(by_name.get("Protected"), Some(&true));
+        assert_eq!(by_name.get("Unprotected"), Some(&false));
+    }
+
+    // T039b: GET /api/v1/contacts returns only protected records.
+    #[tokio::test]
+    async fn api_contacts_returns_only_protected_records() {
+        let (state, mock) = test_state();
+        let bus = mock.advert_bus();
+        let protected_key = dummy_key(3);
+        let unprotected_key = dummy_key(4);
+        bus.upsert_contact(
+            protected_key,
+            "Protected".into(),
+            1,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            Vec::new(),
+            -1,
+            "meshcore",
+        );
+        bus.upsert(unprotected_key, "Unprotected".into(), 1, 0, 0, "meshcore");
+        assert!(matches!(
+            bus.mark_favourite_if_eligible(protected_key, |_| true, 350, &[]),
+            bbs_plugin_api::FavouriteOutcome::Protected(_)
+        ));
+
+        let resp = api_contacts(State(state)).await.into_response();
+        let body = body_json(resp).await;
+        let entries = body.as_array().expect("array response");
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0]["name"].as_str(), Some("Protected"));
+        assert_eq!(entries[0]["protected"].as_bool(), Some(true));
+    }
+
+    // T039b: DELETE /api/v1/adverts rejects a non-Sysop caller.
+    #[tokio::test]
+    async fn api_adverts_clear_rejects_non_sysop() {
+        let (state, _mock) = test_state();
+        let resp = api_adverts_clear(State(state), Extension(regular_user()))
+            .await
+            .into_response();
+        assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+    }
+
+    // T039b (round-19 addition): DELETE /api/v1/adverts removes an
+    // unprotected record but leaves a protected one in place — it still
+    // appears in GET /api/v1/contacts afterward.
+    #[tokio::test]
+    async fn api_adverts_clear_preserves_protected_contacts() {
+        let (state, mock) = test_state();
+        let bus = mock.advert_bus();
+        let protected_key = dummy_key(5);
+        let unprotected_key = dummy_key(6);
+        bus.upsert_contact(
+            protected_key,
+            "Protected".into(),
+            1,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            Vec::new(),
+            -1,
+            "meshcore",
+        );
+        bus.upsert(unprotected_key, "Unprotected".into(), 1, 0, 0, "meshcore");
+        assert!(matches!(
+            bus.mark_favourite_if_eligible(protected_key, |_| true, 350, &[]),
+            bbs_plugin_api::FavouriteOutcome::Protected(_)
+        ));
+
+        let resp = api_adverts_clear(State(Arc::clone(&state)), Extension(sysop()))
+            .await
+            .into_response();
+        assert_eq!(resp.status(), StatusCode::NO_CONTENT);
+
+        let adverts = body_json(api_adverts(State(Arc::clone(&state))).await.into_response()).await;
+        assert_eq!(
+            adverts.as_array().unwrap().len(),
+            1,
+            "the unprotected record must be gone"
+        );
+
+        let contacts = body_json(api_contacts(State(state)).await.into_response()).await;
+        let contacts = contacts.as_array().unwrap();
+        assert_eq!(contacts.len(), 1);
+        assert_eq!(
+            contacts[0]["name"].as_str(),
+            Some("Protected"),
+            "the protected record must survive and still appear in Contacts"
+        );
+    }
+
+    fn aide() -> CurrentUser {
+        CurrentUser {
+            username: "aide".into(),
+            permission_level: 50,
+        }
+    }
+
+    async fn seed_protected_contact(state: &Arc<AppState>) -> String {
+        let bus = state.host.advert_bus();
+        let key = dummy_key(7);
+        bus.upsert_contact(
+            key,
+            "Protected".into(),
+            1,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            Vec::new(),
+            -1,
+            "meshcore",
+        );
+        assert!(matches!(
+            bus.mark_favourite_if_eligible(key, |_| true, 350, &[]),
+            bbs_plugin_api::FavouriteOutcome::Protected(_)
+        ));
+        bus.list_protected()[0].pubkey_hex.clone()
+    }
+
+    // T048: refuses a User-tier caller. Constructed as a direct handler call
+    // with a synthetic CurrentUser rather than through the real login flow —
+    // bbs-web's own login already rejects anything below Aide before a
+    // session can exist, so there is no way to obtain a User-tier session to
+    // present to this endpoint through the live API. This is defense-in-depth
+    // coverage of the in-handler check, not evidence the boundary is
+    // reachable via a real request.
+    #[tokio::test]
+    async fn api_delete_contact_rejects_below_aide() {
+        let (state, _mock) = test_state();
+        let resp = api_delete_contact(
+            State(state),
+            Extension(regular_user()),
+            Path("0".repeat(64)),
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+    }
+
+    // T048: succeeds for Aide/Sysop; a successful delete clears the
+    // protected flag and removes the entry from GET /api/v1/contacts.
+    #[tokio::test]
+    async fn api_delete_contact_succeeds_for_aide() {
+        let (state, mock) = test_state();
+        let pubkey_hex = seed_protected_contact(&state).await;
+
+        let resp = api_delete_contact(
+            State(Arc::clone(&state)),
+            Extension(aide()),
+            Path(pubkey_hex),
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::NO_CONTENT);
+
+        let contacts = body_json(api_contacts(State(state)).await.into_response()).await;
+        assert_eq!(
+            contacts.as_array().unwrap().len(),
+            0,
+            "the deleted contact must no longer appear in Contacts"
+        );
+        // Phase 6 hostile-audit regression (Hostile QA persona): the
+        // default MockHost previously discarded this argument and always
+        // returned NotSupported, so a 204 alone didn't prove the CORRECT
+        // pubkey was ever actually passed to the native removal call.
+        assert_eq!(
+            mock.removed_meshcore_contacts(),
+            vec![dummy_key(7)],
+            "the native removal must be called with the deleted contact's own pubkey"
+        );
+    }
+
+    // T048: deleting an unknown/unprotected pubkey returns 404.
+    #[tokio::test]
+    async fn api_delete_contact_returns_404_for_unknown_pubkey() {
+        let (state, _mock) = test_state();
+        let resp =
+            api_delete_contact(State(state), Extension(sysop()), Path("ab".repeat(32))).await;
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    }
+
+    // T048: an invalid (wrong-length/non-hex) pubkey path param is rejected
+    // as a client error, not a panic or a 500.
+    #[tokio::test]
+    async fn api_delete_contact_rejects_malformed_pubkey() {
+        let (state, _mock) = test_state();
+        let resp =
+            api_delete_contact(State(state), Extension(sysop()), Path("not-hex".into())).await;
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    }
+
+    // Phase 6 hostile-audit regression (Security persona): `u8::from_str_radix`
+    // accepts a leading `+` for unsigned types (e.g. "+1" parses as 1), which
+    // isn't a hex digit — decode_pubkey_hex must not silently accept a
+    // 64-character string built from `+`-prefixed chunks as valid hex.
+    #[tokio::test]
+    async fn api_delete_contact_rejects_plus_prefixed_non_hex() {
+        let (state, _mock) = test_state();
+        let resp =
+            api_delete_contact(State(state), Extension(sysop()), Path("+1".repeat(32))).await;
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    }
+
+    // T048a (round-13 regression): after a delete, a stale full-sync report
+    // still showing the device's old favourited state must not resurrect
+    // the contact — covered at the AdvertBus level by
+    // `lost_removal_write_lets_stale_favorited_resync_re_adopt_after_grace_window`
+    // in crates/bbs-plugin-api/src/advert.rs (this handler calls
+    // AdvertBus::unprotect directly, so that test's coverage of the
+    // grace-window merge applies unchanged here). This test confirms the
+    // HTTP-layer half: immediately after a delete, the contact is gone from
+    // GET /api/v1/contacts (already covered above); no separate coverage
+    // needed at this layer for the grace-window mechanics themselves.
+    #[tokio::test]
+    async fn api_delete_contact_removal_is_immediate_at_the_http_layer() {
+        let (state, _mock) = test_state();
+        let pubkey_hex = seed_protected_contact(&state).await;
+        let resp = api_delete_contact(
+            State(Arc::clone(&state)),
+            Extension(sysop()),
+            Path(pubkey_hex),
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::NO_CONTENT);
+        assert!(
+            !state
+                .host
+                .advert_bus()
+                .is_currently_favourited(&dummy_key(7)),
+            "the contact must be unprotected immediately, not deferred"
+        );
+    }
+
+    // Phase 6 hostile-audit regression (Hostile QA persona): deleting the
+    // same pubkey twice must 404 the second time, not panic or
+    // double-decrement anything.
+    #[tokio::test]
+    async fn api_delete_contact_is_not_idempotent_second_call_404s() {
+        let (state, _mock) = test_state();
+        let pubkey_hex = seed_protected_contact(&state).await;
+
+        let first = api_delete_contact(
+            State(Arc::clone(&state)),
+            Extension(sysop()),
+            Path(pubkey_hex.clone()),
+        )
+        .await;
+        assert_eq!(first.status(), StatusCode::NO_CONTENT);
+
+        let second = api_delete_contact(State(state), Extension(sysop()), Path(pubkey_hex)).await;
+        assert_eq!(second.status(), StatusCode::NOT_FOUND);
+    }
+
+    // Phase 6 hostile-audit regression (Hostile QA persona): a record whose
+    // transport is "meshtastic" but whose node_num is None (a malformed/
+    // incomplete record — not reachable via the normal upsert_meshtastic_node
+    // ingest path, but not ruled out by the type system either) must be
+    // handled gracefully, not panic.
+    #[tokio::test]
+    async fn api_delete_contact_handles_meshtastic_record_with_no_node_num() {
+        let (state, mock) = test_state();
+        let bus = state.host.advert_bus();
+        let key = dummy_key(9);
+        // Deliberately go through upsert_contact (which sets has_full_record,
+        // required for mark_favourite_if_eligible to proceed past
+        // NoRecordYet) with transport = "meshtastic" rather than
+        // upsert_meshtastic_node, which always sets node_num — this is the
+        // only way to construct the malformed shape this test targets.
+        bus.upsert_contact(
+            key,
+            "Malformed".into(),
+            1,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            Vec::new(),
+            -1,
+            "meshtastic",
+        );
+        assert!(matches!(
+            bus.mark_favourite_if_eligible(key, |_| true, 350, &[]),
+            bbs_plugin_api::FavouriteOutcome::Protected(_)
+        ));
+        let pubkey_hex = bus.list_protected()[0].pubkey_hex.clone();
+
+        let resp = api_delete_contact(State(state), Extension(sysop()), Path(pubkey_hex)).await;
+        assert_eq!(
+            resp.status(),
+            StatusCode::NO_CONTENT,
+            "local unprotect must still succeed even though the native removal can't be attempted"
+        );
+        assert!(
+            mock.removed_meshtastic_favorites().is_empty(),
+            "no removal call should be attempted without a node_num to target"
+        );
     }
 }

--- a/crates/bbs-web/web/src/components/AppNav.vue
+++ b/crates/bbs-web/web/src/components/AppNav.vue
@@ -70,10 +70,13 @@ const groups = computed<NavGroup[]>(() => {
     },
   ]
 
-  if (transports.meshcore) {
+  if (transports.meshcore || transports.meshtastic) {
     g.push({
       title: 'mesh',
-      items: [{ to: '/adverts', label: 'adverts' }],
+      items: [
+        { to: '/adverts', label: 'discovered contacts' },
+        { to: '/contacts', label: 'contacts' },
+      ],
     })
   }
 

--- a/crates/bbs-web/web/src/pages/ContactsPage.vue
+++ b/crates/bbs-web/web/src/pages/ContactsPage.vue
@@ -1,11 +1,12 @@
 <script setup lang="ts">
 import { computed, onMounted, onUnmounted, ref } from 'vue'
-import { api, ApiError } from '../api/client'
+import { api } from '../api/client'
 import { useAuthStore } from '../stores/auth'
+import { useToast } from '../composables/useToast'
 import DataTable from '../components/DataTable.vue'
 import { fmtLocal } from '../utils/datetime'
 
-interface Advert {
+interface Contact {
   ts: number
   pubkey: string
   name: string
@@ -18,66 +19,57 @@ interface Advert {
 }
 
 const auth = useAuthStore()
+const toast = useToast()
 
-const rows = ref<Advert[]>([])
+const rows = ref<Contact[]>([])
 const error = ref<string | null>(null)
+const deletingKeys = ref<Set<string>>(new Set())
 let timer: number | undefined
 
-const flood = ref(true)
-const sending = ref(false)
-const sendStatus = ref<{ kind: 'ok' | 'error'; message: string } | null>(null)
-const clearing = ref(false)
+// Monotonic request-sequence guard (Phase 6 hostile-audit fix, Verifier
+// pass): the 5-second poll's GET can still be in flight when a delete
+// completes — without this, that GET's response could land afterward and
+// silently "resurrect" the just-deleted contact in the UI for up to one
+// more poll cycle. Bumping this on every successful delete invalidates any
+// older in-flight load() response, without needing to track specific
+// pubkeys (which would risk permanently hiding a contact that legitimately
+// gets re-protected before such tracking expired).
+let loadSeq = 0
 
 async function load() {
+  const seq = ++loadSeq
   try {
-    rows.value = await api.get<Advert[]>('/api/v1/adverts')
+    const fresh = await api.get<Contact[]>('/api/v1/contacts')
+    if (seq !== loadSeq) return
+    rows.value = fresh
     error.value = null
   } catch (e: any) {
-    error.value = e?.message ?? 'failed to load adverts'
+    if (seq !== loadSeq) return
+    error.value = e?.message ?? 'failed to load contacts'
   }
 }
 
-async function sendAdvert() {
-  sending.value = true
-  sendStatus.value = null
-  try {
-    await api.post('/api/v1/adverts/send', { flood: flood.value })
-    const ts = new Date().toLocaleTimeString()
-    sendStatus.value = {
-      kind: 'ok',
-      message: `Advert sent (${flood.value ? 'flood' : 'direct'}) at ${ts}.`,
-    }
-    await load()
-  } catch (e: any) {
-    let msg = e?.message ?? 'failed to send advert'
-    if (e instanceof ApiError) {
-      if (e.status === 403) msg = 'sysop required'
-      else if (e.status === 503) msg = 'mesh transport not running'
-    }
-    sendStatus.value = { kind: 'error', message: msg }
-  } finally {
-    sending.value = false
-  }
-}
-
-async function clearAdverts() {
+async function deleteContact(row: Contact) {
+  // Guard against a double-click firing two concurrent requests — the
+  // :disabled binding alone can't prevent this, since confirm() blocks
+  // before it's ever applied.
+  if (deletingKeys.value.has(row.pubkey)) return
   if (
     !confirm(
-      'Clear unprotected discovered contacts from memory? Protected contacts are never removed by this. The list will repopulate as nodes are heard.',
+      `Delete "${row.name}" from Contacts? This clears its protected status and best-effort removes it from the radio's own contact list. It can re-become protected if it messages the BBS again.`,
     )
   )
     return
-  clearing.value = true
-  sendStatus.value = null
+  deletingKeys.value.add(row.pubkey)
   try {
-    await api.del('/api/v1/adverts')
-    await load()
+    await api.del(`/api/v1/contacts/${row.pubkey}`)
+    loadSeq++
+    toast.ok(`"${row.name}" deleted from Contacts`)
+    rows.value = rows.value.filter((r) => r.pubkey !== row.pubkey)
   } catch (e: any) {
-    let msg = e?.message ?? 'failed to clear list'
-    if (e instanceof ApiError && e.status === 403) msg = 'sysop required'
-    sendStatus.value = { kind: 'error', message: msg }
+    toast.error(e?.message ?? 'failed to delete contact')
   } finally {
-    clearing.value = false
+    deletingKeys.value.delete(row.pubkey)
   }
 }
 
@@ -92,12 +84,6 @@ function hasCoord(lat: number, lon: number): boolean {
 function shortKey(k: string): string {
   return k.length > 16 ? k.slice(0, 16) + '…' : k
 }
-
-const groups = computed(() => {
-  const m: Record<string, number> = {}
-  for (const r of rows.value) m[r.type_name] = (m[r.type_name] ?? 0) + 1
-  return m
-})
 
 // ── Transport / type filters ────────────────────────────────────────────────
 const filterTransport = ref('')
@@ -124,73 +110,33 @@ onMounted(() => {
 })
 onUnmounted(() => { if (timer !== undefined) window.clearInterval(timer) })
 
-const columns = [
-  { key: 'ts', label: 'last seen' },
-  { key: 'name', label: 'name' },
-  { key: 'protected', label: 'protected' },
-  { key: 'transport', label: 'transport' },
-  { key: 'type_name', label: 'type' },
-  { key: 'pubkey', label: 'pubkey' },
-  { key: 'location', label: 'location' },
-]
+const columns = computed(() => {
+  const base = [
+    { key: 'ts', label: 'last seen' },
+    { key: 'name', label: 'name' },
+    { key: 'transport', label: 'transport' },
+    { key: 'type_name', label: 'type' },
+    { key: 'pubkey', label: 'pubkey' },
+    { key: 'location', label: 'location' },
+  ]
+  return auth.isAide ? [...base, { key: 'actions', label: '' }] : base
+})
 </script>
 
 <template>
   <div class="page">
     <header class="page-header">
-      <h1>discovered contacts</h1>
+      <h1>contacts</h1>
       <p class="muted small">
-        Every node heard over the mesh, protected or not. Polls every 5 s.
-        You must have received a node's advert before you can communicate with it.
-        Protected contacts also appear on the
-        <router-link to="/contacts">contacts</router-link> page and survive
-        node-database flooding on the radio.
+        Protected contacts only — these survive node-database flooding on the
+        radio and stay favorited across a BBS restart. See
+        <router-link to="/adverts">discovered contacts</router-link> for
+        every node heard, protected or not.
       </p>
     </header>
 
-    <!-- Send our own advert -->
-    <section class="send-block">
-      <div class="send-controls">
-        <button
-          @click="sendAdvert"
-          :disabled="sending || clearing || !auth.isSysop"
-          :title="!auth.isSysop ? 'sysop required' : ''"
-        >
-          {{ sending ? 'sending…' : 'send advert' }}
-        </button>
-        <label class="checkbox">
-          <input type="checkbox" v-model="flood" :disabled="sending" />
-          flood (multi-hop)
-        </label>
-        <span class="muted small">
-          {{ flood
-            ? 'rebroadcast hop-by-hop — more reach, more airtime'
-            : 'neighbours only — single hop' }}
-        </span>
-        <button
-          class="btn-danger"
-          @click="clearAdverts"
-          :disabled="sending || clearing || !auth.isSysop"
-          :title="!auth.isSysop ? 'sysop required' : 'Clear unprotected discovered contacts from memory'"
-        >
-          {{ clearing ? 'clearing…' : 'clear list' }}
-        </button>
-      </div>
-      <p v-if="sendStatus" class="status-line small" :class="sendStatus.kind">
-        {{ sendStatus.message }}
-      </p>
-    </section>
-
-    <!-- Type summary badges -->
-    <p class="muted small type-summary">
-      <span v-if="!rows.length">No adverts heard yet.</span>
-      <span v-for="(count, type) in groups" :key="type" class="badge" :class="`type-${type}`">
-        {{ type }}: {{ count }}
-      </span>
-    </p>
-
     <!-- Transport / type filters -->
-    <div class="advert-filters">
+    <div class="contact-filters">
       <label>
         transport
         <select v-model="filterTransport">
@@ -218,15 +164,11 @@ const columns = [
     <DataTable
       :columns="columns"
       :rows="filteredRows"
-      :row-key="(r) => `${r.ts}-${r.pubkey}`"
+      :row-key="(r) => r.pubkey"
       :page-size="50"
-      empty="No adverts heard yet (is mesh transport enabled and connected?)."
+      empty="No protected contacts yet. A contact becomes protected the first time it messages the BBS."
     >
       <template #[`cell:ts`]="{ row }">{{ fmtLocal(row.ts) }}</template>
-      <template #[`cell:protected`]="{ row }">
-        <span v-if="row.protected" class="badge protected-yes" title="survives node-database flooding; excluded from 'clear list'">protected</span>
-        <span v-else class="muted">—</span>
-      </template>
       <template #[`cell:transport`]="{ row }">
         <span v-if="row.transport" class="badge" :class="`transport-${row.transport}`">{{ row.transport }}</span>
         <span v-else class="muted">—</span>
@@ -241,6 +183,15 @@ const columns = [
         <span v-if="hasCoord(row.lat, row.lon)">{{ fmtCoord(row.lat, row.lon) }}</span>
         <span v-else class="muted">—</span>
       </template>
+      <template #[`cell:actions`]="{ row }">
+        <button
+          class="btn-danger btn-small"
+          :disabled="deletingKeys.has(row.pubkey)"
+          @click="deleteContact(row)"
+        >
+          {{ deletingKeys.has(row.pubkey) ? 'deleting…' : 'delete' }}
+        </button>
+      </template>
     </DataTable>
   </div>
 </template>
@@ -251,30 +202,7 @@ const columns = [
 h1 { margin: 0; }
 .small { font-size: 0.85em; }
 
-.send-block {
-  border: 1px solid var(--border);
-  border-radius: 4px;
-  padding: 0.7rem 0.9rem;
-  background: var(--row-alt);
-  display: flex;
-  flex-direction: column;
-  gap: 0.4rem;
-}
-.send-controls { display: flex; align-items: center; gap: 0.9rem; flex-wrap: wrap; }
-.send-controls .checkbox { display: flex; align-items: center; gap: 0.35rem; font-size: 0.9em; }
-
-.status-line { margin: 0; padding: 0.25rem 0.5rem; border-radius: 3px; }
-.status-line.ok    { color: #2a8a2a; border: 1px solid #2a8a2a; background: rgba(42,138,42,0.08); }
-.status-line.error { color: var(--error); border: 1px solid var(--error); background: rgba(200,60,60,0.08); }
-.btn-danger {
-  background: var(--error);
-  color: #fff;
-  border-color: var(--error);
-}
-.btn-danger:hover:not(:disabled) { filter: brightness(1.08); }
-.btn-danger:disabled { opacity: 0.5; }
-
-.advert-filters {
+.contact-filters {
   display: flex;
   align-items: center;
   gap: 1rem;
@@ -282,15 +210,13 @@ h1 { margin: 0; }
   font-size: 0.85em;
   color: var(--muted);
 }
-.advert-filters label { display: flex; align-items: center; gap: 0.4rem; }
-.advert-filters select { font: inherit; padding: 0.15rem 0.3rem; }
+.contact-filters label { display: flex; align-items: center; gap: 0.4rem; }
+.contact-filters select { font: inherit; padding: 0.15rem 0.3rem; }
 .link-btn {
   background: none; border: none; padding: 0;
   color: var(--accent, #4a90d9); cursor: pointer; font: inherit;
   text-decoration: underline;
 }
-
-.type-summary { margin: 0; display: flex; flex-wrap: wrap; gap: 0.4rem; }
 
 .badge {
   display: inline-block; padding: 0.05rem 0.45rem;
@@ -306,7 +232,6 @@ h1 { margin: 0; }
 .badge.type-client_mute   { background: #e0e8d2; color: #404f20; }
 .badge.type-client_hidden { background: var(--row-alt); color: var(--muted); }
 .badge.type-client_base   { background: #d2efd2; color: #205020; }
-.badge.protected-yes      { background: #f0e2c2; color: #604010; font-weight: 600; }
 .badge.type-router        { background: #d2dff0; color: #203560; }
 .badge.type-router_client { background: #d2dff0; color: #203560; }
 .badge.type-router_late   { background: #d2dff0; color: #203560; }
@@ -316,4 +241,13 @@ h1 { margin: 0; }
 .badge.type-lost_and_found { background: #f0d2d2; color: #602020; }
 .badge.transport-meshcore   { background: #d2dff0; color: #203560; }
 .badge.transport-meshtastic { background: #e2d2f0; color: #402060; }
+
+.btn-danger {
+  background: var(--error);
+  color: #fff;
+  border-color: var(--error);
+}
+.btn-danger:hover:not(:disabled) { filter: brightness(1.08); }
+.btn-danger:disabled { opacity: 0.5; }
+.btn-small { padding: 0.15rem 0.5rem; font-size: 0.85em; }
 </style>

--- a/crates/bbs-web/web/src/pages/DashboardPage.vue
+++ b/crates/bbs-web/web/src/pages/DashboardPage.vue
@@ -79,8 +79,12 @@ onMounted(async () => {
       <h2>quick actions</h2>
       <div class="link-grid">
         <router-link class="quick-link" to="/adverts">
-          <span class="ql-title">adverts</span>
+          <span class="ql-title">discovered contacts</span>
           <span class="ql-hint muted">nodes heard over the mesh</span>
+        </router-link>
+        <router-link class="quick-link" to="/contacts">
+          <span class="ql-title">contacts</span>
+          <span class="ql-hint muted">protected contacts</span>
         </router-link>
         <router-link class="quick-link" to="/sessions">
           <span class="ql-title">sessions</span>

--- a/crates/bbs-web/web/src/router.ts
+++ b/crates/bbs-web/web/src/router.ts
@@ -6,6 +6,7 @@ const router = createRouter({
     { path: '/login', name: 'login', component: () => import('./pages/LoginPage.vue') },
     { path: '/', name: 'dashboard', component: () => import('./pages/DashboardPage.vue') },
     { path: '/adverts', name: 'adverts', component: () => import('./pages/AdvertsPage.vue') },
+    { path: '/contacts', name: 'contacts', component: () => import('./pages/ContactsPage.vue') },
     { path: '/sessions', name: 'sessions', component: () => import('./pages/SessionsPage.vue') },
     { path: '/users', name: 'users', component: () => import('./pages/UsersPage.vue') },
     { path: '/rooms', name: 'rooms', component: () => import('./pages/RoomsPage.vue') },

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -453,6 +453,88 @@ The new password must be at least 6 characters. The same operation is available 
 
 ---
 
+### `contacts list` / `contacts discovered` / `contacts delete`
+
+```
+supply-drop-bbs contacts <list|discovered|delete> [OPTIONS]
+```
+
+Manage protected mesh contacts against a **running** BBS's web admin API.
+Unlike every other subcommand, `contacts` does not touch the local database or
+config file directly — it requires a reachable BBS instance with the
+`admin-web` feature enabled, and logs in exactly like the web UI (a session
+cookie, not a separate mechanism). Mirrors the web UI's **Contacts** and
+**Discovered Contacts** pages, including the same permission requirements.
+
+| Flag | Env override | Default | Description |
+|------|-------------|---------|-------------|
+| `--url <URL>` | `SUPPLY_DROP_BBS_URL` | `http://127.0.0.1:8080` | Base URL of the running BBS's web admin API |
+| `--username <NAME>` | `SUPPLY_DROP_BBS_USERNAME` | - | BBS account to authenticate as |
+| `--password <PASSWORD>` | `SUPPLY_DROP_BBS_PASSWORD` | - | Password to authenticate with. Prompted interactively (hidden input) if omitted |
+
+**Login itself requires Aide or Sysop (level 50+)** — the web admin API
+rejects a plain User account before a session can even exist, with the same
+"invalid credentials" error a wrong password would give. This applies to
+`list` and `discovered` too, not just `delete`.
+
+| Action | Description |
+|--------|-------------|
+| `list` | Protected contacts only (mirrors the **Contacts** page) |
+| `discovered` | Every discovered contact, protected or not (mirrors the **Discovered Contacts** page) |
+| `delete <PUBKEY>` | Remove a single **protected** contact by its 64-character hex public key, as shown by `list`. A pubkey that only appears in `discovered` (never protected) has nothing to delete and the server responds 404. |
+
+> **Flag order:** `--url`/`--username`/`--password` belong to `contacts`
+> itself, not to `list`/`discovered`/`delete` — put them **before** the
+> action, e.g. `contacts --username alice delete <PUBKEY>`.
+
+```sh
+supply-drop-bbs contacts --username alice list
+# Password for alice: ••••••••
+# PROTECTED  NAME                     TRANSPORT    TYPE       LAST SEEN            PUBKEY
+# ----------------------------------------------------------------------------------------------------
+# yes        basecamp-node            meshtastic   client     2026-09-01T12:03:11Z ab12cd34ef56...
+
+supply-drop-bbs contacts \
+  --url http://192.168.1.50:8080 --username alice --password hunter2 discovered
+
+supply-drop-bbs contacts --username alice --password hunter2 \
+  delete ab12cd34ef56...
+# deleted: ab12cd34ef56...
+```
+
+> **Non-loopback HTTP:** the session cookie the CLI relies on is marked
+> `Secure` by default (`cookie_secure = true`, see below), and a compliant
+> cookie jar only sends a `Secure` cookie back over `https://` **or** a
+> loopback address (`127.0.0.1`/`localhost`). A `--url` pointing at a LAN
+> address like `http://192.168.1.50:8080` — as in the `discovered` example
+> above — will log in successfully but then silently fail every following
+> request with `401 Unauthorized`, since the cookie never gets sent back.
+> Either set `cookie_secure = false` under `[plugins.web]` (see
+> [CONFIG.md](CONFIG.md), local/dev deployments only) on the server, or put
+> the web admin behind TLS before using `contacts` against a non-loopback
+> `--url`.
+
+For scripted/non-interactive use, set `SUPPLY_DROP_BBS_USERNAME` and
+`SUPPLY_DROP_BBS_PASSWORD` instead of passing `--password` on the command
+line (which would otherwise be visible in shell history and `ps`):
+
+```sh
+export SUPPLY_DROP_BBS_URL=http://127.0.0.1:8080
+export SUPPLY_DROP_BBS_USERNAME=alice
+export SUPPLY_DROP_BBS_PASSWORD=hunter2
+supply-drop-bbs contacts list
+```
+
+**Exit codes:** `0` on success; non-zero on any failure — the BBS not being
+reachable, a failed or under-privileged login, an invalid `--password`
+prompt, a malformed pubkey passed to `delete`, or the pubkey not matching
+any protected contact.
+
+> **Web admin:** The same data and delete action are available in the web UI
+> under **Contacts** (protected) and **Discovered Contacts** (all).
+
+---
+
 ## Permission levels
 
 | Level | Value | How to set |

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -298,6 +298,12 @@ arrive.
 > deduplicated separately. The per-attempt wait is the device's own timeout
 > hint, clamped to the 4–30 s range.
 
+### Contact protection
+
+| Key                     | Type    | Default | Required | Description                              |
+|--------------------------|---------|---------|----------|-------------------------------------------|
+| `protected_contact_cap` | integer | `350`   | no       | Maximum number of contacts that may be protected (favorited on the radio) at once. Once reached, a newly-eligible sender's first DM evicts the oldest-protected, currently session-inactive contact to make room. Set to your device's real contact-table capacity (MeshCore's `max_contacts` varies by hardware). `0` disables protection entirely on this transport. See [PROTOCOL.md](PROTOCOL.md#protected-contacts) for the full mechanism. |
+
 ### Serial mode (`connection_type = "serial"`)
 
 Used for USB-native MeshCore devices (Heltec V3, T-Beam, etc.) that
@@ -502,6 +508,7 @@ either via USB serial or TCP to a running `meshtasticd` instance.
 | `want_ack`         | bool   | `true`     | no       | Request Meshtastic radio-layer acknowledgements     |
 | `reconnect_delay_initial_ms` | integer | `1000` | no | Initial reconnect delay after disconnect           |
 | `reconnect_delay_max_ms`     | integer | `60000`| no | Maximum reconnect delay after repeated failures    |
+| `protected_contact_cap` | integer | `100` | no | Maximum number of nodes that may be protected (favorited) at once. Once reached, a newly-eligible sender's first DM evicts the oldest-protected, currently session-inactive node to make room. Set to your device's real `MAX_NUM_NODES` (firmware/hardware-dependent). `0` disables protection entirely on this transport. See [PROTOCOL.md](PROTOCOL.md#protected-contacts) for the full mechanism. |
 
 ### Serial mode (`connection_type = "serial"`)
 

--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -347,6 +347,37 @@ attacker who already knows or can observe a target's 6-byte prefix. This is
 a known, accepted, unmitigated-in-code limitation — documented here rather
 than silently carried, alongside the Meshtastic firmware-crash risk above.
 
+### MeshCore: self-identification requires `CMD_APP_START` support
+
+The BBS learns its own MeshCore public key exactly once, from the
+`SelfInfo` the device returns in response to `CMD_APP_START` at connect
+time — nothing else in the wire protocol sets it. On firmware that
+responds `ERR_CODE_UNSUPPORTED_CMD` to `CMD_APP_START`, the BBS's own
+public key is never learned for the life of that connection.
+
+This matters because both the eviction path (`ContactsFull`) and the
+new-protection eviction-exclusion list build their "never evict this"
+set from the BBS's own known pubkey. Without it, the BBS's own
+self-registered contact entry is not excluded from eviction-candidate
+selection — worst case, the BBS could select its own entry as the
+`ContactsFull` eviction victim and send `RemoveContact` against itself.
+
+**No clean fix exists today.** The BBS's own contact entry, when it does
+end up in `AdvertBus` on unsupported-`CMD_APP_START` firmware (via an
+ordinary contact sync or an echoed self-advert), carries no marker
+distinguishing it from any other real contact — there is currently no
+protocol-level signal that says "this record is me" independent of
+`CMD_APP_START`'s `SelfInfo`. The one other command that returns
+key material, `ExportPrivateKey` (used on-demand by `node export-key`),
+was considered and rejected as an automatic fallback: its firmware
+support isn't independently verified either, and routinely invoking it
+on every connection just to self-identify would mean materializing the
+node's *private* key far more often than necessary, for a security-
+sensitive operation currently gated behind an explicit sysop CLI action —
+a worse trade than the gap it would close. This is a known, accepted,
+unmitigated-in-code limitation on the affected firmware, documented here
+rather than silently carried, alongside the two limitations above.
+
 ### Discovered Contacts vs. Contacts, and delete semantics
 
 The web admin UI and API distinguish two views over the same underlying

--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -250,6 +250,126 @@ failures (insufficient permission level) respond with a clear
 "you can't do that" message - no information leak about the action
 that would have happened.
 
+## Protected contacts
+
+Both transports' radios (the MeshCore companion device and a Meshtastic
+radio) keep their own bounded, on-device contact/node table. When that table
+fills, the firmware evicts entries to make room for new ones — which is fine
+for a hobbyist client but a problem for the BBS: if the entry the BBS itself
+needs to reply to a user (or the entry a returning user needs to reach the
+BBS) gets evicted at the wrong moment, replies silently fail to route. The
+BBS mitigates this by marking a bounded set of contacts **protected**
+("favorited" on the radio), which most firmware treats as ineligible for its
+own eviction sweeps — trading a small amount of on-device favourite-slots for
+reliable delivery to the users who actually talk to the BBS.
+
+### Eligibility and the protection mechanism
+
+A contact becomes eligible for protection the first time it exchanges a
+real DM with the BBS (a chat-type message on MeshCore; a person-role node —
+`CLIENT`/`CLIENT_MUTE`/`CLIENT_HIDDEN`/`CLIENT_BASE` — on Meshtastic; a
+router/repeater is never protected). On MeshCore this is a full-record
+`AddUpdateContact` write with the `is_favourite` flag set; on Meshtastic
+it's a `set_favorite_node` admin-message write (protobuf tag `39`). Both
+writes go through a deferred-write queue gated on a live session/passkey,
+not sent inline with the reply — a failed or reverted write never blocks
+the user's actual message from being answered.
+
+### Capacity and eviction
+
+Each transport has its own `protected_contact_cap` config key
+(`[plugins.mesh]`/`[plugins.meshtastic]`, see [CONFIG.md](CONFIG.md)) —
+MeshCore defaults to `350`, Meshtastic to `100`; the two are intentionally
+different, tracking real device capacity rather than tracking each other.
+`0` disables protection entirely on that transport. Once the cap is reached,
+a newly-eligible sender's first DM evicts the **oldest-protected,
+currently session-inactive** contact on that transport to make room, rather
+than growing the protected set further — the contact with the earliest
+`protected_at` timestamp among those with no active session and outside a
+brief post-protection grace window. If every protected contact is currently
+mid-session (so none is a safe eviction candidate), the new contact is
+simply not protected and the BBS logs a distinct warning; nothing crashes
+or silently loses state either way.
+
+### MeshCore: saturated contact table
+
+If MeshCore's own contact table is completely full — no further contact,
+protected or not, fits — the BBS's own eviction above can't help (there's
+no room even for the entry replacing an evicted one), and the transport
+logs a clear, distinct warning rather than failing silently. This is a
+refusal, not a crash: MeshCore firmware's own node-database code skips
+favourited entries when it looks for something to evict but degrades
+gracefully when nothing qualifies.
+
+### Meshtastic: saturated node database is a firmware crash risk, not a refusal
+
+Meshtastic's failure mode here is more severe, and the BBS has no way to
+detect or warn about it in advance. Meshtastic firmware's node-database
+eviction search (`NodeDB::getOrCreateMeshNode`, `NodeDB.cpp`) does not
+gracefully refuse when no evictable candidate is found — it falls through
+to an out-of-bounds write against a fixed-size vector, which on a typical
+embedded build (no C++ exception support) crashes or reboots the radio.
+**No BBS-side warning is possible for this case**: by the time the BBS
+could observe a saturated table, the device may have already crashed. This
+finding rests on a single external firmware-source read, not yet
+corroborated by a second independent source — treat it as "verified once,"
+not settled fact, and keep `protected_contact_cap` at or below your
+device's real `MAX_NUM_NODES` as the only available mitigation.
+
+### Path-replay tradeoff
+
+Protecting a MeshCore contact means writing its full record
+(`AddUpdateContact` has no partial/flags-only variant), which necessarily
+touches the device's cached routing path for that contact alongside the
+favourite flag — there's no option that leaves the path provably untouched.
+The BBS replays the contact's own last-known cached path rather than
+resetting it to "unknown": firmware source confirms an explicit path reset
+has the *more* destructive effect of guaranteeing a full rediscovery flood
+on the next send, every time, whereas replaying the cached path is only
+occasionally stale (and self-corrects on the next real exchange). Between
+"occasionally stale but usually valid" and "always destructive," the BBS
+deliberately chooses the former.
+
+### MeshCore prefix-collision limitation
+
+MeshCore contacts are resolved from a DM's 6-byte pubkey prefix, not the
+full 32-byte key — a pre-existing wire-protocol characteristic this feature
+does not introduce. A prefix collision between two distinct real contacts
+was always possible (roughly 2⁻⁴⁸ per pair) and previously caused, at
+worst, a transient misrouted session that self-corrected. This feature
+attaches a more consequential outcome to the same limitation: since
+protecting or deleting a contact is now a full-record radio-side write (not
+just a session mixup), a resolved-by-prefix collision could direct that
+write at the wrong contact's persistent device state. A passive collision
+is still astronomically unlikely; a *deliberate* one is a large but
+not-astronomical computation (roughly 2⁴⁸ Ed25519 keypairs to grind) for an
+attacker who already knows or can observe a target's 6-byte prefix. This is
+a known, accepted, unmitigated-in-code limitation — documented here rather
+than silently carried, alongside the Meshtastic firmware-crash risk above.
+
+### Discovered Contacts vs. Contacts, and delete semantics
+
+The web admin UI and API distinguish two views over the same underlying
+advert data:
+
+- **Discovered Contacts** (`GET /api/v1/adverts`) — every mesh node the BBS
+  has ever seen, protected or not.
+- **Contacts** (`GET /api/v1/contacts`) — only the currently-protected
+  subset; mirrors the CLI's `contacts list` (see [CLI.md](CLI.md)).
+
+Deleting a contact (`DELETE /api/v1/contacts/:pubkey`, Aide/Sysop only) is
+**not a permanent block**. It clears the BBS's own local protection state
+immediately, then best-effort asks the radio to remove the matching native
+favourite/contact entry (a `remove_favorite_node` admin write on Meshtastic,
+a native contact removal on MeshCore) — a failure on that native-removal
+side is logged but doesn't fail the request, since the local state change
+is what actually matters for the BBS's own eviction bookkeeping. Nothing
+prevents the same contact from becoming protected again later if it's still
+eligible (e.g. it DMs the BBS again) — this is a delete of the *protection*,
+not a permanent deny-list entry. A pubkey that only ever appears in
+Discovered Contacts (never protected) has nothing to delete; the endpoint
+responds `404`.
+
 ## Part 3: Internal command schema
 
 The `Command` and `Response` enums in `bbs-core` are the canonical

--- a/src/main.rs
+++ b/src/main.rs
@@ -128,6 +128,58 @@ enum Commands {
         #[command(subcommand)]
         action: NodeAction,
     },
+
+    /// Manage protected mesh contacts via a running BBS's web admin API.
+    ///
+    /// Unlike every other subcommand in this file, this one does NOT work
+    /// standalone against the local database — it requires a running,
+    /// reachable BBS instance with the `admin-web` feature enabled, and
+    /// authenticates against it exactly like the web UI does (a session
+    /// login, not a separate mechanism).
+    Contacts {
+        #[command(subcommand)]
+        action: ContactsAction,
+
+        /// Base URL of the running BBS's web admin API.
+        #[arg(
+            long,
+            env = "SUPPLY_DROP_BBS_URL",
+            default_value = "http://127.0.0.1:8080"
+        )]
+        url: String,
+
+        /// Username to authenticate as. The web admin API's login itself
+        /// requires Aide or Sysop (level 50+) for every action here,
+        /// including `list`/`discovered` — a plain User account cannot log
+        /// in at all and gets the same "invalid credentials" error a wrong
+        /// password would.
+        #[arg(long, env = "SUPPLY_DROP_BBS_USERNAME")]
+        username: String,
+
+        /// Password to authenticate with. Prompted interactively (hidden
+        /// input) if omitted — pass this flag or set the env var for
+        /// non-interactive/scripted use.
+        #[arg(long, env = "SUPPLY_DROP_BBS_PASSWORD")]
+        password: Option<String>,
+    },
+}
+
+#[derive(Subcommand)]
+enum ContactsAction {
+    /// List protected contacts (mirrors the web UI's "Contacts" page).
+    List,
+    /// List every discovered contact, protected or not (mirrors the web
+    /// UI's "Discovered Contacts" page).
+    Discovered,
+    /// Delete a single protected contact by its 64-character hex-encoded
+    /// public key, as shown by `list` (mirrors the web UI's delete button).
+    /// Only *protected* contacts can be deleted this way — a pubkey that
+    /// only appears in `discovered` (never protected) has nothing to
+    /// delete and the server responds 404.
+    Delete {
+        /// The contact's 64-character hex-encoded public key.
+        pubkey: String,
+    },
 }
 
 #[derive(Subcommand)]
@@ -454,6 +506,12 @@ async fn main() {
         Some(Commands::Plugin { action }) => cmd_plugin(config_path.as_deref(), action),
         Some(Commands::Metrics) => cmd_metrics(),
         Some(Commands::Node { action }) => cmd_node(config_path.as_deref(), action).await,
+        Some(Commands::Contacts {
+            action,
+            url,
+            username,
+            password,
+        }) => cmd_contacts(&action, &url, &username, password).await,
     }
 }
 
@@ -2636,4 +2694,407 @@ fn init_tracing(cfg: &config::LoggingConfig) -> LogReloadFn {
             .reload(new_filter)
             .map_err(|e| format!("reload failed: {e}"))
     })
+}
+
+// ── Contacts (web admin API client) ─────────────────────────────────────────
+
+/// One entry from `GET /api/v1/adverts` or `GET /api/v1/contacts` — mirrors
+/// `bbs-web`'s `AdvertResponse` shape.
+#[derive(serde::Deserialize)]
+struct CliContact {
+    ts: i64,
+    pubkey: String,
+    name: String,
+    type_name: String,
+    transport: String,
+    protected: bool,
+}
+
+#[derive(serde::Serialize)]
+struct CliLoginRequest<'a> {
+    username: &'a str,
+    password: &'a str,
+}
+
+#[derive(serde::Deserialize)]
+struct CliErrorBody {
+    error: CliErrorDetail,
+}
+
+#[derive(serde::Deserialize)]
+struct CliErrorDetail {
+    message: String,
+}
+
+/// Print a connection-level failure (refused, timeout, DNS, TLS) as a clear,
+/// actionable error and exit non-zero — FR-013: never print an empty list or
+/// otherwise appear to succeed when the BBS isn't actually reachable.
+fn exit_not_reachable(url: &str, e: &reqwest::Error) -> ! {
+    eprintln!("error: BBS not reachable at {url}: {e}");
+    eprintln!(
+        "  Check that the BBS is running with the admin-web feature enabled \
+         and that --url points at it."
+    );
+    std::process::exit(1);
+}
+
+/// Extract `{"error":{"message":...}}` from a failed response body, falling
+/// back to the bare status line when the body isn't that shape (e.g. a
+/// proxy's own error page).
+async fn error_detail(status: reqwest::StatusCode, resp: reqwest::Response) -> String {
+    resp.json::<CliErrorBody>()
+        .await
+        .map(|b| b.error.message)
+        .unwrap_or_else(|_| status.to_string())
+}
+
+/// `pubkey` reaches here as free-form CLI argument text and is about to be
+/// interpolated into a URL path via `format!` — reject anything that isn't
+/// exactly the 64 hex characters the server expects *before* building that
+/// URL, so a value like `../../whatever` or one containing `?`/`#` can never
+/// redirect the (authenticated) request to an unintended path or query.
+fn is_valid_pubkey_hex(s: &str) -> bool {
+    s.len() == 64 && s.bytes().all(|b| b.is_ascii_hexdigit())
+}
+
+async fn cmd_contacts(
+    action: &ContactsAction,
+    url: &str,
+    username: &str,
+    password: Option<String>,
+) {
+    if let ContactsAction::Delete { pubkey } = action {
+        if !is_valid_pubkey_hex(pubkey) {
+            eprintln!("error: invalid pubkey {pubkey:?} — expected 64 hex characters");
+            std::process::exit(1);
+        }
+    }
+
+    let password = password.unwrap_or_else(|| {
+        dialoguer::Password::new()
+            .with_prompt(format!("Password for {username}"))
+            .interact()
+            .unwrap_or_else(|e| {
+                eprintln!("error reading password: {e}");
+                std::process::exit(1);
+            })
+    });
+
+    let client = match reqwest::Client::builder()
+        .cookie_store(true)
+        .redirect(reqwest::redirect::Policy::none())
+        .build()
+    {
+        Ok(c) => c,
+        Err(e) => {
+            eprintln!("error: failed to build HTTP client: {e}");
+            std::process::exit(1);
+        }
+    };
+
+    let base = url.trim_end_matches('/');
+
+    let login_resp = match client
+        .post(format!("{base}/api/v1/auth/login"))
+        .json(&CliLoginRequest {
+            username,
+            password: &password,
+        })
+        .send()
+        .await
+    {
+        Ok(r) => r,
+        Err(e) => exit_not_reachable(url, &e),
+    };
+
+    if !login_resp.status().is_success() {
+        let status = login_resp.status();
+        let detail = error_detail(status, login_resp).await;
+        eprintln!("error: login failed ({status}): {detail}");
+        std::process::exit(1);
+    }
+
+    match action {
+        ContactsAction::List => list_contacts(&client, base, "/api/v1/contacts", url).await,
+        ContactsAction::Discovered => {
+            list_contacts(&client, base, "/api/v1/adverts", url).await;
+        }
+        ContactsAction::Delete { pubkey } => delete_contact(&client, base, pubkey, url).await,
+    }
+}
+
+async fn list_contacts(client: &reqwest::Client, base: &str, path: &str, url: &str) {
+    let resp = match client.get(format!("{base}{path}")).send().await {
+        Ok(r) => r,
+        Err(e) => exit_not_reachable(url, &e),
+    };
+    if !resp.status().is_success() {
+        let status = resp.status();
+        let detail = error_detail(status, resp).await;
+        eprintln!("error: request failed ({status}): {detail}");
+        std::process::exit(1);
+    }
+    let contacts: Vec<CliContact> = match resp.json().await {
+        Ok(c) => c,
+        Err(e) => {
+            eprintln!("error: failed to parse response: {e}");
+            std::process::exit(1);
+        }
+    };
+
+    if contacts.is_empty() {
+        println!("(no contacts)");
+        return;
+    }
+
+    println!(
+        "{:<10} {:<24} {:<12} {:<10} {:<20} PUBKEY",
+        "PROTECTED", "NAME", "TRANSPORT", "TYPE", "LAST SEEN"
+    );
+    println!("{}", "-".repeat(100));
+    for c in &contacts {
+        let last_seen = time::OffsetDateTime::from_unix_timestamp(c.ts)
+            .map(|t| {
+                t.format(&time::format_description::well_known::Rfc3339)
+                    .unwrap_or_else(|_| c.ts.to_string())
+            })
+            .unwrap_or_else(|_| c.ts.to_string());
+        println!(
+            "{:<10} {:<24} {:<12} {:<10} {:<20} {}",
+            if c.protected { "yes" } else { "no" },
+            truncate(&sanitize_for_terminal(&c.name), 24),
+            sanitize_for_terminal(&c.transport),
+            sanitize_for_terminal(&c.type_name),
+            last_seen,
+            c.pubkey,
+        );
+    }
+}
+
+async fn delete_contact(client: &reqwest::Client, base: &str, pubkey: &str, url: &str) {
+    // Validated by cmd_contacts before this is ever called, so it's safe to
+    // interpolate directly — a bare path segment, never `../`, `?`, or `#`.
+    let resp = match client
+        .delete(format!("{base}/api/v1/contacts/{pubkey}"))
+        .send()
+        .await
+    {
+        Ok(r) => r,
+        Err(e) => exit_not_reachable(url, &e),
+    };
+    let status = resp.status();
+    if status.is_success() {
+        println!("deleted: {pubkey}");
+        return;
+    }
+    let detail = error_detail(status, resp).await;
+    eprintln!("error: delete failed ({status}): {detail}");
+    std::process::exit(1);
+}
+
+/// Replace control characters and explicit Unicode bidi-override characters
+/// with `U+FFFD` before printing text that originates from an untrusted
+/// mesh peer (contact names/types/transports) — otherwise a hostile advert
+/// could inject ANSI/CSI/OSC escapes or right-to-left overrides into the
+/// sysop's own terminal.
+fn sanitize_for_terminal(s: &str) -> String {
+    s.chars()
+        .map(|c| {
+            let unsafe_char =
+                c.is_control() || matches!(c, '\u{202A}'..='\u{202E}' | '\u{2066}'..='\u{2069}');
+            if unsafe_char {
+                '\u{fffd}'
+            } else {
+                c
+            }
+        })
+        .collect()
+}
+
+fn truncate(s: &str, max: usize) -> String {
+    if max == 0 {
+        String::new()
+    } else if s.chars().count() <= max {
+        s.to_owned()
+    } else {
+        s.chars().take(max - 1).collect::<String>() + "…"
+    }
+}
+
+#[cfg(test)]
+mod contacts_tests {
+    use super::*;
+
+    #[test]
+    fn truncate_leaves_short_strings_untouched() {
+        assert_eq!(truncate("basecamp", 24), "basecamp");
+        assert_eq!(truncate("exact-len", 9), "exact-len");
+    }
+
+    #[test]
+    fn truncate_shortens_long_strings_with_ellipsis() {
+        assert_eq!(truncate("basecamp-node-north-ridge", 10), "basecamp-…");
+    }
+
+    #[test]
+    fn truncate_counts_unicode_scalars_not_bytes() {
+        // "café-node-north" has one multi-byte char; a byte-counting
+        // truncate would slice mid-character and panic or corrupt output.
+        let out = truncate("café-node-north", 5);
+        assert_eq!(out.chars().count(), 5);
+        assert!(out.ends_with('…'));
+    }
+
+    #[test]
+    fn truncate_handles_max_zero() {
+        // max is a hard ceiling on the *output* length — "…" alone would
+        // already violate a max of 0.
+        assert_eq!(truncate("anything", 0), "");
+    }
+
+    #[test]
+    fn pubkey_hex_accepts_64_char_hex_either_case() {
+        assert!(is_valid_pubkey_hex(&"ab".repeat(32)));
+        assert!(is_valid_pubkey_hex(&"AB".repeat(32)));
+    }
+
+    #[test]
+    fn pubkey_hex_rejects_wrong_length() {
+        assert!(!is_valid_pubkey_hex("ab12"));
+        assert!(!is_valid_pubkey_hex(&"ab".repeat(33)));
+        assert!(!is_valid_pubkey_hex(""));
+    }
+
+    #[test]
+    fn pubkey_hex_rejects_path_traversal_and_url_special_chars() {
+        // These are exactly the values that would otherwise get spliced
+        // into a URL path via format!() and could redirect the request to
+        // an unintended endpoint.
+        assert!(!is_valid_pubkey_hex("../../../etc/passwd"));
+        assert!(!is_valid_pubkey_hex(&format!("{}?x=1", "a".repeat(60))));
+        assert!(!is_valid_pubkey_hex(&format!("{}#frag", "a".repeat(59))));
+    }
+
+    #[test]
+    fn sanitize_for_terminal_leaves_plain_text_untouched() {
+        assert_eq!(
+            sanitize_for_terminal("basecamp-node café"),
+            "basecamp-node café"
+        );
+    }
+
+    #[test]
+    fn sanitize_for_terminal_replaces_control_and_bidi_override_chars() {
+        // ESC (start of ANSI/CSI/OSC sequences) and an explicit
+        // right-to-left override, both reachable from a mesh peer's
+        // self-reported name.
+        let input = "safe\u{1b}[31mred\u{202e}gnidaelsim";
+        let out = sanitize_for_terminal(input);
+        assert!(!out.contains('\u{1b}'));
+        assert!(!out.contains('\u{202e}'));
+        assert!(out.starts_with("safe"));
+    }
+
+    fn parse(args: &[&str]) -> Cli {
+        Cli::try_parse_from(args).expect("expected args to parse")
+    }
+
+    #[test]
+    fn contacts_list_parses_with_required_flags_and_default_url() {
+        // Flags declared alongside `#[command(subcommand)]` on `Contacts`
+        // belong to the parent and must precede the action token (`list`);
+        // clap treats everything after it as the subcommand's own args.
+        let cli = parse(&[
+            "supply-drop-bbs",
+            "contacts",
+            "--username",
+            "alice",
+            "--password",
+            "hunter2",
+            "list",
+        ]);
+        match cli.command {
+            Some(Commands::Contacts {
+                action,
+                url,
+                username,
+                password,
+            }) => {
+                assert!(matches!(action, ContactsAction::List));
+                assert_eq!(url, "http://127.0.0.1:8080");
+                assert_eq!(username, "alice");
+                assert_eq!(password.as_deref(), Some("hunter2"));
+            }
+            _ => panic!("expected Commands::Contacts"),
+        }
+    }
+
+    #[test]
+    fn contacts_discovered_parses_with_explicit_url() {
+        let cli = parse(&[
+            "supply-drop-bbs",
+            "contacts",
+            "--url",
+            "http://192.168.1.50:8080",
+            "--username",
+            "alice",
+            "discovered",
+        ]);
+        match cli.command {
+            Some(Commands::Contacts {
+                action,
+                url,
+                password,
+                ..
+            }) => {
+                assert!(matches!(action, ContactsAction::Discovered));
+                assert_eq!(url, "http://192.168.1.50:8080");
+                // Not supplied on the command line — prompted interactively later.
+                assert_eq!(password, None);
+            }
+            _ => panic!("expected Commands::Contacts"),
+        }
+    }
+
+    #[test]
+    fn contacts_delete_captures_the_pubkey_argument() {
+        let cli = parse(&[
+            "supply-drop-bbs",
+            "contacts",
+            "--username",
+            "alice",
+            "--password",
+            "hunter2",
+            "delete",
+            "ab12cd34ef56",
+        ]);
+        match cli.command {
+            Some(Commands::Contacts { action, .. }) => match action {
+                ContactsAction::Delete { pubkey } => assert_eq!(pubkey, "ab12cd34ef56"),
+                _ => panic!("expected ContactsAction::Delete"),
+            },
+            _ => panic!("expected Commands::Contacts"),
+        }
+    }
+
+    #[test]
+    fn contacts_requires_username() {
+        // Checked via clap's own command metadata rather than by actually
+        // parsing argv without --username: a real parse would silently pass
+        // whenever SUPPLY_DROP_BBS_USERNAME happens to be set in the
+        // ambient test-process environment (plausible, since that's this
+        // flag's own env var), which would make this assertion a silent
+        // no-op instead of a hard requirement check.
+        use clap::CommandFactory;
+        let command = Cli::command();
+        let contacts = command
+            .get_subcommands()
+            .find(|c| c.get_name() == "contacts")
+            .expect("contacts subcommand exists");
+        let username_arg = contacts
+            .get_arguments()
+            .find(|a| a.get_id() == "username")
+            .expect("username arg exists");
+        assert!(username_arg.is_required_set());
+    }
 }


### PR DESCRIPTION
## Summary

Protects BBS users' MeshCore and Meshtastic contact entries from repeater-advert eviction (issue #185) by pinning DM'd contacts as native favourites on the radio, plus a scope-expanded Discovered Contacts / Contacts split, manual delete, and CLI parity.

- **AdvertBus** (`bbs-plugin-api`): single source of truth for contact-protection decisions, atomic protect/evict outcomes, a per-transport `protected_contact_cap` with oldest-protected eviction, and device-resync merge handling that survives BBS restarts.
- **MeshCore** (`bbs-mesh`): protects a contact on its first real DM via `AddUpdateContact`, replaying its cached path rather than resetting it (the less-destructive option); a saturated contact table logs a clear warning instead of failing silently; retries protection when identity resolves via any advert/path-update frame, with a cooldown-gated `GetContacts` catch-up for senders whose full contact record predates their first DM.
- **Meshtastic** (`bbs-meshtastic`): mirrors the same mechanism via `set_favorite_node`, gated to person-role devices, with protection state rehydrated from the device's own `is_favorite` field and spoofed-pubkey rejection on node_num reassignment.
- **Web admin** (`bbs-web`): splits "Discovered Contacts" (every seen node) from "Contacts" (currently-protected only), adds manual delete (local unprotect + best-effort native radio removal — not a permanent block), and exposes the same data over the API.
- **CLI** (`supply-drop-bbs`): a new `contacts list/discovered/delete` subcommand group, authenticating against a running BBS's web admin API exactly like the web UI does.
- `docs/PROTOCOL.md` documents the mechanism for both transports, including the Meshtastic saturated-node-database firmware-crash risk, the path-replay tradeoff, and the MeshCore prefix-collision limitation this feature makes more consequential without introducing it.

Every phase went through a hostile multi-agent code audit (claim extraction, independent verification, persona review, adversarial skeptic re-verification) before being considered complete. Full workspace gate (`fmt`, `clippy --all-targets --all-features -D warnings`, `test`, `doc`) and the frontend build (`vue-tsc`, `vite`) are green.

## Real-hardware validation

Tested end-to-end against a live MeshCore radio and a live Meshtastic radio on a real regional mesh network:
- DM → protected confirmed on both transports.
- Protection survives an actual physical device power-cycle on both transports — confirmed the *radio's own* persisted favourite state survives, not just BBS-side memory (see PR discussion / commit history for the code-level reasoning).
- A real bug was found mid-testing (a MeshCore node that DMs before ever advertising never became protectable) and fixed in this branch, itself hostile-audited and covered by new regression tests.

Closes #185.

## Test plan

- [x] Full Rust workspace gate green (fmt, clippy --all-targets --all-features -D warnings, test, doc) on Linux
- [x] Frontend build green (`vue-tsc --noEmit`, `vite build`)
- [x] Manual live-server E2E testing of the CLI (login, list, discovered, delete, auth failure, unreachable-server paths) against a real running BBS instance
- [x] Hostile multi-agent audit per phase (MeshCore, Meshtastic, Discovered/Contacts split, manual delete, CLI parity, and the mid-testing bugfix) — findings fixed, reports available on request
- [x] Real-hardware end-to-end walkthrough (both MeshCore and Meshtastic radios) — DM-to-protect and reboot-persistence confirmed on both
- [ ] Fine-grained edge-case regression tests for MeshCore/Meshtastic saturation/eviction scenarios — deferred pending a decision on adding test-only harness infrastructure (outbound-channel saturation injection); see tracked follow-ups

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
