### PR TITLE
fix: stop MeshCore radio preset from clobbering saved field overrides

### DIFF
--- a/crates/bbs-web/web/src/pages/SettingsPage.vue
+++ b/crates/bbs-web/web/src/pages/SettingsPage.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, computed, watch, onMounted } from 'vue'
+import { ref, computed, onMounted } from 'vue'
 import { api, ApiError } from '../api/client'
 
 interface ConfigData {
@@ -399,9 +399,14 @@ function applyPreset(name: string) {
   radioTxPowerDbm.value      = String(p.tx_power_dbm)
 }
 
-watch(radioPreset, (name) => {
-  if (name) applyPreset(name)
-})
+// Fired only by the operator picking a preset from the dropdown — NOT a
+// watch() on radioPreset. loadRadioConfig() also sets radioPreset.value (to
+// reflect a stored preset name), and a watch() would fire from that too,
+// clobbering individually-overridden fields loaded moments earlier with the
+// preset's raw defaults every time the page loads.
+function onRadioPresetChange() {
+  if (radioPreset.value) applyPreset(radioPreset.value)
+}
 
 async function loadRadioConfig() {
   radioLoading.value = true
@@ -1207,8 +1212,12 @@ chmod g+w {{ configFile }}</pre>
 
         <div class="field">
           <label>Region preset</label>
-          <select v-model="radioPreset" :disabled="radioLoading" style="max-width: 320px">
+          <select v-model="radioPreset" @change="onRadioPresetChange" :disabled="radioLoading" style="max-width: 320px">
             <option value="">(select a preset to fill values below)</option>
+            <option
+              v-if="radioPreset && !radioPresets.some(p => p.name === radioPreset)"
+              :value="radioPreset"
+            >{{ radioPreset }}</option>
             <option v-for="p in radioPresets" :key="p.name" :value="p.name">{{ p.name }}</option>
           </select>
           <p class="hint">Selecting a preset fills in the parameters below. You can then adjust individual values.</p>


### PR DESCRIPTION
## Summary
Settings > MeshCore radio showed the wrong values whenever a saved config had both a named preset and at least one individually-tuned field that differs from that preset's canned defaults (e.g. `preset = "USA/Canada"` plus a manually-adjusted `spreading_factor`) — exactly the workflow the UI's own hint text invites ("Selecting a preset fills in the parameters below. You can then adjust individual values.").

**Root cause**: `loadRadioConfig()` correctly set the individual field refs from the server's saved values, but a `watch(radioPreset, ...)` registered nearby also fired from the *same* function setting `radioPreset.value` to reflect the stored preset name — and since Vue's `watch()` callbacks are deferred until after the current synchronous block, that watcher's `applyPreset()` call ran afterward and silently overwrote the just-loaded overrides with the preset's raw defaults.

Reproduced live: a config with `preset = "USA/Canada"` and `spreading_factor` overridden to `10` showed `7` (the preset's default) in the UI every time the page loaded.

**Fix**: removed the `watch()` and moved `applyPreset()` to an explicit `@change` handler on the preset `<select>`, so it only fires when the operator actually picks a new preset, not as a side effect of the ref being set programmatically during load.

Also added a fallback `<option>` for a stored preset name that isn't in the current preset list, matching the existing pattern already used by the Starting room and Timezone selects earlier in this file — without it, an unrecognized preset name silently falls back to the blank placeholder while the stale name is still resubmitted on save.

## Test plan
- [x] Reproduced the bug live: built the binary, ran it against a test config with `preset = "USA/Canada"` + `spreading_factor = 10`, confirmed the Settings UI showed `7` before the fix
- [x] Confirmed the fix: same config, same page load, now correctly shows `10`
- [x] Confirmed the intended feature still works: manually selecting a different preset from the dropdown still fills in all fields correctly
- [x] `vue-tsc --noEmit` (frontend type-check)
- [x] `npm run build` (frontend production build)
- [x] `cargo fmt --all --check`
- [x] `cargo test --workspace`
- [x] `cargo clippy --workspace -- -D warnings`
- [x] Adversarial code review pass on the diff (confirmed Vue's `v-model` + `@change` ordering on `<select>` is safe, no other `radioPreset` side-effect dependents, no leftover `watch` import)

🤖 Generated with [Claude Code](https://claude.com/claude-code)