### PR TITLE
feat: add GUI-based database backup restore

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -161,6 +161,7 @@ dependencies = [
  "matchit",
  "memchr",
  "mime",
+ "multer",
  "percent-encoding",
  "pin-project-lite",
  "rustversion",
@@ -274,6 +275,7 @@ dependencies = [
  "tokio",
  "toml_edit",
  "tracing",
+ "zip",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -108,7 +108,7 @@ argon2      = { version = "0.5", features = ["std"] }
 tempfile    = "3"
 tracing     = "0.1"
 uuid        = { version = "1", features = ["v4", "serde"] }
-axum        = { version = "0.7", features = ["macros", "json"] }
+axum        = { version = "0.7", features = ["macros", "json", "multipart"] }
 axum-extra  = { version = "0.9", features = ["cookie"] }
 tower-http  = { version = "0.5", features = ["cors", "set-header"] }
 rust-embed  = { version = "8" }

--- a/crates/bbs-core/Cargo.toml
+++ b/crates/bbs-core/Cargo.toml
@@ -24,6 +24,7 @@ time.workspace        = true
 tokio.workspace       = true
 toml_edit.workspace   = true
 tracing.workspace     = true
+zip.workspace         = true
 
 [dev-dependencies]
 proptest    = { workspace = true }

--- a/crates/bbs-core/src/db/admin_queries.rs
+++ b/crates/bbs-core/src/db/admin_queries.rs
@@ -469,4 +469,316 @@ impl Database {
 
         Ok(())
     }
+
+    /// Validate an uploaded file as a restorable supply-drop-bbs database,
+    /// WITHOUT touching the live database, then stage it as
+    /// `<data_dir>/pending_restore.staged.db`.
+    ///
+    /// This is deliberately an INERT filename that `main.rs`'s startup check
+    /// never looks at — only `admin_apply_staged_restore` (called from the
+    /// web layer's `api_apply_restore` once the sysop has explicitly
+    /// confirmed) renames it to `pending_restore.db`, the name that actually
+    /// triggers the destructive swap. Staging and confirming must be two
+    /// distinct filesystem states, not two calls that both key off the same
+    /// file: an earlier version of this feature staged directly to
+    /// `pending_restore.db`, which meant ANY unrelated process restart
+    /// between upload and confirmation — a crash, an operator restarting
+    /// the service for an unrelated reason, systemd's own `Restart=always`
+    /// firing after any exit — silently applied a restore nobody had
+    /// confirmed yet (issue #195).
+    ///
+    /// Validation has four tiers: a cheap SQLite file-format check; a check
+    /// that the file already has migration history of its own (see below);
+    /// running this binary's own embedded migrations against the uploaded
+    /// file directly — the same mechanism `Database::open` uses on the live
+    /// database, just pointed at the candidate file instead, which lets an
+    /// older-schema backup be upgraded in place as part of staging it (this
+    /// means "validation" can mutate the uploaded file's on-disk bytes, not
+    /// merely inspect them); and finally the same room-walk-order
+    /// structural check `Database::open` runs after migrating.
+    ///
+    /// The migration history check is load-bearing, not redundant: every
+    /// migration in `crates/bbs-core/migrations/` is written to be safely
+    /// re-runnable (`CREATE TABLE IF NOT EXISTS`, `INSERT OR IGNORE`, or
+    /// `DROP TABLE IF EXISTS` + `CREATE TABLE`), so `sqlx::migrate!().run()`
+    /// on its own happily builds a full, valid, EMPTY schema out of a
+    /// brand-new SQLite file — running the migrator alone cannot tell "a
+    /// real backup that needs a couple of pending migrations" apart from
+    /// "an empty file migrate! is willing to adopt from scratch". Requiring
+    /// `_sqlx_migrations` to already contain at least one successful row
+    /// closes that gap for the common accidental case (an empty file, or a
+    /// foreign app's unrelated database). It is not a cryptographic
+    /// guarantee: sqlx's migration checksums are plain SHA-384 hashes of
+    /// this project's own (public) migration file contents, so a
+    /// hand-crafted file could in principle pre-populate `_sqlx_migrations`
+    /// with correct-looking rows and no real tables behind them. The
+    /// `verify_room_walk_order` check below (mirroring what `Database::open`
+    /// does on the live database) catches that case too, by actually
+    /// querying the `rooms` table rather than trusting bookkeeping alone —
+    /// and this endpoint is sysop-only regardless.
+    ///
+    /// `uploaded_path` may be a raw `.db` file OR a `.zip` bundle in the
+    /// exact shape `admin_backup`'s caller produces (a single `.db`-named
+    /// entry, optional `config.toml`) — a zip is detected by magic bytes
+    /// and its `.db` entry extracted (overwriting `uploaded_path` in place)
+    /// before the checks below run. The zip format is accepted here, in
+    /// the one place both the CLI and the web upload handler call through,
+    /// so neither caller needs its own copy of this detection logic.
+    /// `uploaded_path` is always a disposable file the caller owns for the
+    /// duration of this call (a per-request temp file, or a CLI-made copy
+    /// of the operator's real source file) — never overwrite a file the
+    /// caller doesn't expect to be consumed this way.
+    ///
+    /// Public (not `pub(crate)`) deliberately: this never opens or requires
+    /// the LIVE database, so the CLI `restore` subcommand can call it
+    /// directly, without going through `open_database`/`BbsHost` — staging
+    /// a restore must keep working even when the live database is broken
+    /// or missing, which is often exactly why an operator wants to restore.
+    pub async fn stage_restore(uploaded_path: &Path, data_dir: &Path) -> Result<(), StoreError> {
+        let raw = tokio::fs::read(uploaded_path)
+            .await
+            .map_err(|e| StoreError::Decode(format!("read uploaded file: {e}")))?;
+        if raw.starts_with(b"PK\x03\x04") {
+            let extracted = tokio::task::spawn_blocking(move || extract_single_db_from_zip(&raw))
+                .await
+                .map_err(|e| StoreError::Decode(format!("extracting zip upload: {e}")))?
+                .map_err(StoreError::Decode)?;
+            tokio::fs::write(uploaded_path, &extracted)
+                .await
+                .map_err(|e| StoreError::Decode(format!("writing extracted upload: {e}")))?;
+        } else if !raw.starts_with(b"SQLite format 3\0") {
+            return Err(StoreError::Decode(
+                "not a SQLite database file or a recognized backup zip (bad header)".into(),
+            ));
+        }
+
+        let opts = sqlx::sqlite::SqliteConnectOptions::new()
+            .filename(uploaded_path)
+            .create_if_missing(false)
+            .foreign_keys(true);
+        let pool = sqlx::sqlite::SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect_with(opts)
+            .await
+            .map_err(|e| StoreError::Decode(format!("open uploaded database: {e}")))?;
+
+        let migrations_table_exists: i64 = sqlx::query_scalar(
+            "SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = '_sqlx_migrations'",
+        )
+        .fetch_one(&pool)
+        .await
+        .unwrap_or(0);
+        let applied_migrations: i64 = if migrations_table_exists > 0 {
+            sqlx::query_scalar("SELECT COUNT(*) FROM _sqlx_migrations WHERE success = 1")
+                .fetch_one(&pool)
+                .await
+                .unwrap_or(0)
+        } else {
+            0
+        };
+        if applied_migrations == 0 {
+            pool.close().await;
+            return Err(StoreError::Decode(
+                "uploaded file has no supply-drop-bbs migration history — \
+                 not a backup of this application (an empty or unrelated \
+                 SQLite file cannot be restored)"
+                    .into(),
+            ));
+        }
+
+        let migrate_result = sqlx::migrate!("./migrations").run(&pool).await;
+        // `Database::open` also verifies the room-walk-order invariant
+        // after migrating (see db/mod.rs) — check it here too, on the same
+        // still-open pool, before staging. Without this, a candidate file
+        // that migrates cleanly but has a corrupt room linked-list would
+        // only be caught AFTER the destructive swap in main.rs, whose only
+        // failure handling is to exit — there is no automatic rollback to
+        // the pre-restore safety snapshot.
+        let invariant_result = if migrate_result.is_ok() {
+            Some(super::invariants::verify_room_walk_order(&pool).await)
+        } else {
+            None
+        };
+        pool.close().await;
+        // Best-effort: a VACUUM INTO backup (this project's own admin_backup)
+        // is produced in DELETE journal mode and carries no sidecars, but
+        // defend against an upload that somehow does — a stray WAL/SHM next
+        // to the staged file would otherwise ride along into `data_dir`.
+        let _ = tokio::fs::remove_file(format!("{}-wal", uploaded_path.display())).await;
+        let _ = tokio::fs::remove_file(format!("{}-shm", uploaded_path.display())).await;
+        migrate_result.map_err(|e| {
+            StoreError::Decode(format!(
+                "uploaded file is not a compatible supply-drop-bbs \
+                 database (migration check failed: {e})"
+            ))
+        })?;
+        if let Some(Err(e)) = invariant_result {
+            return Err(StoreError::Decode(format!(
+                "uploaded file has a broken room structure ({e}) — not a \
+                 healthy supply-drop-bbs database"
+            )));
+        }
+
+        let staged_path = data_dir.join("pending_restore.staged.db");
+        // `rename` is atomic but fails across filesystems (EXDEV) — the
+        // upload's temp file and data_dir are not guaranteed to share one,
+        // so fall back to copy+delete on that specific failure.
+        if tokio::fs::rename(uploaded_path, &staged_path)
+            .await
+            .is_err()
+        {
+            tokio::fs::copy(uploaded_path, &staged_path)
+                .await
+                .map_err(|e| StoreError::Decode(format!("stage restore file: {e}")))?;
+            let _ = tokio::fs::remove_file(uploaded_path).await;
+        }
+
+        Ok(())
+    }
+
+    /// Confirm a previously staged restore (see `stage_restore`) by renaming
+    /// it from its inert staged name to `pending_restore.db` — the only
+    /// name `main.rs`'s startup check looks for. Re-checks the staged
+    /// file's SQLite header immediately before the rename: cheap insurance
+    /// against confirming a file left truncated by an interrupted upload
+    /// (e.g. a concurrent upload's copy-fallback still in flight when the
+    /// process exits to apply this one).
+    ///
+    /// Returns an error, touching nothing, if no restore is currently
+    /// staged.
+    ///
+    /// Public for the same reason as `stage_restore`: confirming a restore
+    /// must not require the live database to open cleanly first.
+    pub async fn admin_apply_staged_restore(data_dir: &Path) -> Result<(), StoreError> {
+        let staged_path = data_dir.join("pending_restore.staged.db");
+        if !staged_path.exists() {
+            return Err(StoreError::Decode("no restore is currently staged".into()));
+        }
+        if !sqlite_header_ok(&staged_path).await {
+            let _ = tokio::fs::remove_file(&staged_path).await;
+            return Err(StoreError::Decode(
+                "staged restore file is corrupt (bad header) — discarded, upload again".into(),
+            ));
+        }
+
+        let confirmed_path = data_dir.join("pending_restore.db");
+        if tokio::fs::rename(&staged_path, &confirmed_path)
+            .await
+            .is_err()
+        {
+            tokio::fs::copy(&staged_path, &confirmed_path)
+                .await
+                .map_err(|e| StoreError::Decode(format!("confirm restore file: {e}")))?;
+            let _ = tokio::fs::remove_file(&staged_path).await;
+        }
+        Ok(())
+    }
+}
+
+/// Read just the first 16 bytes of `path` and check them against the SQLite
+/// file-format magic, without loading the whole (potentially multi-gigabyte)
+/// file into memory the way a plain `tokio::fs::read` header check would.
+async fn sqlite_header_ok(path: &std::path::Path) -> bool {
+    use tokio::io::AsyncReadExt;
+    let mut buf = [0u8; 16];
+    let Ok(mut file) = tokio::fs::File::open(path).await else {
+        return false;
+    };
+    file.read_exact(&mut buf).await.is_ok() && buf.starts_with(b"SQLite format 3\0")
+}
+
+/// Extract the single `.db`-named entry from a zip archive's raw bytes, as
+/// produced by `admin_backup`'s zip-bundling caller. Rejects an archive
+/// with zero or more than one `.db` entry rather than guessing which one is
+/// the database. Runs synchronously — callers on an async runtime should
+/// wrap this in `spawn_blocking`, since decompression is CPU-bound.
+fn extract_single_db_from_zip(zip_bytes: &[u8]) -> Result<Vec<u8>, String> {
+    let cursor = std::io::Cursor::new(zip_bytes);
+    let mut archive = zip::ZipArchive::new(cursor).map_err(|e| format!("reading zip: {e}"))?;
+    let mut db_index = None;
+    for i in 0..archive.len() {
+        let entry = archive
+            .by_index(i)
+            .map_err(|e| format!("reading zip entry {i}: {e}"))?;
+        if entry.name().ends_with(".db") {
+            if db_index.is_some() {
+                return Err("zip contains more than one .db file".to_owned());
+            }
+            db_index = Some(i);
+        }
+    }
+    let idx = db_index.ok_or_else(|| "zip does not contain a .db file".to_owned())?;
+    let mut entry = archive
+        .by_index(idx)
+        .map_err(|e| format!("reading zip entry: {e}"))?;
+    let mut out = Vec::with_capacity(entry.size() as usize);
+    std::io::Read::read_to_end(&mut entry, &mut out)
+        .map_err(|e| format!("extracting zip entry: {e}"))?;
+    Ok(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::extract_single_db_from_zip;
+
+    // Issue #195: `admin_backup`'s zip-bundling caller never offers a raw
+    // `.db` for download, only the `.zip` bundle it always produces — so
+    // `stage_restore` must accept that same zip, or the "download a
+    // backup, restore it later" workflow is a dead end.
+    fn build_test_zip(entries: &[(&str, &[u8])]) -> Vec<u8> {
+        use std::io::Write as _;
+        let mut buf = Vec::new();
+        {
+            let cursor = std::io::Cursor::new(&mut buf);
+            let mut zip = zip::ZipWriter::new(cursor);
+            let opts = zip::write::SimpleFileOptions::default();
+            for (name, contents) in entries {
+                zip.start_file(*name, opts).unwrap();
+                zip.write_all(contents).unwrap();
+            }
+            zip.finish().unwrap();
+        }
+        buf
+    }
+
+    #[test]
+    fn extract_single_db_from_zip_finds_the_lone_db_entry() {
+        let zip_bytes = build_test_zip(&[
+            ("backup-2026-09-04.db", b"SQLite format 3\0fake db bytes"),
+            ("config.toml", b"[bbs]\nname = \"Test\"\n"),
+        ]);
+        let extracted =
+            extract_single_db_from_zip(&zip_bytes).expect("a single .db entry must extract");
+        assert_eq!(extracted, b"SQLite format 3\0fake db bytes");
+    }
+
+    #[test]
+    fn extract_single_db_from_zip_rejects_no_db_entry() {
+        let zip_bytes = build_test_zip(&[("config.toml", b"[bbs]\n")]);
+        let result = extract_single_db_from_zip(&zip_bytes);
+        assert!(
+            result.is_err(),
+            "a zip with no .db entry must be rejected, not silently accepted"
+        );
+    }
+
+    #[test]
+    fn extract_single_db_from_zip_rejects_ambiguous_multiple_db_entries() {
+        let zip_bytes = build_test_zip(&[
+            ("one.db", b"SQLite format 3\0aaa"),
+            ("two.db", b"SQLite format 3\0bbb"),
+        ]);
+        let result = extract_single_db_from_zip(&zip_bytes);
+        assert!(
+            result.is_err(),
+            "an ambiguous zip with two .db entries must be rejected rather \
+             than silently picking one"
+        );
+    }
+
+    #[test]
+    fn extract_single_db_from_zip_rejects_a_non_zip_buffer() {
+        let result = extract_single_db_from_zip(b"not a zip at all");
+        assert!(result.is_err());
+    }
 }

--- a/crates/bbs-core/src/db/mod.rs
+++ b/crates/bbs-core/src/db/mod.rs
@@ -88,6 +88,35 @@ impl Database {
         })
     }
 
