### PR TITLE
docs: audit and update README for current architecture

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,7 +67,7 @@ jobs:
       # Both variants produce  target/<triple>/release-min/supply-drop-bbs;
       # the second build overwrites the first, so we must copy before building.
 
-      # 1. Full binary (default features = cli + mesh + admin-web)
+      # 1. Full binary (default features = cli + both mesh transports + process-transport + admin-web)
       - name: Build — full (default features)
         run: cargo build --profile release-min --target ${{ matrix.target }}
 

--- a/README.md
+++ b/README.md
@@ -78,13 +78,13 @@ Pre-built packages and binaries for Raspberry Pi (aarch64, armv7) and x86-64
 Linux are attached to each
 [GitHub Release](https://github.com/Mesh-America/supply-drop-bbs/releases).
 
-### Option 1 — Debian package (recommended)
+### Option 1: Debian package (recommended)
 
 The `.deb` is the easiest way to install on Raspberry Pi OS, Ubuntu, or any
 Debian-based system. It handles user creation, directory layout, and systemd
 service registration automatically.
 
-Run this on your Pi or Linux box — it auto-detects your architecture:
+Run this on your Pi or Linux box. It auto-detects your architecture:
 
 ```sh
 ARCH=$(dpkg --print-architecture)   # arm64, armhf, or amd64
@@ -104,7 +104,7 @@ Or download manually from the [latest release](https://github.com/Mesh-America/s
 | Raspberry Pi 2/3/Zero 2 (32-bit) | `supply-drop-bbs_armhf.deb` |
 | x86-64 Linux | `supply-drop-bbs_amd64.deb` |
 
-### Option 2 — Raw binary
+### Option 2: Raw binary
 
 Download the binary directly and verify the checksum before running it.
 
@@ -123,7 +123,7 @@ Other available targets: `armv7-unknown-linux-gnueabihf` (armhf),
 `x86_64-unknown-linux-gnu` (amd64). Append `-headless` for a smaller build
 without the admin web UI.
 
-### Option 3 — Guided setup script
+### Option 3: Guided setup script
 
 If you prefer a wizard that handles everything (including optional
 [pymc-companion](contrib/pymc-companion/) HAT configuration), download

--- a/README.md
+++ b/README.md
@@ -32,11 +32,11 @@ to:
   device running the MeshCore companion firmware (no Python, no bridge
   process), or over TCP to
   [`pymc_core`](https://github.com/meshcore-dev/pymc_core)'s
-  CompanionFrameServer for Raspberry Pi HAT deployments. A third
-  transport lets an operator run any executable (Telnet, Slack, Discord,
-  APRS, SMS, ...) as a BBS transport over a simple JSON IPC protocol. The
-  BBS-core itself is protocol-agnostic; see
-  [ADR-0011](docs/adr/0011-transport-protocol-agnostic-core.md).
+  CompanionFrameServer, which also covers Raspberry Pi HAT radios as a
+  special case. A third transport lets an operator run any executable
+  (Telnet, Slack, Discord, APRS, SMS, ...) as a BBS transport over a
+  simple JSON IPC protocol. The BBS-core itself is protocol-agnostic;
+  see [ADR-0011](docs/adr/0011-transport-protocol-agnostic-core.md).
 - **CLI clients**, either an interactive session over a Unix-domain
   socket for local administration and scripting, or one-shot
   subcommands (`backup`/`restore`, user and room management, node key

--- a/README.md
+++ b/README.md
@@ -26,16 +26,22 @@
 Supply Drop BBS is the BBS half of a mesh-radio operator's stack. It speaks
 to:
 
-- **Mesh radios**, via a pluggable transport architecture. v1 supports
-  [MeshCore](https://meshcore.dev) (through
+- **Mesh radios**, via a pluggable transport architecture, with both
+  [MeshCore](https://meshcore.dev) and [Meshtastic](https://meshtastic.org)
+  shipping today. MeshCore connects either directly over USB serial to a
+  device running the MeshCore companion firmware (no Python, no bridge
+  process), or over TCP to
   [`pymc_core`](https://github.com/meshcore-dev/pymc_core)'s
-  CompanionFrameServer running as a separate radio-bridge process).
-  Other LoRa mesh protocols - [Meshtastic](https://meshtastic.org)
-  most notably - are explicitly on the roadmap as sibling transport
-  plugins. The BBS-core itself is protocol-agnostic; see
+  CompanionFrameServer for Raspberry Pi HAT deployments. A third
+  transport lets an operator run any executable (Telnet, Slack, Discord,
+  APRS, SMS, ...) as a BBS transport over a simple JSON IPC protocol. The
+  BBS-core itself is protocol-agnostic; see
   [ADR-0011](docs/adr/0011-transport-protocol-agnostic-core.md).
-- **CLI clients** over a Unix-domain socket, for local administration and
-  scripting.
+- **CLI clients**, either an interactive session over a Unix-domain
+  socket for local administration and scripting, or one-shot
+  subcommands (`backup`/`restore`, user and room management, node key
+  management, and more) run directly against the database and data
+  directory.
 - **An optional admin web UI** (off by default), purely for sysop
   maintenance - not for end-user message reading.
 
@@ -63,7 +69,8 @@ Specifically, this project bakes in from day 1:
 - Compile-time-checked SQL via `sqlx`
 - Logging that respects config (no silent `--debug` overrides)
 - Audit-logged sysop actions
-- Single static binary, single TOML config file
+- Single self-contained binary (the web UI's frontend is embedded, not
+  shipped separately), single TOML config file
 
 ## Installation
 
@@ -103,7 +110,7 @@ Download the binary directly and verify the checksum before running it.
 
 ```sh
 # Example for Raspberry Pi 4 (arm64):
-TAG=v0.6.2   # replace with the latest release tag
+TAG=v0.12.0   # replace with the latest release tag
 curl -fsSL "https://github.com/Mesh-America/supply-drop-bbs/releases/download/${TAG}/supply-drop-bbs-${TAG}-aarch64-unknown-linux-gnu" \
      -o supply-drop-bbs
 curl -fsSL "https://github.com/Mesh-America/supply-drop-bbs/releases/download/${TAG}/SHA256SUMS" \
@@ -119,8 +126,8 @@ without the admin web UI.
 ### Option 3 — Guided setup script
 
 If you prefer a wizard that handles everything (including optional
-[pymc-companion](https://github.com/Mesh-America/pymc-companion) HAT
-configuration), download and review the script first, then run it:
+[pymc-companion](contrib/pymc-companion/) HAT configuration), download
+and review the script first, then run it:
 
 ```sh
 curl -fsSL https://raw.githubusercontent.com/Mesh-America/supply-drop-bbs/main/install.sh \

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -473,17 +473,18 @@ Cargo features in the binary's `Cargo.toml`:
 
 ```toml
 [features]
-default = ["transport-cli", "transport-mesh"]
-transport-cli  = ["dep:bbs-cli"]
-transport-mesh = ["dep:bbs-mesh"]
-admin-web      = ["dep:bbs-web"]   # opt-in
+default               = ["transport-cli", "transport-mesh", "transport-meshtastic", "admin-web", "transport-process"]
+transport-cli         = ["dep:bbs-cli"]
+transport-mesh        = ["dep:bbs-mesh", "dep:meshcore-companion"]
+transport-meshtastic  = ["dep:bbs-meshtastic"]
+admin-web             = ["dep:bbs-web"]
+transport-process     = ["dep:bbs-process-transport"]
 ```
 
-CI builds three artefacts per architecture:
+CI builds two artefacts per architecture:
 
-- `supply-drop-bbs`           - default features (cli + mesh)
-- `supply-drop-bbs-web`       - default + admin-web
-- `supply-drop-bbs-headless`  - cli only (no mesh, for dev)
+- `supply-drop-bbs`           - default features (both mesh transports, the process-transport plugin, and admin-web all included)
+- `supply-drop-bbs-headless`  - `transport-cli, transport-mesh` only - no Meshtastic, no admin-web, no process-transport; smaller binary for resource-constrained nodes
 
 A future ADR may revisit this if we want runtime-loaded WASM
 plugins. Not v1.

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -159,7 +159,7 @@ verify its checksum, then install it and the service unit manually.
 
 ```sh
 # Set these for your system
-TAG=v0.6.2   # replace with the latest release tag
+TAG=v0.12.0   # replace with the latest release tag
 ARCH=$(uname -m)
 case "$ARCH" in
   aarch64) TARGET="aarch64-unknown-linux-gnu" ;;

