### PR TITLE
docs: document the one-at-a-time reading-mode shortcuts

### DIFF
--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -410,6 +410,25 @@ R
 Shows the five most recent messages, newest at the top. Good for catching up
 quickly.
 
+### While reading a message
+
+Once `F`, `N`, or `R` shows you a message, single-key shortcuts control what
+happens next — no need to retype the full command:
+
+| Key | Action |
+|-----|--------|
+| `F` | Next message (forward) |
+| `R` | Previous message (back) |
+| `E` | Reply to this message |
+| `D` | Delete this message |
+| `H` | Show this help |
+| `X` | Exit reading |
+
+`D` (or `D <id>` to delete a different message you read earlier in the same
+session) deletes immediately and doesn't disturb your place — deleting the
+message currently on screen ends reading mode since there's nothing left to
+show; deleting any other id leaves you exactly where you were.
+
 ### Scan message headers
 
 ```


### PR DESCRIPTION
## Summary

Issue #184 added `D` (delete) to the one-at-a-time reading sub-mode (`Workflow::Reading`) alongside the pre-existing `F`/`R`/`E`/`H`/`X` shortcuts, but none of these per-message keys were ever documented in `USER_GUIDE.md` — only the commands used to *enter* reading (`F`/`N`/`R`/`S`) were covered, not what a user can actually do once a message is on screen.

Adds a "While reading a message" subsection listing all six keys, matching the in-BBS `HELP_READING_MODE` text exactly, plus a note on `D`'s delete-in-place semantics (deleting the on-screen message ends reading mode; deleting any other id doesn't disturb your place).

Docs-only change, no code touched.

## Fixes
Follow-up documentation gap found while auditing docs for issues resolved this release (#184, #187, #188, #193, #194, #195).

## Test plan
- [x] Docs-only change — no build/test impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)