+    /// Force a WAL checkpoint on the database at `path`, folding any
+    /// committed-but-not-yet-checkpointed transactions from its `-wal`
+    /// sidecar into the main file. A no-op if `path` doesn't exist yet.
+    ///
+    /// Call this before taking a plain-file copy of a database that might
+    /// still be running (e.g. a pre-restore safety snapshot in `main.rs`):
+    /// `std::fs::copy` of the main file alone can silently miss recent
+    /// commits still sitting only in the WAL. This is not a rare edge case
+    /// for this project — `apply_pragmas` raises `wal_autocheckpoint` to
+    /// 10000 pages, and every restart path here goes through
+    /// `std::process::exit`, which (per its own contract) runs no
+    /// destructors and therefore skips the checkpoint a clean connection
+    /// close would otherwise perform.
+    pub async fn checkpoint_wal(path: &str) -> Result<(), DbOpenError> {
+        if !std::path::Path::new(path).exists() {
+            return Ok(());
+        }
+        let opts = base_opts(path).create_if_missing(false);
+        let pool = SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect_with(opts)
+            .await?;
+        sqlx::query("PRAGMA wal_checkpoint(TRUNCATE)")
+            .execute(&pool)
+            .await?;
+        pool.close().await;
+        Ok(())
+    }
+
     /// Borrow the internal credential store.
     ///
     /// Only `bbs-core`'s own auth flow should call this. Plugins have