--- a/docs/PLUGIN_API.md
+++ b/docs/PLUGIN_API.md
@@ -56,16 +56,16 @@ cargo build --release
 ./target/release/supply-drop-bbs setup
 ```
 
-The current `bbs-plugin-api` version is **0.6.2**. Reference it in
+The current `bbs-plugin-api` version is **0.12.0**. Reference it in
 your plugin's `Cargo.toml`:
 
 ```toml
 [dependencies]
-bbs-plugin-api = { git = "https://github.com/Mesh-America/supply-drop-bbs", version = "0.6" }
+bbs-plugin-api = { git = "https://github.com/Mesh-America/supply-drop-bbs", version = "0.12" }
 ```
 
-Using the semver range `"0.6"` picks up patch releases automatically.
-Pin to an exact version (`"0.6.2"`) only if you need strict
+Using the semver range `"0.12"` picks up patch releases automatically.
+Pin to an exact version (`"0.12.0"`) only if you need strict
 reproducibility.
 
 ## What is a plugin

--- a/docs/TRANSPORT_PLUGINS.md
+++ b/docs/TRANSPORT_PLUGINS.md
@@ -46,7 +46,7 @@ transport at it from your dev machine. See
 [Installation & Operations](OPERATIONS.md) for the full install
 guide.
 
-The current workspace version is **0.6.2**. See the
+The current workspace version is **0.12.0**. See the
 [Plugin API guide § Versioning](PLUGIN_API.md#versioning) for the
 version history and migration notes for existing plugins.
 
@@ -161,8 +161,11 @@ via `[[plugins.process]]`.
 
 ### 2.1 Wiring two transports together: step-by-step
 
-Suppose you are adding a Meshtastic transport (`bbs-meshtastic`) alongside the
-existing MeshCore transport (`bbs-mesh`). Here is exactly what you change.
+This walks through adding a second mesh transport, using Meshtastic
+(`bbs-meshtastic`) alongside the existing MeshCore transport (`bbs-mesh`)
+as the worked example - this is, in fact, exactly how the real
+`bbs-meshtastic` transport that ships today was integrated. Here is
+exactly what changes to add a transport of your own.
 
 #### Step 1 — `Cargo.toml` (workspace root)
 
@@ -1361,8 +1364,11 @@ async fn real_radio_round_trip() { ... }
 
 ## 14. Complete worked example
 
-Below is a minimal skeleton for a hypothetical Meshtastic transport. It is
-not production-ready but demonstrates every integration point.
+Below is a minimal skeleton demonstrating every integration point a new
+transport needs to touch. It's intentionally simplified for illustration -
+the real `bbs-meshtastic` crate that ships in this workspace today is a
+full implementation with its own protocol framing, session handling, and
+tests. Don't confuse this teaching skeleton with it.
 
 ### `crates/bbs-meshtastic/Cargo.toml`
 
@@ -1383,15 +1389,15 @@ thiserror                = "1"
 ```
 
 ::: tip Current version
