### PR TITLE
feat: show contact counts in nav/pages, clean up web UI copy

### DIFF
--- a/crates/bbs-core/src/db/admin_queries.rs
+++ b/crates/bbs-core/src/db/admin_queries.rs
@@ -20,11 +20,14 @@ use tracing;
 // dead_code analysis does not follow, so these pub(crate) helpers appear unused.
 #[allow(dead_code)]
 impl Database {
-    /// Aggregate BBS statistics.  `active_sessions` is passed in because the
-    /// session count lives in `BbsHost`, not the DB.
+    /// Aggregate BBS statistics.  `active_sessions`, `discovered_contacts`,
+    /// and `protected_contacts` are passed in because they live in
+    /// `BbsHost`'s session tracker and advert bus, not the DB.
     pub(crate) async fn admin_stats(
         &self,
         active_sessions: usize,
+        discovered_contacts: usize,
+        protected_contacts: usize,
     ) -> Result<AdminStats, StoreError> {
         let active: i64 = sqlx::query_scalar(
             "SELECT COUNT(*) FROM users WHERE status = 0 AND permission_level > 0",
@@ -57,6 +60,8 @@ impl Database {
             total_messages,
             total_rooms,
             active_sessions,
+            discovered_contacts,
+            protected_contacts,
         })
     }
 

--- a/crates/bbs-core/src/host.rs
+++ b/crates/bbs-core/src/host.rs
@@ -1375,8 +1375,10 @@ impl Host for BbsHost {
 
     async fn admin_stats(&self) -> Result<AdminStats, HostError> {
         let active_sessions = self.sessions.read().await.len();
+        let discovered_contacts = self.advert_bus.count();
+        let protected_contacts = self.advert_bus.count_protected();
         self.db
-            .admin_stats(active_sessions)
+            .admin_stats(active_sessions, discovered_contacts, protected_contacts)
             .await
             .map_err(|e| HostError::Storage(format!("{e}")))
     }
@@ -9419,5 +9421,48 @@ mod tests {
             "the corrupt staged file should be discarded, not left around \
              to fail confirmation again on every future attempt"
         );
+    }
+
+    /// `admin_stats`'s `discovered_contacts`/`protected_contacts` fields
+    /// must reflect the same `AdvertBus` the web UI's "Discovered Contacts"
+    /// and "Contacts" pages read from, not some separate count that could
+    /// silently drift from what those pages actually show.
+    #[tokio::test]
+    async fn admin_stats_reflects_advert_bus_counts() {
+        let (host, _live_db_file) = make_host().await;
+
+        let before = host.admin_stats().await.unwrap();
+        assert_eq!(before.discovered_contacts, 0);
+        assert_eq!(before.protected_contacts, 0);
+
+        let bus = host.advert_bus();
+        let protected_key = [1u8; 32];
+        let unprotected_key = [2u8; 32];
+        bus.upsert_contact(
+            protected_key,
+            "Protected".into(),
+            1,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            Vec::new(),
+            -1,
+            "meshcore",
+        );
+        bus.upsert(unprotected_key, "Unprotected".into(), 1, 0, 0, "meshcore");
+        assert!(matches!(
+            bus.mark_favourite_if_eligible(protected_key, |_| true, 350, &[]),
+            bbs_plugin_api::FavouriteOutcome::Protected(_)
+        ));
+
+        let after = host.admin_stats().await.unwrap();
+        assert_eq!(
+            after.discovered_contacts, 2,
+            "counts every record, protected or not"
+        );
+        assert_eq!(after.protected_contacts, 1, "counts only the protected one");
     }
 }

--- a/crates/bbs-plugin-api/src/admin.rs
+++ b/crates/bbs-plugin-api/src/admin.rs
@@ -119,6 +119,12 @@ pub struct AdminStats {
     pub total_rooms: i64,
     /// Count of currently live BBS sessions.
     pub active_sessions: usize,
+    /// Total mesh advert-bus records ever seen, protected or not — "Discovered
+    /// Contacts" in the web UI. `0` when no mesh transport is running.
+    pub discovered_contacts: usize,
+    /// Currently-protected advert-bus records — "Contacts" in the web UI.
+    /// `0` when no mesh transport is running.
+    pub protected_contacts: usize,
 }
 
 /// One entry in the top-senders report.

--- a/crates/bbs-plugin-api/src/advert.rs
+++ b/crates/bbs-plugin-api/src/advert.rs
@@ -782,6 +782,28 @@ impl AdvertBus {
         v
     }
 