--- a/crates/bbs-core/src/host.rs
+++ b/crates/bbs-core/src/host.rs
@@ -1453,6 +1453,25 @@ impl Host for BbsHost {
             .map_err(|e| HostError::Storage(format!("{e}")))
     }
 
+    async fn admin_stage_restore(
+        &self,
+        uploaded_path: &str,
+        data_dir: &str,
+    ) -> Result<(), HostError> {
+        crate::db::Database::stage_restore(
+            std::path::Path::new(uploaded_path),
+            std::path::Path::new(data_dir),
+        )
+        .await
+        .map_err(|e| HostError::Storage(format!("{e}")))
+    }
+
+    async fn admin_apply_staged_restore(&self, data_dir: &str) -> Result<(), HostError> {
+        crate::db::Database::admin_apply_staged_restore(std::path::Path::new(data_dir))
+            .await
+            .map_err(|e| HostError::Storage(format!("{e}")))
+    }
+
     async fn admin_write_audit(
         &self,
         actor: &str,
@@ -8852,6 +8871,327 @@ mod tests {
         assert!(
             matches!(&resp, Response::Text(t) if t == "Mail sent to bob."),
             "multi-step mail send should confirm 'Mail sent to bob.', got: {resp:?}"
+        );
+    }
+
+    // ── Issue #195: restore-upload staging (validate without touching live DB) ─
+
+    /// A genuine backup of this BBS's own schema (produced the same way
+    /// `admin_trigger_backup` does, via VACUUM INTO) must validate and land
+    /// at `<data_dir>/pending_restore.staged.db` — the inert staged name,
+    /// not the name that actually triggers a swap on next boot — without
+    /// touching the live database at all.
+    #[tokio::test]
+    async fn stage_restore_accepts_a_genuine_backup_and_leaves_live_db_untouched() {
+        let (host, live_db_file) = make_host().await;
+
+        // Confirm the live DB has real content before staging anything, so
+        // "untouched" below is a meaningful assertion, not a vacuous one.
+        RoomStore::create(
+            &host.db,
+            "Untouched Room",
+            None,
+            false,
+            PermissionLevel::User,
+            Timestamp::now(),
+        )
+        .await
+        .unwrap();
+        let live_before = tokio::fs::read(live_db_file.path()).await.unwrap();
+
+        let data_dir = tempfile::tempdir().unwrap();
+        let backup_path = data_dir.path().join("source_backup.db");
+        host.db
+            .admin_backup(&backup_path.to_string_lossy())
+            .await
+            .expect("admin_backup should produce a valid backup file");
+
+        host.admin_stage_restore(
+            &backup_path.to_string_lossy(),
+            &data_dir.path().to_string_lossy(),
+        )
+        .await
+        .expect("a genuine backup of this schema must validate and stage");
+
+        let staged = data_dir.path().join("pending_restore.staged.db");
+        assert!(
+            staged.exists(),
+            "a valid upload must be staged at pending_restore.staged.db"
+        );
+        assert!(
+            !data_dir.path().join("pending_restore.db").exists(),
+            "staging alone must never create the confirmed name that \
+             actually triggers a swap on next boot — only \
+             admin_apply_staged_restore may do that"
+        );
+
+        let live_after = tokio::fs::read(live_db_file.path()).await.unwrap();
+        assert_eq!(
+            live_before, live_after,
+            "staging a restore must never modify the live database file"
+        );
+    }
+
+    /// `admin_backup`'s own zip-bundling caller never offers a raw `.db`
+    /// for download, only a `.zip` — so restore must accept that same zip
+    /// end to end, not just in the unit-level zip-extraction tests.
+    #[tokio::test]
+    async fn stage_restore_accepts_a_zip_wrapped_genuine_backup() {
+        let (host, _live_db_file) = make_host().await;
+
+        let data_dir = tempfile::tempdir().unwrap();
+        let backup_path = data_dir.path().join("source_backup.db");
+        host.db
+            .admin_backup(&backup_path.to_string_lossy())
+            .await
+            .unwrap();
+
+        let zip_path = data_dir.path().join("source_backup.zip");
+        let db_bytes = tokio::fs::read(&backup_path).await.unwrap();
+        {
+            use std::io::Write as _;
+            let file = std::fs::File::create(&zip_path).unwrap();
+            let mut zip = zip::ZipWriter::new(file);
+            let opts = zip::write::SimpleFileOptions::default();
+            zip.start_file("source_backup.db", opts).unwrap();
+            zip.write_all(&db_bytes).unwrap();
+            zip.finish().unwrap();
+        }
+
+        host.admin_stage_restore(
+            &zip_path.to_string_lossy(),
+            &data_dir.path().to_string_lossy(),
+        )
+        .await
+        .expect("a zip-wrapped genuine backup must validate and stage");
+
+        assert!(
+            data_dir.path().join("pending_restore.staged.db").exists(),
+            "the extracted .db must be staged, not the zip itself"
+        );
+    }
+
+    /// A file that isn't a SQLite database at all must be rejected before
+    /// anything is staged or the live database is touched.
+    #[tokio::test]
+    async fn stage_restore_rejects_a_non_sqlite_file() {
+        let (host, _live_db_file) = make_host().await;
+
+        let data_dir = tempfile::tempdir().unwrap();
+        let bogus_path = data_dir.path().join("not_a_database.db");
+        tokio::fs::write(&bogus_path, b"definitely not a sqlite file")
+            .await
+            .unwrap();
+
+        let result = host
+            .admin_stage_restore(
+                &bogus_path.to_string_lossy(),
+                &data_dir.path().to_string_lossy(),
+            )
+            .await;
+        assert!(
+            result.is_err(),
+            "a non-SQLite file must be rejected, not silently staged"
+        );
+
+        let staged = data_dir.path().join("pending_restore.staged.db");
+        assert!(
+            !staged.exists(),
+            "a rejected upload must not be staged for restore"
+        );
+    }
+
+    /// Every migration in crates/bbs-core/migrations is written to be safely
+    /// re-runnable (CREATE TABLE IF NOT EXISTS, INSERT OR IGNORE, DROP TABLE
+    /// IF EXISTS + CREATE TABLE), so running the migrator alone against a
+    /// brand-new, empty-but-valid SQLite file succeeds and quietly builds a
+    /// full empty schema out of it. Validation must catch this case
+    /// explicitly — a file migrate! is merely *willing to adopt* is not the
+    /// same as a file that is genuinely a prior backup of this application.
+    #[tokio::test]
+    async fn stage_restore_rejects_a_brand_new_empty_sqlite_file() {
+        let (host, _live_db_file) = make_host().await;
+
+        let data_dir = tempfile::tempdir().unwrap();
+        let empty_path = data_dir.path().join("empty.db");
+        {
+            use sqlx::sqlite::SqliteConnectOptions;
+            let opts = SqliteConnectOptions::new()
+                .filename(&empty_path)
+                .create_if_missing(true);
+            let pool = sqlx::sqlite::SqlitePoolOptions::new()
+                .max_connections(1)
+                .connect_with(opts)
+                .await
+                .unwrap();
+            // Merely opening and closing a connection does not force SQLite
+            // to write its header — that only happens on the first actual
+            // page write. VACUUM forces one, producing a genuinely
+            // initialized, zero-table database, mimicking what
+            // `sqlite3 empty.db "VACUUM;"` produces on the command line.
+            sqlx::query("VACUUM").execute(&pool).await.unwrap();
+            pool.close().await;
+        }
+        assert!(
+            tokio::fs::read(&empty_path).await.unwrap().len() >= 16,
+            "sanity check: SQLite must have written a real header for an \
+             empty database, or this test isn't exercising the header check"
+        );
+
+        let result = host
+            .admin_stage_restore(
+                &empty_path.to_string_lossy(),
+                &data_dir.path().to_string_lossy(),
+            )
+            .await;
+        assert!(
+            result.is_err(),
+            "a brand-new empty SQLite file must be rejected — it has no \
+             migration history, so migrate! alone cannot distinguish it \
+             from a genuine backup that merely needs upgrading"
+        );
+
+        let staged = data_dir.path().join("pending_restore.staged.db");
+        assert!(
+            !staged.exists(),
+            "a rejected upload must not be staged for restore"
+        );
+    }
+
+    /// A candidate file that migrates cleanly (so the earlier checks all
+    /// pass) but has a structurally broken room linked-list must still be
+    /// rejected — otherwise this class of corruption is only discovered
+    /// AFTER the destructive swap in main.rs, which has no automatic
+    /// rollback to the pre-restore safety snapshot.
+    #[tokio::test]
+    async fn stage_restore_rejects_a_migratable_file_with_a_broken_room_walk_order() {
+        let (host, _live_db_file) = make_host().await;
+
+        let data_dir = tempfile::tempdir().unwrap();
+        let backup_path = data_dir.path().join("source_backup.db");
+        host.db
+            .admin_backup(&backup_path.to_string_lossy())
+            .await
+            .unwrap();
+
+        // Corrupt the backup directly: give a second room a NULL
+        // prev_neighbor, creating two "heads" in what must be a single
+        // linked list.
+        {
+            use sqlx::sqlite::SqliteConnectOptions;
+            let opts = SqliteConnectOptions::new()
+                .filename(&backup_path)
+                .create_if_missing(false);
+            let pool = sqlx::sqlite::SqlitePoolOptions::new()
+                .max_connections(1)
+                .connect_with(opts)
+                .await
+                .unwrap();
+            sqlx::query("UPDATE rooms SET prev_neighbor = NULL WHERE id = 2")
+                .execute(&pool)
+                .await
+                .unwrap();
+            pool.close().await;
+        }
+
+        let result = host
+            .admin_stage_restore(
+                &backup_path.to_string_lossy(),
+                &data_dir.path().to_string_lossy(),
+            )
+            .await;
+        assert!(
+            result.is_err(),
+            "a schema-valid but structurally broken room list must be rejected"
+        );
+
+        let staged = data_dir.path().join("pending_restore.staged.db");
+        assert!(
+            !staged.exists(),
+            "a rejected upload must not be staged for restore"
+        );
+    }
+
+    /// Confirming a staged restore must promote it to `pending_restore.db`
+    /// — the only name main.rs's startup check watches for — and must not
+    /// create that name before confirmation happens (issue #195: an
+    /// earlier version staged directly under that name, so ANY unrelated
+    /// restart between upload and confirmation silently applied an
+    /// unconfirmed restore).
+    #[tokio::test]
+    async fn admin_apply_staged_restore_promotes_a_staged_file_to_the_confirmed_name() {
+        let (host, _live_db_file) = make_host().await;
+
+        let data_dir = tempfile::tempdir().unwrap();
+        let backup_path = data_dir.path().join("source_backup.db");
+        host.db
+            .admin_backup(&backup_path.to_string_lossy())
+            .await
+            .unwrap();
+        host.admin_stage_restore(
+            &backup_path.to_string_lossy(),
+            &data_dir.path().to_string_lossy(),
+        )
+        .await
+        .unwrap();
+        assert!(data_dir.path().join("pending_restore.staged.db").exists());
+        assert!(!data_dir.path().join("pending_restore.db").exists());
+
+        host.admin_apply_staged_restore(&data_dir.path().to_string_lossy())
+            .await
+            .expect("a validly staged restore must confirm");
+
+        assert!(
+            data_dir.path().join("pending_restore.db").exists(),
+            "confirming must promote the staged file to the confirmed name"
+        );
+        assert!(
+            !data_dir.path().join("pending_restore.staged.db").exists(),
+            "the inert staged name must not remain after confirmation"
+        );
+    }
+
+    /// Confirming with nothing staged must error and touch nothing —
+    /// otherwise a sysop hitting "apply" a second time, or by mistake,
+    /// could trigger a pointless restart with no restore to apply.
+    #[tokio::test]
+    async fn admin_apply_staged_restore_errors_when_nothing_is_staged() {
+        let (host, _live_db_file) = make_host().await;
+        let data_dir = tempfile::tempdir().unwrap();
+
+        let result = host
+            .admin_apply_staged_restore(&data_dir.path().to_string_lossy())
+            .await;
+        assert!(result.is_err(), "nothing staged must be an error");
+        assert!(!data_dir.path().join("pending_restore.db").exists());
+    }
+
+    /// A staged file left truncated by an interrupted upload must be
+    /// rejected at confirm time, not blindly promoted to the name that
+    /// triggers a destructive swap on next boot.
+    #[tokio::test]
+    async fn admin_apply_staged_restore_rejects_a_corrupt_staged_file() {
+        let (host, _live_db_file) = make_host().await;
+        let data_dir = tempfile::tempdir().unwrap();
+        tokio::fs::write(
+            data_dir.path().join("pending_restore.staged.db"),
+            b"not a real sqlite file",
+        )
+        .await
+        .unwrap();
+
+        let result = host
+            .admin_apply_staged_restore(&data_dir.path().to_string_lossy())
+            .await;
+        assert!(result.is_err(), "a corrupt staged file must be rejected");
+        assert!(
+            !data_dir.path().join("pending_restore.db").exists(),
+            "a rejected confirmation must not create the confirmed name"
+        );
+        assert!(
+            !data_dir.path().join("pending_restore.staged.db").exists(),
+            "the corrupt staged file should be discarded, not left around \
+             to fail confirmation again on every future attempt"
         );
     }
 }