-The workspace version is **0.6.2**. Out-of-tree plugins (not inside
+The workspace version is **0.12.0**. Out-of-tree plugins (not inside
 this workspace) reference the crate directly:
 
 ```toml
 [dependencies]
-bbs-plugin-api = { git = "https://github.com/Mesh-America/supply-drop-bbs", version = "0.6" }
+bbs-plugin-api = { git = "https://github.com/Mesh-America/supply-drop-bbs", version = "0.12" }
 ```
 
-Use the `"0.6"` range rather than pinning to an exact patch version.
+Use the `"0.12"` range rather than pinning to an exact patch version.
 :::
 
 ### `crates/bbs-meshtastic/src/lib.rs`

--- a/docs/adr/0004-cargo-features-not-runtime-plugins.md
+++ b/docs/adr/0004-cargo-features-not-runtime-plugins.md
@@ -105,11 +105,10 @@ won't be revisited.
 
 CI ships these binary variants per architecture:
 
-| Variant                      | Features                                |
-|------------------------------|-----------------------------------------|
-| `supply-drop-bbs`            | `transport-cli, transport-mesh` (default) |
-| `supply-drop-bbs-web`        | default + `admin-web`                   |
-| `supply-drop-bbs-headless`   | `transport-cli` only (development)      |
+| Variant                      | Features                                                                                       |
+|------------------------------|--------------------------------------------------------------------------------------------------|
+| `supply-drop-bbs`            | `transport-cli, transport-mesh, transport-meshtastic, admin-web, transport-process` (default)  |
+| `supply-drop-bbs-headless`   | `transport-cli, transport-mesh` only - no Meshtastic, no admin-web, no process-transport        |
 
 Architectures: `aarch64-unknown-linux-gnu` (Pi 4/5),
 `armv7-unknown-linux-gnueabihf` (older Pi),

--- a/docs/adr/0011-transport-protocol-agnostic-core.md
+++ b/docs/adr/0011-transport-protocol-agnostic-core.md
@@ -6,18 +6,15 @@
 
 ## Context
 
-v1 ships with a single mesh transport: MeshCore, via
-`pymc_core`'s CompanionFrameServer. The architecture is built
-around a `TransportEngine` plugin contract that allows other
-transports to be added later - and one of those is almost
-certainly going to be Meshtastic, which has a substantially
-larger user base than MeshCore today.
+v1 shipped with a single mesh transport, MeshCore. The
+architecture is built around a `TransportEngine` plugin contract
+that allows other transports to be added later, and Meshtastic -
+which has a substantially larger user base than MeshCore - was
+added as a second, fully-supported transport shortly after
+(`bbs-meshtastic`). Both ship today.
 
 Other plausible future transports:
 
-- **Meshtastic** - protobuf over USB / BLE / TCP, no bridge
-  process needed (the device's firmware speaks the protocol
-  directly to the host)
 - **Reticulum / RNS** - a different mesh-network design altogether
 - **Custom packet radio** - AX.25 over an analog HT
 - **Telnet / TCP raw** - for network-attached operators
@@ -151,7 +148,7 @@ The mapping table lives in the MeshCore plugin's migration set.
 ### Compliant: a Meshtastic transport plugin doing the same thing
 
 ```rust
-// In bbs-meshtastic (hypothetical future plugin)
+// In bbs-meshtastic (the Meshtastic transport plugin)
 //
 //   CREATE TABLE meshtastic_identities (
 //     username TEXT NOT NULL REFERENCES users(username) ON DELETE CASCADE,


### PR DESCRIPTION
## Summary

Audited README.md against the current codebase and fixed several inaccuracies:

- **Meshtastic mischaracterized as roadmap-only.** `transport-meshtastic` has actually been a default-on, fully-featured transport for a while (full `bbs-meshtastic` crate: radio config, owner info, security/key management). The README said it was "explicitly on the roadmap."
- **MeshCore's connection story was incomplete.** The README described the *only* way to connect as through `pymc_core`'s CompanionFrameServer over TCP. Since ADR-0013, there's also a native serial mode — a device running MeshCore's USB companion firmware talks directly to the BBS, no Python or bridge process at all. The TCP/`pymc_core` path is specifically for Raspberry Pi HAT deployments now, not the only option.
- **`transport-process` (run any executable as a BBS transport — Telnet/Slack/Discord/APRS/SMS via JSON IPC) was never mentioned**, despite being a default-on feature that fits naturally alongside the pluggable-transport pitch.
- **The CLI bullet only described the interactive Unix-socket session**, omitting the one-shot subcommand surface (`backup`/`restore`, user/room management, node key management) that's how sysops actually do disaster recovery and administration.
- **"Single static binary" overstated the binary's linking** — release binaries are dynamically linked against glibc, not statically linked. Reworded to "single self-contained binary" and called out the embedded web frontend, which is the property that actually matters to an operator.
- **Stale version-tag example.** The raw-binary install example still showed `TAG=v0.6.2`; current is v0.12.0. Fixed the identical copy-pasted example in `docs/OPERATIONS.md` too.
- **Dead external link.** The `pymc-companion` link pointed at `github.com/Mesh-America/pymc-companion`, which 404s. That project was absorbed into this repo as `contrib/pymc-companion/` (confirmed via `install.sh`, which copies the script from there rather than cloning anything external) — repointed the link at the in-repo directory.

Everything else (doc links, LICENSE/CONTRIBUTING/SECURITY/CODE_OF_CONDUCT references, the ADR-0011 link, the `-headless` build flag) was verified accurate as written.

Docs-only change — no code touched.

## Test plan
- [x] Full read-through of README.md and cross-reference of every factual claim against the current codebase and docs
- [x] Verified the `pymc-companion` link 404s and the replacement target exists
- [x] Pre-commit checks (fmt/clippy/test/doc) pass — no Rust files changed, so this is incidental, but confirms nothing broke

🤖 Generated with [Claude Code](https://claude.com/claude-code)