+    /// Total number of records the bus has ever seen (protected or not) —
+    /// backs the web UI's "Discovered Contacts" nav badge. Cheaper than
+    /// `list().len()`: no clone, no sort.
+    pub fn count(&self) -> usize {
+        let inner = self.inner.lock().expect("advert bus poisoned");
+        inner.records.len()
+    }
+
+    /// Count of currently-protected records — backs the web UI's "Contacts"
+    /// nav badge. See [`list_protected`](Self::list_protected) for what
+    /// "currently protected" means; cheaper than `list_protected().len()`:
+    /// no clone, no sort.
+    pub fn count_protected(&self) -> usize {
+        let inner = self.inner.lock().expect("advert bus poisoned");
+        let now = unix_now_u64();
+        inner
+            .records
+            .values()
+            .filter(|r| is_effectively_protected(r, now))
+            .count()
+    }
+
     /// [`list`](Self::list), filtered to currently-protected records — backs
     /// the web UI's "Contacts" view (as distinct from "Discovered Contacts",
     /// which shows everything via `list`).
@@ -1397,6 +1419,30 @@ mod tests {
         let protected = bus.list_protected();
         assert_eq!(protected.len(), 1);
         assert_eq!(protected[0].pubkey_hex, hex_encode(&protected_key));
+    }
+
+    /// `count()`/`count_protected()` must agree with `list().len()`/
+    /// `list_protected().len()` for the same bus state — they exist only to
+    /// avoid the clone+sort those do, not to define a different answer.
+    #[test]
+    fn count_and_count_protected_match_list_lengths() {
+        let bus = AdvertBus::new();
+        assert_eq!(bus.count(), 0);
+        assert_eq!(bus.count_protected(), 0);
+
+        let protected_key = dummy_key(117);
+        let unprotected_key = dummy_key(118);
+        seed_meshcore_contact(&bus, protected_key);
+        bus.upsert(unprotected_key, "U".into(), 1, 0, 0, "meshcore");
+        assert!(matches!(
+            bus.mark_favourite_if_eligible(protected_key, always_eligible, 350, &[]),
+            FavouriteOutcome::Protected(_)
+        ));
+
+        assert_eq!(bus.count(), bus.list().len());
+        assert_eq!(bus.count(), 2);
+        assert_eq!(bus.count_protected(), bus.list_protected().len());
+        assert_eq!(bus.count_protected(), 1);
     }
 
     /// Phase 5 hostile-audit regression (Extractor pass): `AdvertRecord::