--- a/crates/bbs-plugin-api/src/host.rs
+++ b/crates/bbs-plugin-api/src/host.rs
@@ -384,6 +384,28 @@ pub trait Host: Send + Sync {
         Err(HostError::NotSupported("admin_delete_backup".into()))
     }
 
+    /// Validate `uploaded_path` as a restorable database WITHOUT touching
+    /// the live one, then stage it in `data_dir` for restore-on-next-startup.
+    /// Returns an error (and leaves the live database untouched) if the
+    /// file isn't a real, migration-compatible copy of this BBS's schema.
+    async fn admin_stage_restore(
+        &self,
+        uploaded_path: &str,
+        data_dir: &str,
+    ) -> Result<(), HostError> {
+        let _ = (uploaded_path, data_dir);
+        Err(HostError::NotSupported("admin_stage_restore".into()))
+    }
+
+    /// Confirm a previously staged restore (see `admin_stage_restore`) by
+    /// promoting it from its inert staged name to the name that actually
+    /// triggers the database swap on next startup. Returns an error if
+    /// nothing is currently staged in `data_dir`.
+    async fn admin_apply_staged_restore(&self, data_dir: &str) -> Result<(), HostError> {
+        let _ = data_dir;
+        Err(HostError::NotSupported("admin_apply_staged_restore".into()))
+    }
+
     // ── Audit log ────────────────────────────────────────────────────────────────
 
     /// Append one entry to the durable audit log.

--- a/crates/bbs-web/src/lib.rs
+++ b/crates/bbs-web/src/lib.rs
@@ -47,6 +47,8 @@
 //! │  │  GET  /api/v1/backups              (auth)       │    │
 //! │  │  GET  /api/v1/backups/:filename    (auth)       │    │
 //! │  │  DELETE /api/v1/backups/:filename  (auth)       │    │
+//! │  │  POST /api/v1/backups/restore      (auth)       │    │
+//! │  │  POST /api/v1/backups/restore/apply(auth)       │    │
 //! │  │  GET  /api/v1/plugins              (auth)       │    │
 //! │  │  POST /api/v1/plugins              (auth)       │    │
 //! │  │  DELETE /api/v1/plugins/:name      (auth)       │    │
@@ -83,7 +85,7 @@ use error_tracker::{ErrorEntry, ErrorStore};
 use rss_monitor::RssAlert;
 
 use async_trait::async_trait;
-use axum::extract::{Path, Query, Request, State};
+use axum::extract::{DefaultBodyLimit, Multipart, Path, Query, Request, State};
 use axum::http::{header, HeaderMap, HeaderValue, StatusCode};
 use axum::middleware::{self, Next};
 use axum::response::sse::{Event, Sse};
