### PR TITLE
fix(web): remove prefilled admin username from login form

### DIFF
--- a/crates/bbs-web/web/src/pages/LoginPage.vue
+++ b/crates/bbs-web/web/src/pages/LoginPage.vue
@@ -9,7 +9,7 @@ const router = useRouter()
 const route = useRoute()
 const auth = useAuthStore()
 
-const username = ref('admin')
+const username = ref('')
 const password = ref('')
 const error = ref<string | null>(null)
 const loading = ref(false)


### PR DESCRIPTION
## Summary

The web admin login form pre-filled the username field with `admin`, nudging every visitor toward assuming that account name exists and should be guessed against — the same pattern flagged in #186.

- `crates/bbs-web/web/src/pages/LoginPage.vue`: `username` now defaults to an empty string instead of `'admin'`.

Fixes #188.

## Test plan

- [x] `vue-tsc --noEmit && vite build` green