--- a/crates/bbs-web/web/src/components/AppNav.vue
+++ b/crates/bbs-web/web/src/components/AppNav.vue
@@ -74,8 +74,8 @@ const groups = computed<NavGroup[]>(() => {
     g.push({
       title: 'mesh',
       items: [
-        { to: '/adverts', label: 'discovered contacts' },
-        { to: '/contacts', label: 'contacts' },
+        { to: '/adverts', label: 'discovered contacts', count: () => stats.discoveredContacts },
+        { to: '/contacts', label: 'contacts', count: () => stats.protectedContacts },
       ],
     })
   }
@@ -204,7 +204,7 @@ const groups = computed<NavGroup[]>(() => {
               <span
                 v-if="item.rssBadge && stats.rssAlertActive"
                 class="nav-badge rss-badge"
-                title="RSS memory growing — possible leak"
+                title="RSS memory growing (possible leak)"
               >mem↑</span>
             </router-link>
           </li>

--- a/crates/bbs-web/web/src/pages/AdvertsPage.vue
+++ b/crates/bbs-web/web/src/pages/AdvertsPage.vue
@@ -138,7 +138,7 @@ const columns = [
 <template>
   <div class="page">
     <header class="page-header">
-      <h1>discovered contacts</h1>
+      <h1>discovered contacts <span class="count-badge">{{ rows.length }}</span></h1>
       <p class="muted small">
         Every node heard over the mesh, protected or not. Polls every 5 s.
         You must have received a node's advert before you can communicate with it.
@@ -164,8 +164,8 @@ const columns = [
         </label>
         <span class="muted small">
           {{ flood
-            ? 'rebroadcast hop-by-hop — more reach, more airtime'
-            : 'neighbours only — single hop' }}
+            ? 'rebroadcast hop-by-hop: more reach, more airtime'
+            : 'neighbours only: single hop' }}
         </span>
         <button
           class="btn-danger"
@@ -250,6 +250,12 @@ const columns = [
 .page-header { display: flex; flex-direction: column; gap: 0.2rem; }
 h1 { margin: 0; }
 .small { font-size: 0.85em; }
+.count-badge {
+  display: inline-block; font-size: 0.55em; font-weight: 600;
+  background: var(--row-alt); color: var(--muted); border-radius: 999px;
+  padding: 0.15em 0.65em; vertical-align: middle; letter-spacing: 0.02em;
+  border: 1px solid var(--border);
+}
 
 .send-block {
   border: 1px solid var(--border);

--- a/crates/bbs-web/web/src/pages/BackupsPage.vue
+++ b/crates/bbs-web/web/src/pages/BackupsPage.vue
@@ -115,7 +115,7 @@ async function uploadRestoreFile() {
     restoreFile.value = null
     if (fileInput.value) fileInput.value.value = ''
   } catch (e: any) {
-    error.value = e?.message ?? 'upload failed — the file was not staged'
+    error.value = e?.message ?? 'upload failed: the file was not staged'
   } finally {
     uploading.value = false
   }
@@ -135,7 +135,7 @@ async function applyRestore() {
   actionOk.value = null
   try {
     await api.post('/api/v1/backups/restore/apply')
-    actionOk.value = 'Restore applying — the service is restarting. This page will stop responding for a few seconds.'
+    actionOk.value = 'Restore applying. The service is restarting, and this page will stop responding for a few seconds.'
     restoreStaged.value = false
   } catch (e: any) {
     error.value = e?.message ?? 'restore failed to apply'
@@ -176,8 +176,8 @@ onMounted(load)
     <section class="restore-panel">
       <h2>restore from backup</h2>
       <p class="muted small">
-        Upload a <code>.db</code> or <code>.zip</code> backup — from this system or another —
-        to replace the current database. The file is validated before anything changes; nothing
+        Upload a <code>.db</code> or <code>.zip</code> backup, from this system or another, to
+        replace the current database. The file is validated before anything changes; nothing
         is applied until you confirm below.
       </p>
       <div class="restore-controls">
@@ -195,7 +195,7 @@ onMounted(load)
       <div v-if="restoreStaged" class="restore-staged">
         <p>
           A validated backup is staged and ready. Applying it <strong>replaces the current
-          database</strong> and restarts the service — a safety snapshot of the current
+          database</strong> and restarts the service. A safety snapshot of the current
           database is taken automatically first.
         </p>
         <button class="danger" @click="applyRestore" :disabled="applying">

--- a/crates/bbs-web/web/src/pages/ContactsPage.vue
+++ b/crates/bbs-web/web/src/pages/ContactsPage.vue
@@ -126,9 +126,9 @@ const columns = computed(() => {
 <template>
   <div class="page">
     <header class="page-header">
-      <h1>contacts</h1>
+      <h1>contacts <span class="count-badge">{{ rows.length }}</span></h1>
       <p class="muted small">
-        Protected contacts only — these survive node-database flooding on the
+        Protected contacts only. These survive node-database flooding on the
         radio and stay favorited across a BBS restart. See
         <router-link to="/adverts">discovered contacts</router-link> for
         every node heard, protected or not.
@@ -201,6 +201,12 @@ const columns = computed(() => {
 .page-header { display: flex; flex-direction: column; gap: 0.2rem; }
 h1 { margin: 0; }
 .small { font-size: 0.85em; }
+.count-badge {
+  display: inline-block; font-size: 0.55em; font-weight: 600;
+  background: var(--row-alt); color: var(--muted); border-radius: 999px;
+  padding: 0.15em 0.65em; vertical-align: middle; letter-spacing: 0.02em;
+  border: 1px solid var(--border);
+}
 
 .contact-filters {
   display: flex;

--- a/crates/bbs-web/web/src/pages/DashboardPage.vue
+++ b/crates/bbs-web/web/src/pages/DashboardPage.vue
@@ -39,7 +39,7 @@ onMounted(async () => {
   <div class="page">
     <header class="page-header">
       <h1>dashboard</h1>
-      <p class="muted">supply drop bbs — admin panel</p>
+      <p class="muted">supply drop bbs admin panel</p>
     </header>
 
     <p v-if="error" class="error">{{ error }}</p>

--- a/crates/bbs-web/web/src/pages/ErrorsPage.vue
+++ b/crates/bbs-web/web/src/pages/ErrorsPage.vue
@@ -66,7 +66,7 @@ onUnmounted(() => {
     <header class="page-header">
       <div>
         <h1>errors</h1>
-        <p class="muted">Deduplicated WARN/ERROR log entries — sorted by frequency</p>
+        <p class="muted">Deduplicated WARN/ERROR log entries, sorted by frequency</p>
       </div>
       <button @click="load" :disabled="loading">refresh</button>
     </header>
@@ -77,7 +77,7 @@ onUnmounted(() => {
     <div v-if="!loading && entries.length === 0 && !error" class="empty-state">
       <p class="healthy-icon">✓</p>
       <p>No errors recorded</p>
-      <p class="muted">No WARN or ERROR events since the last restart — the server is healthy.</p>
+      <p class="muted">No WARN or ERROR events since the last restart. The server is healthy.</p>
     </div>
 
     <div v-if="entries.length > 0" class="table-wrap">

--- a/crates/bbs-web/web/src/pages/LogsPage.vue
+++ b/crates/bbs-web/web/src/pages/LogsPage.vue
@@ -106,7 +106,7 @@ onUnmounted(stop)
       </div>
       <div v-else class="empty-state">
         <p class="muted" v-if="!running">Press <strong>start</strong> to begin streaming log events.</p>
-        <p class="muted" v-else>No log events yet — application events will appear here as they occur.</p>
+        <p class="muted" v-else>No log events yet. Application events will appear here as they occur.</p>
       </div>
     </div>
   </div>

--- a/crates/bbs-web/web/src/pages/MessagesPage.vue
+++ b/crates/bbs-web/web/src/pages/MessagesPage.vue
@@ -176,7 +176,7 @@ onUnmounted(() => { if (pollTimer !== null) clearInterval(pollTimer) })
     <header class="page-header">
       <div>
         <h1>messages</h1>
-        <p class="muted">Browse and moderate room messages — mail DMs are private</p>
+        <p class="muted">Browse and moderate room messages. Mail DMs are private</p>
       </div>
       <div class="search-bar">
         <input

--- a/crates/bbs-web/web/src/pages/MetricsPage.vue
+++ b/crates/bbs-web/web/src/pages/MetricsPage.vue
@@ -274,7 +274,7 @@ onUnmounted(() => {
     <header class="page-header">
       <div>
         <h1>metrics</h1>
-        <p class="muted">System resource snapshot — refreshes every 30 s</p>
+        <p class="muted">System resource snapshot, refreshes every 30 s</p>
       </div>
       <button @click="load" :disabled="loading">refresh</button>
     </header>
@@ -283,7 +283,7 @@ onUnmounted(() => {
     <p v-if="loading && !snap" class="muted">Loading…</p>
 
     <div v-if="stats.rssAlertActive" class="rss-alert-banner">
-      <strong>Memory growth detected</strong> — process RSS has increased
+      <strong>Memory growth detected.</strong> Process RSS has increased
       monotonically for at least 5 minutes
       <span v-if="stats.rssGrowthBytes > 0"> (+{{ fmt(stats.rssGrowthBytes) }})</span>.
       This may indicate a memory leak. Monitor closely or consider restarting.
@@ -362,7 +362,7 @@ onUnmounted(() => {
     <section v-if="delivery" class="section">
       <h2 class="section-title">Inbound message health (cumulative since start)</h2>
       <p class="muted">
-        Where inbound DMs are lost before the BBS acts on them — read alongside the confirm rate above
+        Where inbound DMs are lost before the BBS acts on them. Read alongside the confirm rate above
         to tell an outbound return-path problem from an inbound one.
       </p>
       <div class="metrics-grid">
@@ -375,7 +375,7 @@ onUnmounted(() => {
           <div class="card-label">Dedup drops</div>
           <div class="big-num">{{ ratePct(dedupDropRate) }}</div>
           <div class="bar-track"><div class="bar-fill" :style="{ width: rateWidth(dedupDropRate) + '%' }" :class="failBarClass(dedupDropRate)"></div></div>
-          <div class="card-sub muted">{{ delivery.dedup_dropped_timestamp }} timestamp / {{ delivery.dedup_dropped_text }} text — retransmissions dropped</div>
+          <div class="card-sub muted">{{ delivery.dedup_dropped_timestamp }} timestamp / {{ delivery.dedup_dropped_text }} text (retransmissions dropped)</div>
         </div>
       </div>
     </section>
@@ -394,14 +394,14 @@ onUnmounted(() => {
       </svg>
       <div class="trend-axis muted">
         <span>{{ trendStart }}</span>
-        <span>confirm rate % — gaps are minutes with no reply traffic</span>
+        <span>confirm rate %, gaps are minutes with no reply traffic</span>
         <span>{{ trendEnd }}</span>
       </div>
     </section>
 
     <!-- Per-node link health -->
     <section v-if="delivery && delivery.per_node.length > 0" class="section">
-      <h2 class="section-title">Per-node link health — worst first ({{ delivery.nodes_tracked }} node{{ delivery.nodes_tracked === 1 ? '' : 's' }} tracked)</h2>
+      <h2 class="section-title">Per-node link health, worst first ({{ delivery.nodes_tracked }} node{{ delivery.nodes_tracked === 1 ? '' : 's' }} tracked)</h2>
       <div class="table-wrap">
         <table class="data-table">
           <thead>

--- a/crates/bbs-web/web/src/pages/PluginsPage.vue
+++ b/crates/bbs-web/web/src/pages/PluginsPage.vue
@@ -97,7 +97,7 @@ async function restartServer() {
   restarting.value = true
   try {
     await api.post('/api/v1/restart', {})
-    toast.ok('Restart initiated — page will reload in a few seconds…')
+    toast.ok('Restart initiated. Page will reload in a few seconds…')
     setTimeout(() => window.location.reload(), 5000)
   } catch (e: any) {
     toast.error(e?.message ?? 'restart failed')
@@ -219,7 +219,7 @@ onUnmounted(() => { if (pollTimer !== null) clearInterval(pollTimer) })
 
     <!-- Restart banner -->
     <div v-if="pendingRestart" class="restart-banner">
-      <span>Transport config changed — a restart is required for changes to take effect.</span>
+      <span>Transport config changed. A restart is required for changes to take effect.</span>
       <button v-if="auth.isSysop" :disabled="restarting" @click="restartServer" class="restart-btn">
         {{ restarting ? 'restarting…' : 'restart now' }}
       </button>
@@ -313,7 +313,7 @@ onUnmounted(() => { if (pollTimer !== null) clearInterval(pollTimer) })
             </td>
             <td>
               <span :class="stateClass(p)">{{ p.state }}</span>
-              <span v-if="p.state === 'crashed'" class="muted small"> — {{ p.reason }}</span>
+              <span v-if="p.state === 'crashed'" class="muted small">: {{ p.reason }}</span>
             </td>
             <td class="muted small">{{ p.restart_count }}</td>
             <td v-if="auth.isSysop" class="actions">
@@ -345,7 +345,7 @@ onUnmounted(() => { if (pollTimer !== null) clearInterval(pollTimer) })
       <div v-if="logPlugin" class="drawer-backdrop" @click.self="logPlugin = null">
         <aside class="drawer">
           <div class="drawer-header">
-            <h2>{{ logPlugin.name }} — stderr</h2>
+            <h2>{{ logPlugin.name }}: stderr</h2>
             <button class="secondary small-btn" @click="logPlugin = null">✕</button>
           </div>
           <p v-if="loadingLogs" class="muted">loading…</p>

--- a/crates/bbs-web/web/src/pages/RoomsPage.vue
+++ b/crates/bbs-web/web/src/pages/RoomsPage.vue
@@ -183,10 +183,10 @@ onUnmounted(() => { if (pollTimer !== null) clearInterval(pollTimer) })
             <label class="field">
               <span>minimum permission level</span>
               <select v-model="editMinLevel">
-                <option :value="0">0 — unvalidated</option>
-                <option :value="10">10 — user</option>
-                <option :value="50">50 — aide</option>
-                <option :value="100">100 — sysop</option>
+                <option :value="0">0: unvalidated</option>
+                <option :value="10">10: user</option>
+                <option :value="50">50: aide</option>
+                <option :value="100">100: sysop</option>
               </select>
             </label>
           </template>

--- a/crates/bbs-web/web/src/pages/SettingsPage.vue
+++ b/crates/bbs-web/web/src/pages/SettingsPage.vue
@@ -173,7 +173,7 @@ function validate(): boolean {
     // UTF-8 bytes, not characters — a flag emoji is 8 bytes.
     const bytes = new TextEncoder().encode(form.value.bbs_name).length
     if (bytes > 31)
-      errs.bbs_name = `Name is ${bytes} bytes; maximum is 31 (MeshCore advert limit — emoji count as several bytes each).`
+      errs.bbs_name = `Name is ${bytes} bytes; maximum is 31 (MeshCore advert limit; emoji count as several bytes each).`
     else if ([...form.value.bbs_name].some((ch) => { const c = ch.codePointAt(0) ?? 0; return c < 0x20 || (c >= 0x7f && c <= 0x9f) }))
       errs.bbs_name = 'Name must not contain control characters.'
   }
@@ -481,41 +481,41 @@ async function applyRadioConfig() {
 // ── Meshtastic region / modem preset constants ────────────────────────────────
 
 const MESHTASTIC_REGIONS = [
-  { value: 0,  label: 'UNSET — not configured' },
-  { value: 1,  label: 'US — United States (902–928 MHz)' },
-  { value: 2,  label: 'EU_433 — Europe 433 MHz' },
-  { value: 3,  label: 'EU_868 — Europe 868 MHz' },
-  { value: 4,  label: 'CN — China 470–510 MHz' },
-  { value: 5,  label: 'JP — Japan 920–923 MHz' },
-  { value: 6,  label: 'ANZ — Australia/New Zealand 915–928 MHz' },
-  { value: 7,  label: 'KR — South Korea 920–923 MHz' },
-  { value: 8,  label: 'TW — Taiwan 920–925 MHz' },
-  { value: 9,  label: 'RU — Russia 868 MHz' },
-  { value: 10, label: 'IN — India 865–867 MHz' },
-  { value: 11, label: 'NZ_865 — New Zealand 865 MHz' },
-  { value: 12, label: 'TH — Thailand 920–925 MHz' },
-  { value: 13, label: 'LORA_24 — 2.4 GHz (SX128x)' },
-  { value: 14, label: 'UA_433 — Ukraine 433 MHz' },
-  { value: 15, label: 'UA_868 — Ukraine 868 MHz' },
-  { value: 16, label: 'MY_433 — Malaysia 433 MHz' },
-  { value: 17, label: 'MY_919 — Malaysia 919 MHz' },
-  { value: 18, label: 'SG_923 — Singapore 923 MHz' },
+  { value: 0,  label: 'UNSET: not configured' },
+  { value: 1,  label: 'US: United States (902–928 MHz)' },
+  { value: 2,  label: 'EU_433: Europe 433 MHz' },
+  { value: 3,  label: 'EU_868: Europe 868 MHz' },
+  { value: 4,  label: 'CN: China 470–510 MHz' },
+  { value: 5,  label: 'JP: Japan 920–923 MHz' },
+  { value: 6,  label: 'ANZ: Australia/New Zealand 915–928 MHz' },
+  { value: 7,  label: 'KR: South Korea 920–923 MHz' },
+  { value: 8,  label: 'TW: Taiwan 920–925 MHz' },
+  { value: 9,  label: 'RU: Russia 868 MHz' },
+  { value: 10, label: 'IN: India 865–867 MHz' },
+  { value: 11, label: 'NZ_865: New Zealand 865 MHz' },
+  { value: 12, label: 'TH: Thailand 920–925 MHz' },
+  { value: 13, label: 'LORA_24: 2.4 GHz (SX128x)' },
+  { value: 14, label: 'UA_433: Ukraine 433 MHz' },
+  { value: 15, label: 'UA_868: Ukraine 868 MHz' },
+  { value: 16, label: 'MY_433: Malaysia 433 MHz' },
+  { value: 17, label: 'MY_919: Malaysia 919 MHz' },
+  { value: 18, label: 'SG_923: Singapore 923 MHz' },
 ]
 
 const MESHTASTIC_PRESETS = [
-  { value: 0, label: 'LONG_FAST — long range, fast (default)' },
-  { value: 1, label: 'LONG_SLOW — long range, slow (deprecated in 2.7)' },
-  { value: 3, label: 'MEDIUM_SLOW — medium range, slow' },
-  { value: 4, label: 'MEDIUM_FAST — medium range, fast' },
-  { value: 5, label: 'SHORT_SLOW — short range, slow' },
-  { value: 6, label: 'SHORT_FAST — short range, fast' },
-  { value: 7, label: 'LONG_MODERATE — long range, moderate (125 kHz)' },
-  { value: 8, label: 'SHORT_TURBO — fastest (500 kHz, not legal everywhere)' },
-  { value: 9, label: 'LONG_TURBO — long range, 500 kHz' },
-  { value: 10, label: 'LITE_FAST — EU_866 compliant, ~MEDIUM_FAST range' },
-  { value: 11, label: 'LITE_SLOW — EU_866 compliant, ~LONG_FAST range' },
-  { value: 12, label: 'NARROW_FAST — EU_868 62.5 kHz, ~SHORT_SLOW range' },
-  { value: 13, label: 'NARROW_SLOW — EU_868 62.5 kHz, ~LONG_FAST range' },
+  { value: 0, label: 'LONG_FAST: long range, fast (default)' },
+  { value: 1, label: 'LONG_SLOW: long range, slow (deprecated in 2.7)' },
+  { value: 3, label: 'MEDIUM_SLOW: medium range, slow' },
+  { value: 4, label: 'MEDIUM_FAST: medium range, fast' },
+  { value: 5, label: 'SHORT_SLOW: short range, slow' },
+  { value: 6, label: 'SHORT_FAST: short range, fast' },
+  { value: 7, label: 'LONG_MODERATE: long range, moderate (125 kHz)' },
+  { value: 8, label: 'SHORT_TURBO: fastest (500 kHz, not legal everywhere)' },
+  { value: 9, label: 'LONG_TURBO: long range, 500 kHz' },
+  { value: 10, label: 'LITE_FAST: EU_866 compliant, ~MEDIUM_FAST range' },
+  { value: 11, label: 'LITE_SLOW: EU_866 compliant, ~LONG_FAST range' },
+  { value: 12, label: 'NARROW_FAST: EU_868 62.5 kHz, ~SHORT_SLOW range' },
+  { value: 13, label: 'NARROW_SLOW: EU_868 62.5 kHz, ~LONG_FAST range' },
 ]
 
 // Region frequency ranges (MHz) and preset bandwidths (kHz), used to show the
@@ -658,13 +658,13 @@ async function saveMeshtasticRadio() {
       ignore_mqtt:        meshtasticIgnoreMqtt.value,
     })
     if (res?.applied === false) {
-      meshtasticRadioOk.value = 'Saved. The device is not connected right now — these settings will be applied automatically the next time the BBS connects to it.'
+      meshtasticRadioOk.value = 'Saved. The device is not connected right now; these settings will be applied automatically the next time the BBS connects to it.'
     } else if (res?.confirmed && res?.device_config) {
       // Update the form to reflect the device's actual current values.
       applyMeshtasticRadioFields(res.device_config)
-      meshtasticRadioOk.value = 'Applied — confirmed on device.'
+      meshtasticRadioOk.value = 'Applied and confirmed on device.'
     } else {
-      meshtasticRadioOk.value = res?.message ?? 'Settings sent — use "Load from device" shortly to confirm.'
+      meshtasticRadioOk.value = res?.message ?? 'Settings sent. Use "Load from device" shortly to confirm.'
     }
   } catch (e: any) {
     meshtasticRadioError.value = e?.message ?? 'failed to save meshtastic radio config'
@@ -728,14 +728,14 @@ async function saveMeshtasticOwner() {
       short_name: meshtasticShortName.value || null,
     })
     if (res?.applied === false) {
-      meshtasticOwnerOk.value = 'Saved. The device is not connected right now — this name will be applied automatically the next time the BBS connects to it.'
+      meshtasticOwnerOk.value = 'Saved. The device is not connected right now; this name will be applied automatically the next time the BBS connects to it.'
     } else if (res?.confirmed && res?.device_owner) {
       meshtasticOwner.value = res.device_owner
       meshtasticLongName.value = res.device_owner.long_name
       meshtasticShortName.value = res.device_owner.short_name
-      meshtasticOwnerOk.value = 'Applied — confirmed on device.'
+      meshtasticOwnerOk.value = 'Applied and confirmed on device.'
     } else {
-      meshtasticOwnerOk.value = res?.message ?? 'Name sent — use "Load from device" shortly to confirm.'
+      meshtasticOwnerOk.value = res?.message ?? 'Name sent. Use "Load from device" shortly to confirm.'
     }
   } catch (e: any) {
     meshtasticOwnerError.value = e?.message ?? 'failed to save device owner info'
@@ -847,7 +847,7 @@ function cancelEditNodeKey() {
 function validateHex64(value: string): string | null {
   const h = value.trim()
   if (h.length !== 64) return `Must be exactly 64 hex characters (${h.length} given).`
-  if (!/^[0-9a-fA-F]+$/.test(h)) return 'Contains invalid characters — only 0-9 and a-f are allowed.'
+  if (!/^[0-9a-fA-F]+$/.test(h)) return 'Contains invalid characters. Only 0-9 and a-f are allowed.'
   return null
 }
 
@@ -1032,7 +1032,7 @@ chmod g+w {{ configFile }}</pre>
         <p class="hint">
           When set, the mesh transport sends your coordinates to the radio on connect so your
           node appears on the map in LoRa adverts.
-          <strong>Takes effect on the next mesh transport reconnect — no restart needed.</strong>
+          <strong>Takes effect on the next mesh transport reconnect. No restart needed.</strong>
         </p>
         <div class="field checkbox-field">
           <label>
@@ -1097,7 +1097,7 @@ chmod g+w {{ configFile }}</pre>
             <label>Mesh session lifetime (days)</label>
             <input v-model.number="form.security_session_mesh_days" type="number" min="1" max="365" />
             <p v-if="validationErrors.security_session_mesh_days" class="field-error">{{ validationErrors.security_session_mesh_days }}</p>
-            <p v-else class="hint">Mesh sessions persist longer — radio users disconnect frequently.</p>
+            <p v-else class="hint">Mesh sessions persist longer, since radio users disconnect frequently.</p>
           </div>
         </div>
         <div class="field-row">
@@ -1122,7 +1122,7 @@ chmod g+w {{ configFile }}</pre>
           <select v-model="form.logging_level">
             <option v-for="l in LOG_LEVELS" :key="l" :value="l">{{ l }}</option>
           </select>
-          <p class="hint">Takes effect immediately — no restart needed.</p>
+          <p class="hint">Takes effect immediately. No restart needed.</p>
         </div>
       </section>
 
@@ -1131,7 +1131,7 @@ chmod g+w {{ configFile }}</pre>
         <h2>Access policy</h2>
         <p class="hint">
           Controls how new registrations are handled. Changes take effect
-          immediately — no restart required. See also the in-BBS
+          immediately, no restart required. See also the in-BBS
           <code>OPENACCESS</code> / <code>CLOSEACCESS</code> / <code>GUESTROOM</code> commands.
         </p>
 
@@ -1145,7 +1145,7 @@ chmod g+w {{ configFile }}</pre>
             Require sysop verification before users can access rooms
           </label>
           <p class="hint">
-            Uncheck for SHTF mode — new users get full access immediately on
+            Uncheck for SHTF mode: new users get full access immediately on
             registration. When unchecked, the guest room (below) still exists but
             has no access restriction.
           </p>
@@ -1192,7 +1192,7 @@ chmod g+w {{ configFile }}</pre>
         <h2>MeshCore radio</h2>
         <p class="hint">
           LoRa parameters and routing settings for the MeshCore companion device.
-          <strong>Save</strong> records them in config.toml — the BBS applies them to
+          <strong>Save</strong> records them in config.toml. The BBS applies them to
           the device automatically on every connect (skipped when they already
           match, so a restart with no changes is a no-op). Use
           <strong>Apply to device</strong> to push the LoRa parameters immediately,
@@ -1223,7 +1223,7 @@ chmod g+w {{ configFile }}</pre>
           <p class="hint">
             Bytes each hop adds to a flooded packet's routing path. More bytes make
             path-hash collisions (mis-routes) less likely on a dense mesh, at a little
-            more airtime per packet. Applied to the device on every connect —
+            more airtime per packet. Applied to the device on every connect,
             regardless of connection type.
           </p>
         </div>
@@ -1418,7 +1418,7 @@ chmod g+w {{ configFile }}</pre>
           </p>
         </div>
         <div v-else class="muted" style="margin:0.5rem 0;">
-          {{ meshtasticSecurityLoading ? 'Loading…' : 'Not available — device not connected, or use "Refresh from device" above.' }}
+          {{ meshtasticSecurityLoading ? 'Loading…' : 'Not available. Device not connected, or use "Refresh from device" above.' }}
         </div>
 
         <h3 style="margin: 1.5rem 0 0.5rem">Re-announce</h3>
@@ -1455,7 +1455,7 @@ chmod g+w {{ configFile }}</pre>
           <div v-if="!editingNodeKey" class="key-display">
             <code v-if="nodeIdentity?.pubkey" class="key-hex">{{ nodeIdentity.pubkey }}</code>
             <span v-else-if="nodeIdentityLoading" class="muted">loading…</span>
-            <span v-else class="muted">not connected — start the mesh transport to read the device key</span>
+            <span v-else class="muted">not connected, start the mesh transport to read the device key</span>
             <button
               v-if="nodeIdentity?.pubkey"
               type="button"

--- a/crates/bbs-web/web/src/stores/stats.ts
+++ b/crates/bbs-web/web/src/stores/stats.ts
@@ -6,6 +6,8 @@ interface Stats {
   pending_users: number
   active_users: number
   active_sessions: number
+  discovered_contacts: number
+  protected_contacts: number
   [key: string]: unknown
 }
 
@@ -13,6 +15,8 @@ export const useStatsStore = defineStore('stats', () => {
   const pendingUsers = ref(0)
   const activeUsers = ref(0)
   const activeSessions = ref(0)
+  const discoveredContacts = ref(0)
+  const protectedContacts = ref(0)
   const errorAlerts = ref(0)
   const rssAlertActive = ref(false)
   const rssGrowthBytes = ref(0)
@@ -27,6 +31,8 @@ export const useStatsStore = defineStore('stats', () => {
       pendingUsers.value = s.pending_users
       activeUsers.value = s.active_users
       activeSessions.value = s.active_sessions
+      discoveredContacts.value = s.discovered_contacts
+      protectedContacts.value = s.protected_contacts
     } catch {
       // non-fatal — badge just won't update
     }
@@ -89,6 +95,8 @@ export const useStatsStore = defineStore('stats', () => {
     pendingUsers,
     activeUsers,
     activeSessions,
+    discoveredContacts,
+    protectedContacts,
     errorAlerts,
     rssAlertActive,
     rssGrowthBytes,


### PR DESCRIPTION
## Summary

- Adds discovered/protected contact counts to the web admin UI: a nav sidebar badge on **discovered contacts** and **contacts** (matching the existing pattern already used for sessions/users), plus a real-time count next to the `<h1>` on each of those two pages, sourced directly from the already-fetched list.
- Backed by two new `AdvertBus` methods, `count()` and `count_protected()`, cheaper than `list().len()`/`list_protected().len()` since they skip the clone and sort those do. `AdminStats` gains two new fields (`discovered_contacts`, `protected_contacts`), computed in `BbsHost::admin_stats()` from the advert bus, following the same pattern already used for `active_sessions` (passed in rather than queried from the database, since neither the session tracker nor the advert bus lives there).
- Web UI copy pass: removed em-dash sentence-connectors from user-facing text across roughly a dozen page components (tooltips, toast messages, help text, dropdown option labels), rewriting each as a plain sentence, comma, colon, or parenthetical depending on context. Deliberately left two things alone: the em-dash used as a bare placeholder glyph for empty/null table values (a standard UI convention, not the pattern being removed) and en-dashes in frequency-range labels like `902–928 MHz` (correct typography for numeric ranges, not an AI-writing tell).

## Test plan
- [x] New unit tests: `count_and_count_protected_match_list_lengths` (crates/bbs-plugin-api/src/advert.rs), `admin_stats_reflects_advert_bus_counts` (crates/bbs-core/src/host.rs)
- [x] `cargo fmt --all --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo build --workspace --all-features`
- [x] `cargo test --workspace --all-features`
- [x] `npm run build` (vue-tsc + vite, frontend)

🤖 Generated with [Claude Code](https://claude.com/claude-code)