@@ -241,6 +243,17 @@ struct AppState {
     /// by the host binary after plugin init via [`WebPlugin::set_backup_dir`].
     /// When `None` the backup endpoints return 503.
     backup_dir: std::sync::Mutex<Option<String>>,
+    /// The BBS's data directory, sourced from `[bbs] data_dir` and injected
+    /// by the host binary after plugin init via [`WebPlugin::set_data_dir`].
+    /// Used to stage an uploaded restore file where `main.rs`'s startup
+    /// check will find it (issue #195).
+    data_dir: std::sync::Mutex<Option<String>>,
+    /// Serializes the whole validate-and-stage / confirm sequence for a
+    /// restore so two concurrent uploads (or an upload racing a confirm)
+    /// can't clobber the shared `pending_restore*.db` paths — an async
+    /// mutex, not `std::sync::Mutex`, since the guard must be held across
+    /// `.await` points (file I/O, running migrations against the upload).
+    restore_lock: tokio::sync::Mutex<()>,
     sessions: Mutex<HashMap<String, WebSession>>,
     started_at: Instant,
     log_tx: broadcast::Sender<String>,
@@ -270,6 +283,8 @@ impl AppState {
             host,
             config,
             backup_dir: std::sync::Mutex::new(None),
+            data_dir: std::sync::Mutex::new(None),
+            restore_lock: tokio::sync::Mutex::new(()),
             sessions: Mutex::new(HashMap::new()),
             started_at: Instant::now(),
             log_tx,
@@ -289,6 +304,11 @@ impl AppState {
     /// Return the configured backup directory, if any.
     fn backup_dir(&self) -> Option<String> {
         self.backup_dir.lock().expect("backup_dir poisoned").clone()
+    }
+
+    /// Return the BBS's data directory, if injected.
+    fn data_dir(&self) -> Option<String> {
+        self.data_dir.lock().expect("data_dir poisoned").clone()
     }
 
     fn create_session(&self, username: String, permission_level: u8) -> String {
@@ -559,10 +579,20 @@ impl WebPlugin {
     /// Set the directory where backup files are stored.
     ///
     /// Always sourced from `[backup] directory` in the operator config —
-    /// there is no separate `[plugins.web] backup_dir` setting.  Must be
-    /// called before `start()`.
+    /// there is no separate `[plugins.web] backup_dir` setting. Safe to call
+    /// at any time, including after `start()`: request handlers read this
+    /// value live from its `Mutex` rather than caching it at startup.
     pub fn set_backup_dir(&self, dir: Option<String>) {
         *self.state.backup_dir.lock().expect("backup_dir poisoned") = dir;
+    }
+
+    /// Set the BBS's data directory, used to stage restore uploads where
+    /// `main.rs`'s startup check will find them. Sourced from `[bbs]
+    /// data_dir`. Safe to call at any time, including after `start()`: request
+    /// handlers read this value live from its `Mutex` rather than caching it
+    /// at startup.
+    pub fn set_data_dir(&self, dir: Option<String>) {
+        *self.state.data_dir.lock().expect("data_dir poisoned") = dir;
     }
 }
 
@@ -673,6 +703,11 @@ fn build_router(state: Arc<AppState>) -> Router {
             "/backups/:filename",
             get(api_download_backup).delete(api_delete_backup),
         )
+        .route(
+            "/backups/restore",
+            post(api_upload_restore).layer(DefaultBodyLimit::max(RESTORE_UPLOAD_MAX_BYTES)),
+        )
+        .route("/backups/restore/apply", post(api_apply_restore))
         .route("/plugins", get(api_list_plugins).post(api_add_plugin))
         .route(
             "/plugins/:name",
@@ -3809,6 +3844,203 @@ async fn api_delete_backup(
         }
         Err(e) => server_error(&e.to_string()),
     }
+}
+
+/// axum's own default multipart/request body limit is 2 MiB — far too small
+/// for a real database backup. This route raises it just for itself (not
+/// the whole API) to a generous ceiling; the endpoint is sysop-gated, so the
+/// only downside of a large cap is disk/memory use by an already-trusted
+/// operator, not an unauthenticated DoS surface.
+const RESTORE_UPLOAD_MAX_BYTES: usize = 2 * 1024 * 1024 * 1024;
+
+/// `POST /api/v1/backups/restore` — accepts a multipart file upload,
+/// validates it as a restorable database WITHOUT touching the live one, and
+/// stages it for restore on next startup. Does NOT restart the process —
+/// call `api_apply_restore` (`POST /api/v1/backups/restore/apply`)
+/// separately once the sysop has confirmed (issue #195: upload and the
+/// destructive restart are deliberately two separate steps).
+///
+/// Accepts either a raw `.db` file or the `.zip` bundle `api_trigger_backup`
+/// produces (single `.db` entry, optional `config.toml`) — `api_trigger_backup`
+/// never offers a raw `.db` for download, only the zip, so a zip-only
+/// validator would reject every backup this same page ever produces.
+/// Zip detection and extraction live in `Database::stage_restore` (bbs-core)
+/// rather than here, so the CLI `restore` subcommand shares the same logic
+/// without depending on bbs-web.
+async fn api_upload_restore(
+    State(state): State<Arc<AppState>>,
+    Extension(caller): Extension<CurrentUser>,
+    mut multipart: Multipart,
+) -> Response {
+    if caller.permission_level < 100 {
+        return (StatusCode::FORBIDDEN, Json(json_error("sysop required"))).into_response();
+    }
+    let data_dir = match state.data_dir() {
+        Some(d) => d,
+        None => {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(json_error("data_dir not configured")),
+            )
+                .into_response()
+        }
+    };
+    // Held for the rest of this handler so a second concurrent upload (or a
+    // confirm) can't interleave with this one's validate-then-rename onto
+    // the shared pending_restore.staged.db path.
+    let _restore_guard = state.restore_lock.lock().await;
+
+    let field = match multipart.next_field().await {
+        Ok(Some(f)) => f,
+        Ok(None) => {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(json_error("no file in upload")),
+            )
+                .into_response()
+        }
+        Err(e) => {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(json_error(&format!("reading upload: {e}"))),
+            )
+                .into_response()
+        }
+    };
+    let bytes = match field.bytes().await {
+        Ok(b) => b,
+        Err(e) => {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(json_error(&format!("reading upload: {e}"))),
+            )
+                .into_response()
+        }
+    };
+
+    // Write into data_dir itself (not the system temp dir) so the rename
+    // stage_restore performs on success lands on the same filesystem and
+    // is a fast, atomic move rather than a copy. stage_restore itself
+    // detects and extracts a zip upload, so the raw bytes are written
+    // as-is here regardless of format.
+    let tmp_path =
+        std::path::Path::new(&data_dir).join(format!("restore_upload_{}.tmp", Uuid::new_v4()));
+    if let Err(e) = tokio::fs::write(&tmp_path, &bytes).await {
+        return server_error(&format!("saving upload: {e}"));
+    }
+
+    let result = state
+        .host
+        .admin_stage_restore(&tmp_path.to_string_lossy(), &data_dir)
+        .await;
+    // On failure stage_restore never moves the file — clean it up here so
+    // a rejected upload doesn't leave junk in data_dir.
+    if result.is_err() {
+        let _ = tokio::fs::remove_file(&tmp_path).await;
+    }
+
+    match result {
+        Ok(()) => {
+            let _ = state
+                .host
+                .admin_write_audit(
+                    &format!("web:{}", caller.username),
+                    "restore_staged",
+                    None,
+                    None,
+                )
+                .await;
+            Json(serde_json::json!({
+                "message": "upload validated and staged — call restore to apply it"
+            }))
+            .into_response()
+        }
+        Err(e) => (
+            StatusCode::UNPROCESSABLE_ENTITY,
+            Json(json_error(&e.to_string())),
+        )
+            .into_response(),
+    }
+}
+
+/// `POST /api/v1/backups/restore/apply` — confirms a previously-staged
+/// restore (see `api_upload_restore`) by promoting it from its inert staged
+/// name to the name `main.rs`'s startup check actually looks for
+/// (`admin_apply_staged_restore`), then exits the process so systemd's
+/// `Restart=always` brings up a fresh instance that performs the swap.
+/// Reuses `api_restart`'s exact systemd-presence gate and delayed-exit
+/// pattern, since the safe way to apply a restore and the safe way to
+/// restart the service are the same mechanism (issue #195).
+///
+/// Confirming and staging are deliberately two different filesystem states:
+/// an earlier version of this feature staged directly under the name
+/// `main.rs` watches for, which meant ANY unrelated restart between upload
+/// and confirmation — a crash, an operator restarting the service for an
+/// unrelated reason, systemd firing `Restart=always` after any exit —
+/// silently applied a restore nobody had confirmed yet.
+async fn api_apply_restore(
+    State(state): State<Arc<AppState>>,
+    Extension(caller): Extension<CurrentUser>,
+) -> Response {
+    if caller.permission_level < 100 {
+        return (StatusCode::FORBIDDEN, Json(json_error("sysop required"))).into_response();
+    }
+    let data_dir = match state.data_dir() {
+        Some(d) => d,
+        None => {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(json_error("data_dir not configured")),
+            )
+                .into_response()
+        }
+    };
+    // Same lock api_upload_restore holds, so a confirm can't run while an
+    // upload is still mid-validate/rename against the same staged path.
+    let _restore_guard = state.restore_lock.lock().await;
+
+    if std::env::var("INVOCATION_ID").is_err() {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(json_error(
+                "not running under systemd — restart manually to apply the \
+                 staged restore: sudo systemctl restart supply-drop-bbs",
+            )),
+        )
+            .into_response();
+    }
+
+    if let Err(e) = state.host.admin_apply_staged_restore(&data_dir).await {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(json_error(&format!(
+                "no restore is staged, or it could not be confirmed: {e}"
+            ))),
+        )
+            .into_response();
+    }
+
+    let _ = state
+        .host
+        .admin_write_audit(
+            &format!("web:{}", caller.username),
+            "restore_applied",
+            None,
+            None,
+        )
+        .await;
+
+    tracing::warn!("web admin: database restore confirmed — exiting to apply it on restart");
+    tokio::spawn(async {
+        tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+        std::process::exit(1);
+    });
+
+    (
+        StatusCode::ACCEPTED,
+        Json(serde_json::json!({ "message": "restore applying — service is restarting" })),
+    )
+        .into_response()
 }
 
 // ── Domain event formatting ───────────────────────────────────────────────────

--- a/crates/bbs-web/web/src/pages/BackupsPage.vue
+++ b/crates/bbs-web/web/src/pages/BackupsPage.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { ref, computed, onMounted } from 'vue'
-import { api } from '../api/client'
+import { api, request } from '../api/client'
 
 interface BackupRecord {
   filename: string
@@ -21,6 +21,12 @@ const triggering = ref(false)
 const deleting = ref<string | null>(null)
 const error = ref<string | null>(null)
 const actionOk = ref<string | null>(null)
+
+const restoreFile = ref<File | null>(null)
+const uploading = ref(false)
+const applying = ref(false)
+const restoreStaged = ref(false)
+const fileInput = ref<HTMLInputElement | null>(null)
 
 const backupDirConfigured = computed(() => settings.value?.backup_dir != null)
 
@@ -84,6 +90,60 @@ async function deleteBackup(filename: string) {
   }
 }
 
+function pickRestoreFile(e: Event) {
+  const input = e.target as HTMLInputElement
+  restoreFile.value = input.files?.[0] ?? null
+  error.value = null
+  actionOk.value = null
+}
+
+// Uploads and validates the file WITHOUT restarting anything — the server
+// checks it's a real, migration-compatible database before staging it, and
+// nothing about the live system changes until applyRestore is confirmed
+// separately.
+async function uploadRestoreFile() {
+  if (!restoreFile.value) return
+  uploading.value = true
+  error.value = null
+  actionOk.value = null
+  try {
+    const form = new FormData()
+    form.append('file', restoreFile.value)
+    await request('/api/v1/backups/restore', { method: 'POST', body: form })
+    restoreStaged.value = true
+    actionOk.value = `${restoreFile.value.name} validated and staged. Review, then apply below to restore it.`
+    restoreFile.value = null
+    if (fileInput.value) fileInput.value.value = ''
+  } catch (e: any) {
+    error.value = e?.message ?? 'upload failed — the file was not staged'
+  } finally {
+    uploading.value = false
+  }
+}
+
+// The destructive step: exits the process so it restarts with the staged
+// file swapped in. A pre-restore safety snapshot of the CURRENT database is
+// taken automatically before anything is overwritten.
+async function applyRestore() {
+  if (!confirm(
+    'This will REPLACE the current database with the staged backup and ' +
+    'restart the service now. A safety snapshot of the current database ' +
+    'is taken first. Continue?'
+  )) return
+  applying.value = true
+  error.value = null
+  actionOk.value = null
+  try {
+    await api.post('/api/v1/backups/restore/apply')
+    actionOk.value = 'Restore applying — the service is restarting. This page will stop responding for a few seconds.'
+    restoreStaged.value = false
+  } catch (e: any) {
+    error.value = e?.message ?? 'restore failed to apply'
+  } finally {
+    applying.value = false
+  }
+}
+
 onMounted(load)
 </script>
 
@@ -112,6 +172,37 @@ onMounted(load)
     <div v-if="backupDirConfigured" class="dir-info muted small">
       directory: <code>{{ settings!.backup_dir }}</code>
     </div>
+
+    <section class="restore-panel">
+      <h2>restore from backup</h2>
+      <p class="muted small">
+        Upload a <code>.db</code> or <code>.zip</code> backup — from this system or another —
+        to replace the current database. The file is validated before anything changes; nothing
+        is applied until you confirm below.
+      </p>
+      <div class="restore-controls">
+        <input
+          ref="fileInput"
+          type="file"
+          accept=".db,.zip"
+          :disabled="uploading"
+          @change="pickRestoreFile"
+        />
+        <button @click="uploadRestoreFile" :disabled="!restoreFile || uploading">
+          {{ uploading ? 'validating…' : 'upload & validate' }}
+        </button>
+      </div>
+      <div v-if="restoreStaged" class="restore-staged">
+        <p>
+          A validated backup is staged and ready. Applying it <strong>replaces the current
+          database</strong> and restarts the service — a safety snapshot of the current
+          database is taken automatically first.
+        </p>
+        <button class="danger" @click="applyRestore" :disabled="applying">
+          {{ applying ? 'applying…' : 'apply restore (restarts service)' }}
+        </button>
+      </div>
+    </section>
 
     <p v-if="error" class="error">{{ error }}</p>
     <p v-if="actionOk" class="ok">{{ actionOk }}</p>
@@ -173,6 +264,25 @@ p { margin: 0; }
 .ok { color: #2a8a2a; }
 
 .dir-info { margin-top: -0.25rem; }
+
+.restore-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+  padding: 0.9rem 1.1rem;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+}
+.restore-panel h2 { margin: 0; font-size: 1em; }
+.restore-controls { display: flex; align-items: center; gap: 0.6rem; flex-wrap: wrap; }
+.restore-staged {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  padding-top: 0.5rem;
+  border-top: 1px solid var(--border);
+}
+.restore-staged p { line-height: 1.5; }
 .config-notice {
   padding: 0.9rem 1.1rem;
   border: 1px solid var(--warning);

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -244,6 +244,67 @@ Backup created: backup_20260511_142301.db
   location: /var/lib/supply-drop-bbs/backups
 ```
 
+> Produces a raw `.db` file. The web UI's "create backup" button produces a
+> `.zip` bundling the same `.db` with `config.toml` — `restore stage` below
+> accepts either.
+
+---
+
+### `restore stage` / `restore apply`
+
+```
+supply-drop-bbs restore stage <PATH>
+supply-drop-bbs restore apply [--yes]
+```
+
+Validate and apply a database restore from a backup file — the CLI
+equivalent of the web UI's Backups page restore flow. Works directly
+against the local database and data directory; no running BBS instance is
+required (unlike `contacts`). Staging and confirming are deliberately two
+separate steps, mirroring the web UI's upload-then-confirm flow: staging
+alone never changes anything, and confirming only takes effect the next
+time the BBS process starts.
+
+`stage` accepts either a raw `.db` file or the `.zip` bundle `backup`/the
+web UI produce, and runs the same validation the web upload endpoint does:
+a SQLite-format check, a check that the file has this application's own
+migration history, migrating it in place if it's an older schema, and a
+room-structure check. A file that fails any of these is rejected and
+nothing is staged.
+
+```sh
+supply-drop-bbs restore stage /var/lib/supply-drop-bbs/backups/backup_20260511_142301.db
+# Restore staged from /var/lib/supply-drop-bbs/backups/backup_20260511_142301.db.
+# Run `supply-drop-bbs restore apply` to confirm it, then restart the BBS to apply it.
+
+supply-drop-bbs restore apply
+# This will replace the live database the next time the BBS starts. A safety
+# snapshot of the current database is taken first, but this is still a
+# destructive operation. Continue? [y/N] y
+# Restore confirmed.
+# Restart the BBS to apply it, e.g.: sudo systemctl restart supply-drop-bbs
+```
+
+Pass `--yes` to `apply` to skip the interactive confirmation prompt for
+scripted/non-interactive use:
+
+```sh
+supply-drop-bbs restore apply --yes
+```
+
+`apply` only promotes a previously staged file to the name the BBS's
+startup check looks for — it does not restart the service itself. The
+actual database swap happens the next time the BBS process starts, after a
+safety snapshot of the current database is taken automatically.
+
+**Exit codes:** `0` on success (including a user-declined confirmation
+prompt, which prints "Aborted" rather than treating it as an error);
+non-zero if the source path in `stage` isn't a file, the file fails
+validation, or `apply` is run with nothing staged.
+
+> **Web admin:** The same upload/validate/stage/confirm flow is available
+> in the web UI under **Backups** → restore.
+
 ---
 
 ### `node show-key`

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -537,6 +537,25 @@ Or use the **Trigger backup** button in the web admin UI.
               backup-host:/srv/bbs-backups/$(hostname)/
 ```
 
+### Restoring from a backup
+
+```sh
+supply-drop-bbs restore stage /var/lib/supply-drop-bbs/backups/<file>.db
+supply-drop-bbs restore apply
+sudo systemctl restart supply-drop-bbs
+```
+
+Or use the **Backups** page in the web admin UI: upload the backup file
+(a raw `.db` or the `.zip` the web UI's own "create backup" button
+produces), then confirm the restore once it validates. Either way,
+staging and confirming are deliberately separate steps — nothing changes
+until you confirm, and the database is only actually swapped the next
+time the BBS process starts. A safety snapshot of the current database is
+taken automatically before the swap; see [Disaster recovery](#disaster-recovery)
+if you need to roll back to it. This works even when the live database is
+broken (see [Corrupted database](#corrupted-database)) — staging and
+confirming never require the live database to open successfully.
+
 ## Rooms and access control
 
 ### Built-in rooms
@@ -666,6 +685,20 @@ The options are independent and compose naturally:
 
 ### Corrupted database
 
+Preferred: `restore stage`/`restore apply` work even when the live database
+won't open — staging and confirming never touch it directly, and a safety
+snapshot of whatever's currently at the live path is taken automatically
+before the swap.
+
+```sh
+sudo -u supply-drop supply-drop-bbs restore stage /var/lib/supply-drop-bbs/backups/<file>.db
+sudo -u supply-drop supply-drop-bbs restore apply --yes
+sudo systemctl restart supply-drop-bbs
+```
+
+Fallback if the CLI itself won't run (e.g. the binary is missing or the
+data directory is inaccessible to the `supply-drop` account):
+
 ```sh
 sudo systemctl stop supply-drop-bbs
 sudo mv /var/lib/supply-drop-bbs/bbs.sqlite /var/lib/supply-drop-bbs/bbs.sqlite.corrupt
@@ -675,6 +708,10 @@ sudo cp /var/lib/supply-drop-bbs/backups/<latest>.sqlite /var/lib/supply-drop-bb
 sudo chown supply-drop:supply-drop /var/lib/supply-drop-bbs/bbs.sqlite
 sudo systemctl start supply-drop-bbs
 ```
+
+The fallback skips all of `restore`'s validation (SQLite-format check,
+migration-history check, room-structure check) — only use it when the CLI
+path genuinely isn't available.
 
 ### Lost sysop access
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -95,6 +95,21 @@ enum Commands {
     /// Trigger an immediate database backup.
     Backup,
 
+    /// Validate and apply a database restore from a backup file.
+    ///
+    /// Works directly against the local database and data directory, like
+    /// `backup`/`user`/`room` — no running BBS instance or web admin API
+    /// required (unlike `contacts`). Deliberately does NOT require the
+    /// live database to open cleanly: restoring is often needed exactly
+    /// because the live database is broken, so `stage`/`apply` never touch
+    /// it directly. Mirrors the web UI's Backups page restore flow —
+    /// `stage` then `apply` are the same two deliberately-separate steps
+    /// as upload-then-confirm there.
+    Restore {
+        #[command(subcommand)]
+        action: RestoreAction,
+    },
+
     /// Manage user accounts.
     User {
         #[command(subcommand)]
@@ -161,6 +176,36 @@ enum Commands {
         /// non-interactive/scripted use.
         #[arg(long, env = "SUPPLY_DROP_BBS_PASSWORD")]
         password: Option<String>,
+    },
+}
+
+#[derive(Subcommand)]
+enum RestoreAction {
+    /// Validate a backup file and stage it for restore, without touching
+    /// the live database.
+    ///
+    /// Accepts either a raw `.db` file or the `.zip` bundle the `backup`
+    /// subcommand (and the web UI's "create backup" button) produces —
+    /// both are validated the same way `stage_restore` validates a web
+    /// upload: SQLite-format check, migration-history check, migrating in
+    /// place, and a room-structure check. Staging never applies anything;
+    /// run `apply` afterward to confirm it.
+    Stage {
+        /// Path to a `.db` or `.zip` backup file.
+        path: PathBuf,
+    },
+
+    /// Confirm a previously staged restore.
+    ///
+    /// The database is actually swapped in the next time the BBS process
+    /// starts — this command does not restart anything itself. If the BBS
+    /// runs as a service, restart it afterward (e.g. `sudo systemctl
+    /// restart supply-drop-bbs`) to apply the restore.
+    Apply {
+        /// Skip the interactive "type yes to continue" confirmation
+        /// prompt — for scripted/non-interactive use.
+        #[arg(long)]
+        yes: bool,
     },
 }
 
@@ -500,6 +545,7 @@ async fn main() {
         Some(Commands::Config { action }) => cmd_config(config_path.as_deref(), action),
         Some(Commands::Migrate) => cmd_migrate(&cli).await,
         Some(Commands::Backup) => cmd_backup(&cli).await,
+        Some(Commands::Restore { ref action }) => cmd_restore(&cli, action).await,
         Some(Commands::User { ref action }) => cmd_user(&cli, action).await,
         Some(Commands::Room { ref action }) => cmd_room(&cli, action).await,
         #[cfg(feature = "transport-process")]
@@ -571,6 +617,32 @@ async fn open_database(path: &std::path::Path) -> Database {
                      sudo supply-drop-bbs --data-dir /var/lib/supply-drop-bbs <subcommand> ..."
             );
             std::process::exit(1);
+        }
+    }
+}
+
+/// Delete every `pre-restore-safety-*.db` file in `data_dir` except `keep`,
+/// so repeated restores don't accumulate an unbounded number of
+/// full-database-sized snapshots on disk — a real concern on the
+/// SD-card-class storage this project targets.
+fn prune_old_restore_safety_snapshots(data_dir: &std::path::Path, keep: &std::path::Path) {
+    let Ok(entries) = std::fs::read_dir(data_dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path == keep {
+            continue;
+        }
+        let is_old_snapshot = path
+            .file_name()
+            .and_then(|n| n.to_str())
+            .map(|n| n.starts_with("pre-restore-safety-") && n.ends_with(".db"))
+            .unwrap_or(false);
+        if is_old_snapshot {
+            if let Err(e) = std::fs::remove_file(&path) {
+                warn!(path = %path.display(), "could not prune old restore safety snapshot: {e}");
+            }
         }
     }
 }
@@ -709,6 +781,95 @@ async fn cmd_run(cli: &Cli) {
     if let Err(e) = std::fs::create_dir_all(data_dir) {
         error!(path = %data_dir.display(), "could not create data directory: {e}");
         std::process::exit(1);
+    }
+
+    // ── 3b. Apply a staged database restore, if one is pending ─────────────────
+    // Must run before Database::open (below): this fresh process has no live
+    // connections to the database file yet, so swapping it is safe.
+    //
+    // `pending_restore.db`'s mere presence here is deliberately the ONLY
+    // signal for "the sysop confirmed this restore" — api_upload_restore
+    // (crates/bbs-web/src/lib.rs, issue #195) validates an uploaded file and
+    // stages it under a separate, inert name (`pending_restore.staged.db`)
+    // that this check never looks at; only api_apply_restore promotes it to
+    // this name, then exits so systemd's `Restart=always` brings this
+    // instance back up to perform the swap below. Do not stage directly
+    // under this name from anywhere: doing so would mean ANY unrelated
+    // restart between upload and confirmation (a crash, an operator
+    // restarting the service for an unrelated reason, systemd firing
+    // `Restart=always` after any exit) silently applies an unconfirmed
+    // restore.
+    let db_path_for_restore = cfg
+        .database
+        .path
+        .as_ref()
+        .expect("database.path set by resolve()");
+    let pending_restore = data_dir.join("pending_restore.db");
+    if pending_restore.exists() {
+        info!(path = %pending_restore.display(), "applying staged database restore");
+
+        // Safety net: snapshot the current live database before overwriting
+        // it, so a bad or wrong-system upload doesn't destroy data with no
+        // way back. No live connection exists yet in THIS process, but that
+        // doesn't mean the file is checkpoint-clean: every restart path in
+        // this binary (this restore flow and the pre-existing api_restart
+        // alike) exits via std::process::exit, which skips the checkpoint a
+        // clean connection close would otherwise run, and this project
+        // raises wal_autocheckpoint to 10000 pages — so a live,
+        // un-checkpointed WAL sidecar next to db_path is the normal case
+        // here, not a rare one. Checkpoint it into the main file first, or
+        // a plain file copy could silently miss recently committed messages.
+        if db_path_for_restore.exists() {
+            if let Err(e) = Database::checkpoint_wal(&db_path_for_restore.to_string_lossy()).await {
+                warn!(
+                    "could not checkpoint the live database's WAL before \
+                     snapshotting it — proceeding with a plain file copy \
+                     anyway, which may miss very recent messages: {e}"
+                );
+            }
+
+            let stamp = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_secs())
+                .unwrap_or(0);
+            let safety_path = data_dir.join(format!("pre-restore-safety-{stamp}.db"));
+            if let Err(e) = std::fs::copy(db_path_for_restore, &safety_path) {
+                let _ = std::fs::remove_file(&safety_path);
+                error!("could not snapshot the live database before restoring — aborting restore, database left untouched: {e}");
+                std::process::exit(1);
+            }
+            info!(path = %safety_path.display(), "pre-restore safety snapshot saved");
+
+            // Keep only the snapshot just taken — an unbounded number of
+            // full-database-sized files would otherwise accumulate across
+            // repeated restores.
+            prune_old_restore_safety_snapshots(data_dir, &safety_path);
+        }
+
+        if let Err(e) = std::fs::rename(&pending_restore, db_path_for_restore) {
+            // `rename` can fail across filesystems (EXDEV) — data_dir and
+            // database.path are configured independently and aren't
+            // guaranteed to share one. Fall back to copy+delete, matching
+            // the identical fallback `stage_restore`'s own rename already
+            // has for the same reason.
+            if let Err(copy_err) = std::fs::copy(&pending_restore, db_path_for_restore) {
+                error!(
+                    "could not apply staged restore (rename failed: {e}; \
+                     copy fallback also failed: {copy_err})"
+                );
+                std::process::exit(1);
+            }
+            let _ = std::fs::remove_file(&pending_restore);
+        }
+        // The old live database's WAL/SHM sidecars (if any) now refer to
+        // data that no longer exists at this path — remove them so the
+        // restored file starts clean rather than SQLite trying to replay a
+        // stale WAL against it.
+        for ext in ["-wal", "-shm"] {
+            let sidecar = PathBuf::from(format!("{}{ext}", db_path_for_restore.display()));
+            let _ = std::fs::remove_file(sidecar);
+        }
+        info!("database restore applied — continuing startup with the restored database");
     }
 
     // ── 4. Database ───────────────────────────────────────────────────────────
@@ -904,6 +1065,7 @@ async fn cmd_run(cli: &Cli) {
                 .as_ref()
                 .map(|d| d.to_string_lossy().into_owned());
             plugin.set_backup_dir(backup_dir);
+            plugin.set_data_dir(Some(data_dir.to_string_lossy().into_owned()));
         }
         #[cfg(feature = "transport-process")]
         if let Some(ref plugin) = wp {
@@ -1729,6 +1891,89 @@ async fn cmd_backup(cli: &Cli) {
         Err(e) => {
             eprintln!("error creating backup: {e}");
             std::process::exit(1);
+        }
+    }
+}
+
+async fn cmd_restore(cli: &Cli, action: &RestoreAction) {
+    let cfg = load_config(cli);
+    let data_dir = cfg
+        .bbs
+        .data_dir
+        .as_ref()
+        .expect("data_dir set by resolve()");
+
+    if let Err(e) = tokio::fs::create_dir_all(data_dir).await {
+        eprintln!("error creating data directory: {e}");
+        std::process::exit(1);
+    }
+
+    match action {
+        RestoreAction::Stage { path } => {
+            if !path.is_file() {
+                eprintln!("error: {} is not a file", path.display());
+                std::process::exit(1);
+            }
+
+            // Copy into data_dir itself rather than pointing stage_restore
+            // at the operator's own file directly — stage_restore may
+            // overwrite its input in place (e.g. extracting a zip), and
+            // the operator's source file must never be touched.
+            let tmp_path = data_dir.join("restore_cli_upload.tmp");
+            if let Err(e) = tokio::fs::copy(path, &tmp_path).await {
+                eprintln!("error copying {}: {e}", path.display());
+                std::process::exit(1);
+            }
+
+            let result = Database::stage_restore(&tmp_path, data_dir).await;
+            if result.is_err() {
+                let _ = tokio::fs::remove_file(&tmp_path).await;
+            }
+
+            match result {
+                Ok(()) => {
+                    println!("Restore staged from {}.", path.display());
+                    println!(
+                        "Run `supply-drop-bbs restore apply` to confirm it, then restart the \
+                         BBS to apply it."
+                    );
+                }
+                Err(e) => {
+                    eprintln!("error staging restore: {e}");
+                    std::process::exit(1);
+                }
+            }
+        }
+        RestoreAction::Apply { yes } => {
+            if !*yes {
+                let confirmed = dialoguer::Confirm::new()
+                    .with_prompt(
+                        "This will replace the live database the next time the BBS starts. \
+                         A safety snapshot of the current database is taken first, but this \
+                         is still a destructive operation. Continue?",
+                    )
+                    .default(false)
+                    .interact()
+                    .unwrap_or(false);
+                if !confirmed {
+                    println!("Aborted — nothing was confirmed.");
+                    return;
+                }
+            }
+
+            match Database::admin_apply_staged_restore(data_dir).await {
+                Ok(()) => {
+                    println!("Restore confirmed.");
+                    println!(
+                        "Restart the BBS to apply it, e.g.: sudo systemctl restart \
+                         supply-drop-bbs"
+                    );
+                }
+                Err(e) => {
+                    eprintln!("error confirming restore: {e}");
+                    std::process::exit(1);
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary

Adds a full upload → validate → stage → confirm-apply restore flow to the web admin backups page: upload a `.db` or `.zip` backup, the server validates it without touching the live database, stages it, and a separate confirm step triggers a process restart that performs the actual swap at next startup (after taking a pre-restore safety snapshot).

Also adds a CLI equivalent — `supply-drop-bbs restore stage <path>` / `supply-drop-bbs restore apply` — for operators without a running web session, including when the live database itself won't open (often exactly why a restore is needed).

**A pre-merge hostile code-audit** (Maintainer, Data-integrity, and Concurrency reviewer passes, plus two independent claim verifiers covering 47 extracted claims) found and fixed **5 Critical/High bugs** in the initial implementation before this ever shipped:

1. **Empty-database bypass** — `stage_restore` trusted `sqlx::migrate!().run()`'s `Ok()` as proof of a genuine backup, but every migration uses `CREATE TABLE IF NOT EXISTS`/`INSERT OR IGNORE`/`DROP TABLE IF EXISTS`+`CREATE TABLE`, so migrate! alone succeeds against a completely empty SQLite file. Fixed by requiring `_sqlx_migrations` to already have history, plus a room-walk-order structural check mirroring `Database::open`.
2. **Zip rejected** — the only backup format the page's own "create backup" button produces is a `.zip`, but restore required raw SQLite bytes — the primary "download a backup, restore it later" workflow was a dead end. Fixed by detecting and extracting a zip upload's single `.db` entry.
3. **2 MiB upload limit** — axum's default body limit wasn't overridden, so any real database upload was silently rejected. Raised to 2 GiB for this route.
4. **Silent-apply-on-unrelated-restart** — `main.rs` decided whether to apply a destructive database swap purely from file existence at a fixed path, with no distinct confirmation signal. Any unrelated restart between upload and confirmation (a crash, an unrelated "restart service" click, systemd's own `Restart=always`) would silently apply an unconfirmed restore. Fixed via a staged-vs-confirmed filename split: staging lands on an inert name main.rs never looks at; only the explicit confirm step promotes it to the name that triggers a swap.
5. **Possible WAL data loss** — the pre-restore safety snapshot copied only the main `.db` file. This project runs WAL mode with a high checkpoint threshold, and every restart here exits via `std::process::exit` (skipping the checkpoint a clean close would perform), so a live, un-checkpointed WAL sidecar is the normal case, not rare — a plain copy could silently miss recent messages, which cleanup then deletes. Fixed with a new `Database::checkpoint_wal` run before the snapshot.

Also hardened: pre-restore safety snapshots are now pruned instead of accumulating unbounded, `main.rs`'s rename has the same EXDEV cross-filesystem fallback `stage_restore`'s already had, and a `restore_lock` mutex serializes upload/confirm against races on the shared staged-file path.

**CLI parity (added after initial review):** `Database::stage_restore`/`admin_apply_staged_restore` are now `pub` (were `pub(crate)`) so the new `restore` CLI subcommand can call them directly, bypassing `open_database`/`BbsHost` entirely — `open_database` exits fatally if the live database won't open, which would make a CLI restore command useless in exactly the scenario it's most needed for. Zip detection/extraction moved from bbs-web into `stage_restore` itself so the CLI and the web handler share one implementation. Documentation for both the GUI and CLI flows is included in this PR (`docs/CLI.md`, `docs/OPERATIONS.md`).

**Not yet done:** the audit's Security, API-contract, and Hostile QA engineer persona passes were planned but not completed — a session crash interrupted the audit mid-run. Filed as follow-up beads (local `bd` issue tracker, not GitHub issues): `supply-drop-bbs-2qz` (complete the missing audit passes) and `supply-drop-bbs-fuh` (a Concurrency finding: a cancelled upload request can orphan a background file copy after the lock releases).

## Fixes
Fixes #195

## Test plan
- [x] New/updated unit tests covering: empty-db rejection, zip-vs-raw-db acceptance (including an end-to-end zip-wrapped-genuine-backup test), the staged→confirmed promotion flow (including corrupt-staged-file rejection), and the room-walk-order structural check
- [x] `cargo fmt --all --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo build --workspace --all-features`
- [x] `cargo test --workspace --all-features`
- [x] `npm run build` (frontend, BackupsPage.vue)
- [x] Hostile code-audit (3 reviewer personas + 2 claim verifiers) run on this diff; 5 Critical/High findings fixed, 2 follow-ups filed for remaining scope

🤖 Generated with [Claude Code](https://claude.com/claude-code)