### PR TITLE
feat(mesh): broadcast configured GPS position in MeshCore/Meshtastic adverts

### DIFF
--- a/crates/bbs-core/src/host.rs
+++ b/crates/bbs-core/src/host.rs
@@ -271,6 +271,10 @@ pub struct BbsHost {
     /// Optional GPS coordinates from `[location]` config section.
     /// Wrapped in a RwLock so the web admin can update it without a restart.
     location: std::sync::RwLock<Option<(f64, f64)>>,
+    /// Whether `location` (if set) should be broadcast in mesh self-adverts —
+    /// `[location].share_in_advert`. Wrapped in an `AtomicBool` so the web
+    /// admin can flip it without a restart, mirroring `location` itself.
+    share_location_in_advert: std::sync::atomic::AtomicBool,
     /// MeshCore advert node name (the BBS name), pre-truncated to an
     /// advert-safe length. Set at startup from `bbs.name`; read by the mesh
     /// transport on connect to push `SetAdvertName` to the radio so the node
@@ -305,8 +309,11 @@ impl BbsHost {
     }
 
     /// Create a [`BbsHost`] with an optional GPS location.
+    ///
+    /// Advert sharing defaults to `true` (matching `[location].share_in_advert`'s
+    /// default) — use [`with_config`](Self::with_config) to override it.
     pub fn with_location(db: Database, location: Option<(f64, f64)>) -> Self {
-        Self::with_config(db, location, AccessPolicy::default(), None)
+        Self::with_config(db, location, true, AccessPolicy::default(), None)
     }
 
     /// Create a [`BbsHost`] with a full configuration.
@@ -316,6 +323,7 @@ impl BbsHost {
     pub fn with_config(
         db: Database,
         location: Option<(f64, f64)>,
+        share_location_in_advert: bool,
         policy: AccessPolicy,
         config_path: Option<PathBuf>,
     ) -> Self {
@@ -328,6 +336,7 @@ impl BbsHost {
             advert_bus: Arc::new(AdvertBus::new()),
             login_failures: tokio::sync::Mutex::new(HashMap::new()),
             location: std::sync::RwLock::new(location),
+            share_location_in_advert: std::sync::atomic::AtomicBool::new(share_location_in_advert),
             node_name: std::sync::RwLock::new(None),
             access_policy: RwLock::new(policy),
             guest_room_id: std::sync::RwLock::new(None),
@@ -636,6 +645,15 @@ impl Host for BbsHost {
 
     fn set_node_location(&self, location: Option<(f64, f64)>) {
         *self.location.write().unwrap() = location;
+    }
+
+    fn share_location_in_advert(&self) -> bool {
+        self.share_location_in_advert.load(Ordering::Relaxed)
+    }
+
+    fn set_share_location_in_advert(&self, share: bool) {
+        self.share_location_in_advert
+            .store(share, Ordering::Relaxed);
     }
 
     fn mesh_node_name(&self) -> Option<String> {
@@ -7568,7 +7586,7 @@ mod tests {
         let db = Database::open(&f.path().to_string_lossy())
             .await
             .expect("db open");
-        let host = BbsHost::with_config(db, None, policy, None);
+        let host = BbsHost::with_config(db, None, true, policy, None);
         host.ensure_guest_room().await.expect("ensure_guest_room");
         (Arc::new(host), f)
     }

--- a/crates/bbs-mesh/src/session.rs
+++ b/crates/bbs-mesh/src/session.rs
@@ -161,6 +161,25 @@ pub struct SessionState {
     /// never reset on reconnect, so the cooldown persists across reconnects
     /// too.
     contacts_catchup_requested_at: Option<Instant>,
+    /// The device's `CMD_SET_OTHER_PARAMS` fields as last reported by
+    /// `SelfInfo` (refreshed after this transport pushes its own change).
+    /// `None` until the device has reported `SelfInfo` at least once —
+    /// firmware old enough to skip `SelfInfo` on `AppStart` may not support
+    /// `CMD_SET_OTHER_PARAMS` at all, so nothing derived from this is ever
+    /// sent in that case. Used to sync `advert_loc_policy` (the "Share
+    /// Position in Advert" bit) without clobbering the other three fields
+    /// this transport doesn't manage.
+    pub device_other_params: Option<DeviceOtherParams>,
+}
+
+/// Snapshot of the device's `CMD_SET_OTHER_PARAMS` fields — see
+/// [`SessionState::device_other_params`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct DeviceOtherParams {
+    pub manual_add_contacts: u8,
+    pub telemetry_modes: u8,
+    pub advert_loc_policy: u8,
+    pub multi_acks: u8,
 }
 
 impl SessionState {

--- a/crates/bbs-mesh/src/transport.rs
+++ b/crates/bbs-mesh/src/transport.rs
@@ -40,7 +40,10 @@ use bbs_plugin_api::{
 };
 use meshcore_companion::{
     client::{ClientConfig, ClientEvent, CompanionClient, SerialConfig},
-    constants::{ADV_TYPE_CHAT, MAX_FRAME_SIZE, MAX_PATH_SIZE, TXT_TYPE_PLAIN},
+    constants::{
+        ADVERT_LOC_NONE, ADVERT_LOC_SHARE, ADV_TYPE_CHAT, MAX_FRAME_SIZE, MAX_PATH_SIZE,
+        TXT_TYPE_PLAIN,
+    },
     frame::OutboundFrame,
     types::{Contact, SelfInfo},
 };
@@ -63,7 +66,7 @@ use crate::{
     metrics::DeliveryStats,
     presets::resolve_radio,
     send_tracker::{RetryConfig, SendTracker, SentOutcome},
-    session::SessionState,
+    session::{DeviceOtherParams, SessionState},
 };
 
 /// Floor for how long to wait for a reply's end-to-end ACK before retransmitting.
@@ -248,6 +251,58 @@ fn next_outbound_timestamp() -> u32 {
     }
 }
 
+/// Push the device's advert-location-sharing policy bit if it doesn't already
+/// match the configured `[location]` sharing preference.
+///
+/// `SetAdvertLatlon` (sent separately) only stores raw coordinates on the
+/// device — it is `advert_loc_policy` (`ADVERT_LOC_SHARE` vs `ADVERT_LOC_NONE`,
+/// pushed via `CMD_SET_OTHER_PARAMS`) that actually makes the firmware include
+/// lat/lon in outgoing self-adverts. This is the on-device equivalent of the
+/// official MeshCore app's "Share Position in Advert" checkbox.
+///
+/// `CMD_SET_OTHER_PARAMS` sets four fields at once, so this preserves the
+/// other three (`manual_add`, `telemetry_modes`, `multi_acks`) from the
+/// last-known device state rather than clobbering them. No-ops until the
+/// device has reported `SelfInfo` at least once — older firmware that skips
+/// `SelfInfo` on `AppStart` may not support this command at all — and no-ops
+/// again if the desired policy already matches, to avoid a needless write on
+/// every periodic advert tick.
+async fn sync_advert_location_policy(
+    cmd_tx: &mpsc::Sender<OutboundFrame>,
+    host: &Arc<dyn Host>,
+    state: &Arc<Mutex<SessionState>>,
+) {
+    let desired = if host.node_location().is_some() && host.share_location_in_advert() {
+        ADVERT_LOC_SHARE
+    } else {
+        ADVERT_LOC_NONE
+    };
+    let updated: Option<DeviceOtherParams> = {
+        let mut guard = state.lock().expect("state mutex poisoned");
+        match guard.device_other_params.as_mut() {
+            Some(params) if params.advert_loc_policy != desired => {
+                params.advert_loc_policy = desired;
+                Some(*params)
+            }
+            _ => None,
+        }
+    };
+    if let Some(params) = updated {
+        info!(
+            advert_loc_policy = desired,
+            "mesh: syncing advert location-sharing policy"
+        );
+        let _ = cmd_tx
+            .send(OutboundFrame::SetOtherParams {
+                manual_add: params.manual_add_contacts,
+                telemetry_modes: params.telemetry_modes,
+                advert_loc_policy: params.advert_loc_policy,
+                multi_acks: params.multi_acks,
+            })
+            .await;
+    }
+}
+
 /// Push the configured node name + location to the radio and broadcast a
 /// self-advert. Used by the on-connect advert, the periodic advert tick, and the
 /// web-UI "send advert" trigger. Refreshing the name/location first means the
@@ -257,6 +312,7 @@ fn next_outbound_timestamp() -> u32 {
 async fn broadcast_self_advert(
     cmd_tx: &mpsc::Sender<OutboundFrame>,
     host: &Arc<dyn Host>,
+    state: &Arc<Mutex<SessionState>>,
     flood: bool,
 ) {
     if let Some((lat, lon)) = host.node_location() {
@@ -266,6 +322,7 @@ async fn broadcast_self_advert(
             .send(OutboundFrame::SetAdvertLatlon { lat_1e6, lon_1e6 })
             .await;
     }
+    sync_advert_location_policy(cmd_tx, host, state).await;
     if let Some(node_name) = host.mesh_node_name() {
         if !node_name.is_empty() {
             let _ = cmd_tx
@@ -487,6 +544,7 @@ impl Plugin for MeshTransport {
         let mut advert_send_rx = host.advert_bus().subscribe_send();
         let advert_cmd_tx = self.cmd_tx.clone();
         let advert_host = Arc::clone(&host);
+        let advert_state = Arc::clone(&state);
         let mut advert_shutdown_rx = self.shutdown_tx.subscribe();
         tokio::spawn(async move {
             loop {
@@ -494,7 +552,7 @@ impl Plugin for MeshTransport {
                     result = advert_send_rx.recv() => {
                         match result {
                             Ok(flood) => {
-                                broadcast_self_advert(&advert_cmd_tx, &advert_host, flood).await;
+                                broadcast_self_advert(&advert_cmd_tx, &advert_host, &advert_state, flood).await;
                             }
                             Err(tokio::sync::broadcast::error::RecvError::Lagged(n)) => {
                                 warn!("mesh: advert send requests lagged by {n}");
@@ -953,8 +1011,21 @@ async fn event_loop(
                             );
                             // Record our own pubkey so the NewAdvert handler can
                             // detect self-advert echoes and preserve configured GPS.
-                            state.lock().expect("state mutex poisoned").self_pubkey =
-                                Some(info.pubkey);
+                            // Also snapshot the device's CMD_SET_OTHER_PARAMS fields
+                            // (manual_add/telemetry/advert_loc_policy/multi_acks) so
+                            // sync_advert_location_policy can flip advert_loc_policy
+                            // later without clobbering the other three.
+                            {
+                                let mut guard =
+                                    state.lock().expect("state mutex poisoned");
+                                guard.self_pubkey = Some(info.pubkey);
+                                guard.device_other_params = Some(DeviceOtherParams {
+                                    manual_add_contacts: info.manual_add_contacts,
+                                    telemetry_modes: info.telemetry_modes,
+                                    advert_loc_policy: info.advert_loc_policy,
+                                    multi_acks: info.multi_acks,
+                                });
+                            }
                             // Publish pubkey to Host so the web UI can display it.
                             let pubkey_hex: String = info.pubkey.iter().map(|b| format!("{b:02x}")).collect();
                             host.set_node_pubkey(pubkey_hex);
@@ -997,6 +1068,11 @@ async fn event_loop(
                                     TRANSPORT_NAME,
                                 );
                             }
+                            // Flip the device's advert-location-sharing policy bit if
+                            // it doesn't already match `[location].share_in_advert`
+                            // (works whether or not a location is configured — an
+                            // unconfigured location resolves to ADVERT_LOC_NONE).
+                            sync_advert_location_policy(&cmd_tx, &host, &state).await;
                             // Set the routing path-hash width (2- or 3-byte paths).
                             // Pushed here in the SelfInfo branch — a device modern
                             // enough to answer AppStart supports this newer command;
@@ -1163,7 +1239,7 @@ async fn event_loop(
                 }
             }
             _ = advert_tick.tick() => {
-                broadcast_self_advert(&cmd_tx, &host, true).await;
+                broadcast_self_advert(&cmd_tx, &host, &state, true).await;
                 last_advert_at = Some(Instant::now());
             }
             Some(req) = key_rx.recv() => {

--- a/crates/bbs-mesh/tests/transport.rs
+++ b/crates/bbs-mesh/tests/transport.rs
@@ -40,6 +40,14 @@ fn radio_frame(payload: &[u8]) -> Vec<u8> {
 }
 
 fn self_info_frame(name: &str) -> Vec<u8> {
+    self_info_frame_with_policy(name, ADVERT_LOC_NONE)
+}
+
+/// Like [`self_info_frame`] but with an explicit `advert_loc_policy` byte —
+/// lets a test simulate a device that already has (or doesn't have) the
+/// "Share Position in Advert" bit set, to exercise
+/// `sync_advert_location_policy`'s sync-only-on-mismatch behaviour.
+fn self_info_frame_with_policy(name: &str, advert_loc_policy: u8) -> Vec<u8> {
     let mut body = Vec::new();
     body.push(ADV_TYPE_CHAT);
     body.push(20u8);
@@ -47,10 +55,10 @@ fn self_info_frame(name: &str) -> Vec<u8> {
     body.extend_from_slice(&[0xAAu8; 32]);
     body.extend_from_slice(&0i32.to_le_bytes());
     body.extend_from_slice(&0i32.to_le_bytes());
-    body.push(0u8);
-    body.push(ADVERT_LOC_NONE);
-    body.push(0u8);
-    body.push(0u8);
+    body.push(0u8); // multi_acks
+    body.push(advert_loc_policy);
+    body.push(0u8); // telemetry_modes
+    body.push(0u8); // manual_add_contacts
     body.extend_from_slice(&915_000u32.to_le_bytes());
     body.extend_from_slice(&125_000u32.to_le_bytes());
     body.push(10u8);
@@ -479,6 +487,118 @@ async fn radio_params_not_resent_when_they_already_match() {
     assert_eq!(
         first[0], CMD_SET_PATH_HASH_MODE,
         "matching radio config must not be re-sent"
+    );
+
+    transport.stop().await.unwrap();
+}
+
+/// A configured `[location]` with sharing enabled (the default) must flip the
+/// device's `advert_loc_policy` byte to `ADVERT_LOC_SHARE` on connect — the
+/// on-device equivalent of the MeshCore app's "Share Position in Advert"
+/// checkbox — when the device reports it's currently off. Without this the
+/// BBS pushes raw coordinates (`SetAdvertLatlon`) but never actually turns on
+/// broadcasting, so the node never appears on public MeshCore maps even
+/// though GPS is configured (the exact bug this guards against).
+///
+/// `CMD_SET_OTHER_PARAMS` sets four fields at once, so this also checks the
+/// other three (manual_add/telemetry_modes/multi_acks) are carried over
+/// unchanged from the device's own `SelfInfo`, not clobbered with zeros.
+#[tokio::test]
+async fn advert_location_shared_when_configured_and_device_not_yet_sharing() {
+    let host = Arc::new(MockHost::new());
+    host.set_location(Some((37.7749, -122.4194)), true);
+    let (transport, mut bridge) = make_transport(Arc::clone(&host), None).await;
+
+    let app_start = bridge.recv_n(11).await;
+    assert_eq!(app_start[3], CMD_APP_START);
+    // Device currently has sharing off; SelfInfo reports manual_add=0,
+    // telemetry_modes=0, multi_acks=0 (see self_info_frame_with_policy).
+    bridge
+        .send(&self_info_frame_with_policy("Node", ADVERT_LOC_NONE))
+        .await;
+
+    let set_latlon = tokio::time::timeout(
+        Duration::from_secs(2),
+        bridge.read_until_cmd(CMD_SET_ADVERT_LATLON),
+    )
+    .await
+    .expect("expected CMD_SET_ADVERT_LATLON on connect");
+    assert_eq!(set_latlon[0], CMD_SET_ADVERT_LATLON);
+
+    let set_other = tokio::time::timeout(
+        Duration::from_secs(2),
+        bridge.read_until_cmd(CMD_SET_OTHER_PARAMS),
+    )
+    .await
+    .expect("expected CMD_SET_OTHER_PARAMS to sync advert_loc_policy");
+    assert_eq!(set_other[1], 0, "manual_add_contacts must be preserved");
+    assert_eq!(set_other[2], 0, "telemetry_modes must be preserved");
+    assert_eq!(
+        set_other[3], ADVERT_LOC_SHARE,
+        "advert_loc_policy must flip to SHARE"
+    );
+    assert_eq!(set_other[4], 0, "multi_acks must be preserved");
+
+    transport.stop().await.unwrap();
+}
+
+/// The mirror case: `share_in_advert = false` must push `ADVERT_LOC_NONE`
+/// when the device currently has sharing on — e.g. an operator turning the
+/// checkbox off after previously enabling it. Coordinates are still
+/// configured (and still pushed via `SetAdvertLatlon`); only the broadcast
+/// policy is turned off.
+#[tokio::test]
+async fn advert_location_unshared_when_disabled_and_device_currently_sharing() {
+    let host = Arc::new(MockHost::new());
+    host.set_location(Some((37.7749, -122.4194)), false);
+    let (transport, mut bridge) = make_transport(Arc::clone(&host), None).await;
+
+    let app_start = bridge.recv_n(11).await;
+    assert_eq!(app_start[3], CMD_APP_START);
+    bridge
+        .send(&self_info_frame_with_policy("Node", ADVERT_LOC_SHARE))
+        .await;
+
+    let set_other = tokio::time::timeout(
+        Duration::from_secs(2),
+        bridge.read_until_cmd(CMD_SET_OTHER_PARAMS),
+    )
+    .await
+    .expect("expected CMD_SET_OTHER_PARAMS to sync advert_loc_policy");
+    assert_eq!(
+        set_other[3], ADVERT_LOC_NONE,
+        "advert_loc_policy must flip back to NONE when sharing is disabled"
+    );
+
+    transport.stop().await.unwrap();
+}
+
+/// No location configured (the default `MockHost`) must never emit
+/// `CMD_SET_OTHER_PARAMS` — the desired policy (`ADVERT_LOC_NONE`) already
+/// matches what a freshly-flashed/default device reports, so there is
+/// nothing to sync. Guards the "no-op when already matching" branch of
+/// `sync_advert_location_policy` explicitly, on top of the many other tests
+/// that already rely on no extra frames appearing here (e.g.
+/// `complete_handshake`'s strict ordering assertions).
+#[tokio::test]
+async fn no_advert_location_sync_when_nothing_configured() {
+    let host = Arc::new(MockHost::new());
+    let (transport, mut bridge) = make_transport(Arc::clone(&host), None).await;
+    bridge.complete_handshake("Node").await;
+
+    // Give any (incorrect) SetOtherParams frame a chance to arrive, then
+    // confirm the connection is otherwise healthy — a stray frame here would
+    // desync the next assertion in whatever test runs against this bridge,
+    // but since the test ends here we instead prove liveness with a benign
+    // round-trip: request an advert send and confirm no SetOtherParams shows
+    // up ahead of it.
+    host.advert_bus().request_send(true);
+    let cmd = tokio::time::timeout(Duration::from_secs(2), bridge.read_command())
+        .await
+        .expect("expected some command after requesting an advert send");
+    assert_ne!(
+        cmd[0], CMD_SET_OTHER_PARAMS,
+        "no location configured — advert_loc_policy already matches, nothing to sync"
     );
 
     transport.stop().await.unwrap();

--- a/crates/bbs-meshtastic/src/lib.rs
+++ b/crates/bbs-meshtastic/src/lib.rs
@@ -1050,13 +1050,21 @@ async fn event_loop(
                             // Always sync the device clock to system time on connect.
                             deferred_writes.push(DeferredWrite::Time);
                             // Manage fixed position from the host's configured GPS:
-                            // set it when a location is configured, clear it otherwise.
+                            // set it when a location is configured AND sharing is
+                            // enabled (`[location].share_in_advert` — the same
+                            // preference the MeshCore transport reads to decide
+                            // whether to advertise position), clear it otherwise.
+                            // Meshtastic has no separate device-side "share" bit like
+                            // MeshCore's advert_loc_policy — a fixed position is
+                            // broadcast via the node's own Position app port as soon
+                            // as it's set, so gating the write itself is this
+                            // transport's equivalent of the "Share Position in
+                            // Advert" checkbox.
                             match host.node_location() {
-                                Some((lat, lon)) => deferred_writes
-                                    .push(DeferredWrite::SetFixedPosition { lat, lon }),
-                                None => {
-                                    deferred_writes.push(DeferredWrite::RemoveFixedPosition)
+                                Some((lat, lon)) if host.share_location_in_advert() => {
+                                    deferred_writes.push(DeferredWrite::SetFixedPosition { lat, lon })
                                 }
+                                _ => deferred_writes.push(DeferredWrite::RemoveFixedPosition),
                             }
                             // Push configured radio params, node name, and the
                             // node-info broadcast interval (all skip-if-unchanged).

--- a/crates/bbs-plugin-api/src/host.rs
+++ b/crates/bbs-plugin-api/src/host.rs
@@ -528,6 +528,28 @@ pub trait Host: Send + Sync {
     /// The mesh transport reads this on the next reconnect.
     fn set_node_location(&self, _location: Option<(f64, f64)>) {}
 
+    /// Whether the configured GPS location (if any) should be broadcast in
+    /// mesh self-adverts — mirrors the official MeshCore app's "Share
+    /// Position in Advert" checkbox. Independent of [`node_location`](Self::node_location)
+    /// itself: an operator may want the BBS to know its own coordinates
+    /// without publishing them mesh-wide.
+    ///
+    /// The mesh transport reads this alongside `node_location()` on
+    /// `Connected` and sets the device's `advert_loc_policy` byte
+    /// accordingly (`ADVERT_LOC_SHARE` vs `ADVERT_LOC_NONE`). The
+    /// Meshtastic transport reads it to decide whether to push a fixed
+    /// position to the device at all. Defaults to `true` so existing
+    /// `[location]` configs keep behaving as documented.
+    fn share_location_in_advert(&self) -> bool {
+        true
+    }
+
+    /// Update the in-memory advert-sharing preference without a restart.
+    /// Called by the web admin after saving a `[location]` config change.
+    /// Transports read this on the next reconnect (or the next periodic
+    /// advert / fixed-position sync).
+    fn set_share_location_in_advert(&self, _share: bool) {}
+
     /// Return the node name to advertise on the mesh (the BBS name), already
     /// truncated to a MeshCore-safe length.
     ///

--- a/crates/bbs-plugin-api/src/testing.rs
+++ b/crates/bbs-plugin-api/src/testing.rs
@@ -95,6 +95,14 @@ struct MockHostState {
     /// routes through in production, unlike this mock's own short-circuiting
     /// override of that method (which never touches this channel at all).
     mesh_key_tx: Option<tokio::sync::mpsc::Sender<MeshKeyRequest>>,
+    /// GPS coordinates returned by `node_location()`. Set via
+    /// [`MockHost::set_location`]. `None` by default, matching the trait's
+    /// own default.
+    location: Option<(f64, f64)>,
+    /// Value returned by `share_location_in_advert()`. Set via
+    /// [`MockHost::set_location`] or [`MockHost::set_share_location_in_advert`].
+    /// `true` by default, matching the trait's own default.
+    share_location_in_advert: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -138,6 +146,8 @@ impl MockHost {
                 removed_meshcore_contacts: Vec::new(),
                 removed_meshtastic_favorites: Vec::new(),
                 mesh_key_tx: None,
+                location: None,
+                share_location_in_advert: true,
             }),
             events: tx,
             advert_bus: Arc::new(AdvertBus::new()),
@@ -189,6 +199,26 @@ impl MockHost {
     /// backpressure without dropping or reordering. Defaults to zero (no delay).
     pub fn set_process_delay(&self, delay: Duration) {
         self.state.lock().expect("mock poisoned").process_delay = delay;
+    }
+
+    /// Configure the coordinates `node_location()` returns and whether
+    /// `share_location_in_advert()` reports them as shareable — the two
+    /// settings a transport reads together to decide what (if anything) to
+    /// push to the radio/device on connect.
+    pub fn set_location(&self, location: Option<(f64, f64)>, share_in_advert: bool) {
+        let mut state = self.state.lock().expect("mock poisoned");
+        state.location = location;
+        state.share_location_in_advert = share_in_advert;
+    }
+
+    /// Flip the advert-sharing preference without changing the configured
+    /// coordinates. The `Host` trait impl below delegates to this so the
+    /// two can't drift.
+    pub fn set_share_location_in_advert(&self, share: bool) {
+        self.state
+            .lock()
+            .expect("mock poisoned")
+            .share_location_in_advert = share;
     }
 
     /// Inspect the commands that have been dispatched, in order.
@@ -332,6 +362,28 @@ impl Host for MockHost {
 
     fn advert_bus(&self) -> Arc<AdvertBus> {
         Arc::clone(&self.advert_bus)
+    }
+
+    fn node_location(&self) -> Option<(f64, f64)> {
+        self.state.lock().expect("mock poisoned").location
+    }
+
+    fn set_node_location(&self, location: Option<(f64, f64)>) {
+        self.state.lock().expect("mock poisoned").location = location;
+    }
+
+    fn share_location_in_advert(&self) -> bool {
+        self.state
+            .lock()
+            .expect("mock poisoned")
+            .share_location_in_advert
+    }
+
+    fn set_share_location_in_advert(&self, share: bool) {
+        // Inherent methods take priority over trait methods in Rust's method
+        // resolution, so this calls MockHost::set_share_location_in_advert
+        // (above), not itself — no recursion.
+        self.set_share_location_in_advert(share);
     }
 
     /// Stores the sender, unlike the trait's default no-op body — so a test

--- a/crates/bbs-web/src/lib.rs
+++ b/crates/bbs-web/src/lib.rs
@@ -2041,6 +2041,7 @@ struct ConfigResponse {
     bbs_timezone: Option<String>,
     location_latitude: Option<f64>,
     location_longitude: Option<f64>,
+    location_share_in_advert: Option<bool>,
     backup_enabled: Option<bool>,
     backup_interval_hours: Option<u32>,
     backup_keep_daily: Option<u32>,
@@ -2068,6 +2069,7 @@ struct ConfigPatch {
     location_latitude: Option<Option<f64>>,
     #[serde(default, deserialize_with = "deserialize_some")]
     location_longitude: Option<Option<f64>>,
+    location_share_in_advert: Option<bool>,
     backup_enabled: Option<bool>,
     backup_interval_hours: Option<u32>,
     backup_keep_daily: Option<u32>,
@@ -2495,6 +2497,7 @@ async fn api_get_config(
         bbs_timezone: toml_str_field(&val, "bbs", "timezone"),
         location_latitude: toml_f64_field(&val, "location", "latitude"),
         location_longitude: toml_f64_field(&val, "location", "longitude"),
+        location_share_in_advert: toml_bool_field(&val, "location", "share_in_advert"),
         backup_enabled: toml_bool_field(&val, "backup", "enabled"),
         backup_interval_hours: toml_u32_field(&val, "backup", "interval_hours"),
         backup_keep_daily: toml_u32_field(&val, "backup", "keep_daily"),
@@ -2605,6 +2608,10 @@ async fn api_patch_config(
             Some(f) => doc["location"]["longitude"] = toml_edit::value(f),
         }
     }
+    let share_in_advert_touched = patch.location_share_in_advert.is_some();
+    if let Some(v) = patch.location_share_in_advert {
+        doc["location"]["share_in_advert"] = toml_edit::value(v);
+    }
     if let Some(v) = patch.backup_enabled {
         doc["backup"]["enabled"] = toml_edit::value(v);
     }
@@ -2679,6 +2686,14 @@ async fn api_patch_config(
             _ => None,
         };
         state.host.set_node_location(new_location);
+    }
+    if share_in_advert_touched {
+        let share_in_advert = doc
+            .get("location")
+            .and_then(|s| s.get("share_in_advert"))
+            .and_then(|v| v.as_bool())
+            .unwrap_or(true);
+        state.host.set_share_location_in_advert(share_in_advert);
     }
 
     // Audit log — best-effort.

--- a/crates/bbs-web/web/src/pages/SettingsPage.vue
+++ b/crates/bbs-web/web/src/pages/SettingsPage.vue
@@ -12,6 +12,7 @@ interface ConfigData {
   bbs_timezone: string | null
   location_latitude: number | null
   location_longitude: number | null
+  location_share_in_advert: boolean | null
   backup_enabled: boolean | null
   backup_interval_hours: number | null
   backup_keep_daily: number | null
@@ -41,6 +42,7 @@ const form = ref({
   location_enabled: false,
   location_latitude: '',
   location_longitude: '',
+  location_share_in_advert: true,
   backup_enabled: true,
   backup_interval_hours: 6,
   backup_keep_daily: 7,
@@ -118,6 +120,7 @@ function populateForm(c: ConfigData) {
   form.value.location_enabled   = c.location_latitude != null && c.location_longitude != null
   form.value.location_latitude  = c.location_latitude  != null ? String(c.location_latitude)  : ''
   form.value.location_longitude = c.location_longitude != null ? String(c.location_longitude) : ''
+  form.value.location_share_in_advert = c.location_share_in_advert ?? true
 
   form.value.backup_enabled        = c.backup_enabled        ?? true
   form.value.backup_interval_hours = c.backup_interval_hours ?? 6
@@ -248,6 +251,7 @@ async function save() {
       patch.location_latitude  = null
       patch.location_longitude = null
     }
+    patch.location_share_in_advert = form.value.location_share_in_advert
 
     const res = await api.patch<{ message: string }>('/api/v1/config', patch)
     saveOk.value = res.message
@@ -1062,8 +1066,7 @@ chmod g+w {{ configFile }}</pre>
       <section v-show="settingsTab === 'general'" class="card">
         <h2>GPS location</h2>
         <p class="hint">
-          When set, the mesh transport sends your coordinates to the radio on connect so your
-          node appears on the map in LoRa adverts.
+          When set, the mesh transport sends your coordinates to the radio on connect.
           <strong>Takes effect on the next mesh transport reconnect. No restart needed.</strong>
         </p>
         <div class="field checkbox-field">
@@ -1085,6 +1088,18 @@ chmod g+w {{ configFile }}</pre>
               placeholder="e.g. -122.4194" />
             <p v-if="validationErrors.location_longitude" class="field-error">{{ validationErrors.location_longitude }}</p>
           </div>
+        </div>
+        <div class="field checkbox-field">
+          <label>
+            <input type="checkbox" v-model="form.location_share_in_advert" />
+            Share Position in Advert
+          </label>
+          <p class="hint">
+            Broadcast these coordinates to the mesh so your node appears on MeshCore maps.
+            Uncheck to keep the BBS aware of its own location without publishing it —
+            matches the same checkbox in the official MeshCore app. Has no effect while
+            "Set GPS coordinates" above is off.
+          </p>
         </div>
       </section>
 

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -206,6 +206,61 @@ sudo supply-drop-bbs config guest-room off \
 
 ---
 
+### `config location`
+
+```
+supply-drop-bbs config location <latitude> <longitude> [OPTIONS]
+supply-drop-bbs config location off [OPTIONS]
+```
+
+Set or clear this node's GPS coordinates. Writes `latitude`/`longitude` to the `[location]` section of the config file. Radio transports push these coordinates to the device on connect. **Takes effect on the next BBS restart.**
+
+Setting coordinates alone does not make the node appear on public mesh maps — see `config share-position` below.
+
+| Argument | Meaning |
+|----------|---------|
+| `<latitude> <longitude>` | WGS-84 decimal degrees, e.g. `37.7749 -122.4194` |
+| `off` | Clear both coordinates |
+
+```sh
+sudo supply-drop-bbs config location 37.7749 -122.4194 \
+  --config /etc/supply-drop-bbs/config.toml
+
+sudo supply-drop-bbs config location off \
+  --config /etc/supply-drop-bbs/config.toml
+```
+
+> **Tip:** The web admin's **Settings** page can apply the same change live, without a restart.
+
+---
+
+### `config share-position`
+
+```
+supply-drop-bbs config share-position <on|off> [OPTIONS]
+```
+
+Enable or disable broadcasting the configured GPS coordinates in mesh self-adverts — mirrors the official MeshCore app's **"Share Position in Advert"** checkbox. Writes `share_in_advert` to the `[location]` section. Has no effect until coordinates are also set via `config location`. **Takes effect on the next BBS restart.**
+
+| Argument | Meaning |
+|----------|---------|
+| `on` | Broadcast coordinates in mesh self-adverts — this is what makes the node appear on MeshCore maps (default) |
+| `off` | Keep the BBS aware of its own coordinates without publishing them |
+
+```sh
+# Stop broadcasting position (coordinates stay configured)
+sudo supply-drop-bbs config share-position off \
+  --config /etc/supply-drop-bbs/config.toml
+
+# Resume broadcasting
+sudo supply-drop-bbs config share-position on \
+  --config /etc/supply-drop-bbs/config.toml
+```
+
+> **Tip:** The web admin's **Settings** page can apply the same change live, without a restart.
+
+---
+
 ### `migrate`
 
 ```

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -162,26 +162,39 @@ supply-drop-bbs config guest-room off
 ## `[location]` - GPS coordinates
 
 When set, the mesh transport sends your node's coordinates to the radio
-immediately after each connection is established, so it appears on the
-MeshCore map in LoRa adverts. **Takes effect on the next mesh transport
-reconnect — no server restart needed.**
+immediately after each connection is established. **Takes effect on the
+next mesh transport reconnect — no server restart needed.**
 
-| Key         | Type  | Default | Required | Description                          |
-|-------------|-------|---------|----------|--------------------------------------|
-| `latitude`  | float | (unset) | no       | WGS-84 latitude, degrees (-90…90)    |
-| `longitude` | float | (unset) | no       | WGS-84 longitude, degrees (-180…180) |
+| Key               | Type    | Default | Required | Description                                    |
+|-------------------|---------|---------|----------|-------------------------------------------------|
+| `latitude`        | float   | (unset) | no       | WGS-84 latitude, degrees (-90…90)              |
+| `longitude`       | float   | (unset) | no       | WGS-84 longitude, degrees (-180…180)           |
+| `share_in_advert` | boolean | `true`  | no       | Broadcast the coordinates in mesh self-adverts |
 
-Both keys must be set together; setting only one has no effect.
-Remove both (or omit the section) to stop broadcasting GPS coordinates.
+Both `latitude`/`longitude` must be set together; setting only one has no
+effect. Remove both (or omit the section) to stop pushing GPS coordinates
+to the radio entirely.
 
-The setup wizard prompts for these during initial configuration and
-writes them here. They can also be edited live from the web admin's
-**Settings** page without restarting the server.
+`share_in_advert` mirrors the official MeshCore app's **"Share Position in
+Advert"** checkbox: with `latitude`/`longitude` set but `share_in_advert =
+false`, the BBS still knows its own coordinates (e.g. for the web UI) but
+does not publish them — the node won't appear on public MeshCore maps.
+Set it to `true` (the default) to actually broadcast the position, which is
+what makes the node show up on the map. On MeshCore this flips the
+device's `advert_loc_policy` byte (`CMD_SET_OTHER_PARAMS`); on Meshtastic
+it gates whether a fixed position is pushed to the device at all, since
+Meshtastic broadcasts any configured fixed position automatically via its
+own Position app port.
+
+The setup wizard prompts for `latitude`/`longitude` during initial
+configuration and writes them here. All three keys can also be edited live
+from the web admin's **Settings** page without restarting the server.
 
 ```toml
 [location]
-latitude  = 37.7749
-longitude = -122.4194
+latitude        = 37.7749
+longitude       = -122.4194
+share_in_advert = true
 ```
 
 ## `[database]` - persistence
@@ -555,8 +568,9 @@ radio only reboots when something actually changed.
 On connect the BBS also:
 
 - **syncs the device clock** to system time,
-- **sets a fixed GPS position** from the `[location]` config (or clears it when no
-  location is configured), and
+- **sets a fixed GPS position** from the `[location]` config when coordinates are
+  set and `share_in_advert` is `true` (clears it otherwise — see
+  [`[location]`](#location---gps-coordinates)), and
 - sets the device's `node_info_broadcast_secs` to **3600 s (1 h, the firmware
   minimum)** so the node re-announces itself to the mesh hourly. This is the
   firmware-native way neighbouring nodes discover the BBS; you can also force an

--- a/docs/PLUGIN_API.md
+++ b/docs/PLUGIN_API.md
@@ -220,6 +220,18 @@ pub trait Host: Send + Sync {
     /// returned by the next call to `node_location()`.
     fn set_node_location(&self, location: Option<(f64, f64)>);
 
+    /// Whether the configured location (if any) should be broadcast in
+    /// mesh self-adverts — mirrors the MeshCore app's "Share Position
+    /// in Advert" checkbox. Defaults to `true`. Independent of
+    /// `node_location()`: an operator may want the BBS to know its own
+    /// coordinates without publishing them mesh-wide.
+    fn share_location_in_advert(&self) -> bool { true }
+
+    /// Update the in-memory advert-sharing preference without a
+    /// restart. Same admin-only caller convention as
+    /// `set_node_location`.
+    fn set_share_location_in_advert(&self, share: bool) {}
+
     // ── Audit ───────────────────────────────────────────────────
 
     /// Append-only audit log. Plugins should call this for any
@@ -307,6 +319,31 @@ Calling on each reconnect (rather than caching at `init`) is
 intentional: a sysop can update the coordinates via the web UI while
 the service is running, and the change takes effect the next time
 the transport reconnects.
+
+`SetAdvertLatlon` only stores raw coordinates on the device — it does
+**not** by itself make the node appear on public MeshCore maps. Whether
+those coordinates are actually included in outgoing self-adverts is a
+separate device-side policy bit (`advert_loc_policy`, set via
+`CMD_SET_OTHER_PARAMS`), gated by `host.share_location_in_advert()`. Read
+both together:
+
+```rust
+if let Some((lat, lon)) = host.node_location() {
+    // ... push SetAdvertLatlon as above ...
+}
+let desired_policy = if host.node_location().is_some() && host.share_location_in_advert() {
+    ADVERT_LOC_SHARE
+} else {
+    ADVERT_LOC_NONE
+};
+// ... push CMD_SET_OTHER_PARAMS with advert_loc_policy = desired_policy,
+// preserving the device's other CMD_SET_OTHER_PARAMS fields ...
+```
+
+A transport without an equivalent device-side policy bit (e.g.
+Meshtastic, which broadcasts any configured fixed position
+automatically) should instead gate the position write itself on
+`share_location_in_advert()`.
 
 ### What transport plugins must NOT do
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -192,11 +192,16 @@ fn default_require_verify() -> bool {
 
 /// GPS coordinates for this BBS node.
 ///
-/// When set, the mesh transport sends `SetAdvertLatlon` to the radio on
-/// connect so the node's location is broadcast in LoRa adverts.
-/// Both fields must be present for the location to be applied; a partial
-/// entry (only lat or only lon) is silently ignored.
-#[derive(Debug, Clone, Default, Deserialize, Serialize)]
+/// When set, the mesh transport pushes the coordinates to the radio on
+/// connect (`SetAdvertLatlon`) and, when [`share_in_advert`](Self::share_in_advert)
+/// is also `true`, flips the device's advert-location policy bit so the
+/// coordinates actually ride along in outgoing self-adverts — the same
+/// thing the official MeshCore app's "Share Position in Advert" checkbox
+/// controls. The Meshtastic transport mirrors this with its own native
+/// fixed-position mechanism. Both fields must be present for the location
+/// to be applied; a partial entry (only lat or only lon) is silently
+/// ignored.
+#[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct LocationConfig {
     /// Latitude in decimal degrees (e.g. `37.7749`).
@@ -206,6 +211,25 @@ pub struct LocationConfig {
     /// Longitude in decimal degrees (e.g. `-122.4194`).
     #[serde(default)]
     pub longitude: Option<f64>,
+
+    /// Broadcast the coordinates in mesh self-adverts. Defaults to `true`.
+    ///
+    /// Set to `false` to have the BBS know its own coordinates (e.g. for
+    /// display) without publishing them mesh-wide — mirrors the MeshCore
+    /// app's "Share Position in Advert" checkbox. Has no effect unless
+    /// `latitude`/`longitude` are also set.
+    #[serde(default = "default_share_in_advert")]
+    pub share_in_advert: bool,
+}
+
+impl Default for LocationConfig {
+    fn default() -> Self {
+        Self {
+            latitude: None,
+            longitude: None,
+            share_in_advert: default_share_in_advert(),
+        }
+    }
 }
 
 impl LocationConfig {
@@ -216,6 +240,10 @@ impl LocationConfig {
             _ => None,
         }
     }
+}
+
+fn default_share_in_advert() -> bool {
+    true
 }
 
 // ── [database] ────────────────────────────────────────────────────────────────

--- a/src/main.rs
+++ b/src/main.rs
@@ -365,6 +365,36 @@ enum ConfigAction {
         /// Room name, or `off` to disable.
         value: String,
     },
+
+    /// Set or clear this node's GPS coordinates.
+    ///
+    /// Writes `latitude`/`longitude` to the `[location]` section of the
+    /// config file. Radio transports push these coordinates on connect.
+    /// Whether they're actually broadcast in mesh self-adverts is a
+    /// separate setting — see `config share-position`.
+    /// Changes take effect on the next BBS restart. (The web admin's
+    /// Settings page can apply the same change live, without a restart.)
+    Location {
+        /// Latitude in decimal degrees (-90..90), or `off` to clear both
+        /// coordinates.
+        latitude: String,
+        /// Longitude in decimal degrees (-180..180). Required unless
+        /// `latitude` is `off`.
+        longitude: Option<String>,
+    },
+
+    /// Enable or disable broadcasting GPS coordinates in mesh self-adverts.
+    ///
+    /// Mirrors the official MeshCore app's "Share Position in Advert"
+    /// checkbox. Writes `share_in_advert` to the `[location]` section.
+    /// Has no effect until coordinates are also set via `config location`.
+    /// Changes take effect on the next BBS restart. (The web admin's
+    /// Settings page can apply the same change live, without a restart.)
+    SharePosition {
+        /// `on` to broadcast coordinates (default), `off` to keep the BBS
+        /// aware of its own location without publishing it.
+        enabled: String,
+    },
 }
 
 #[derive(Subcommand)]
@@ -915,6 +945,7 @@ async fn cmd_run(cli: &Cli) {
     let bbs = BbsHost::with_config(
         db,
         cfg.location.as_coords(),
+        cfg.location.share_in_advert,
         access_policy,
         host_config_path,
     );
@@ -1448,6 +1479,50 @@ fn cmd_config(config_path: Option<&std::path::Path>, action: ConfigAction) {
                 );
             }
         }
+        ConfigAction::Location {
+            latitude,
+            longitude,
+        } => {
+            if latitude.eq_ignore_ascii_case("off") {
+                config_remove_location_key(config_path, "latitude");
+                config_remove_location_key(config_path, "longitude");
+                println!("GPS coordinates cleared. Restart the BBS for the change to take effect.");
+            } else {
+                let Some(longitude) = longitude else {
+                    eprintln!("error: longitude is required unless latitude is 'off'");
+                    std::process::exit(1);
+                };
+                let lat: f64 = match latitude.parse() {
+                    Ok(v) if (-90.0..=90.0).contains(&v) => v,
+                    _ => {
+                        eprintln!("error: latitude must be a number between -90 and 90");
+                        std::process::exit(1);
+                    }
+                };
+                let lon: f64 = match longitude.parse() {
+                    Ok(v) if (-180.0..=180.0).contains(&v) => v,
+                    _ => {
+                        eprintln!("error: longitude must be a number between -180 and 180");
+                        std::process::exit(1);
+                    }
+                };
+                config_edit_location_float(config_path, "latitude", lat);
+                config_edit_location_float(config_path, "longitude", lon);
+                println!("location = {lat}, {lon}. Restart the BBS for the change to take effect.");
+            }
+        }
+        ConfigAction::SharePosition { enabled } => {
+            let value = match enabled.to_ascii_lowercase().as_str() {
+                "on" | "true" | "1" => true,
+                "off" | "false" | "0" => false,
+                other => {
+                    eprintln!("error: expected on|off, got '{other}'");
+                    std::process::exit(1);
+                }
+            };
+            config_edit_location_bool(config_path, "share_in_advert", value);
+            println!("share_in_advert = {value}. Restart the BBS for the change to take effect.");
+        }
     }
 }
 
@@ -1554,6 +1629,41 @@ fn config_remove_bbs_key(config_path: Option<&std::path::Path>, key: &str) {
     let (path, mut doc) = open_config_for_edit(config_path);
     if let Some(bbs) = doc.get_mut("bbs").and_then(|t| t.as_table_mut()) {
         bbs.remove(key);
+    }
+    if let Err(e) = atomic_write_file(&path, doc.to_string().as_bytes()) {
+        eprintln!("error writing {}: {e}", path.display());
+        std::process::exit(1);
+    }
+}
+
+fn config_edit_location_float(config_path: Option<&std::path::Path>, key: &str, value: f64) {
+    let (path, mut doc) = open_config_for_edit(config_path);
+    if doc.get("location").is_none() {
+        doc["location"] = toml_edit::Item::Table(toml_edit::Table::new());
+    }
+    doc["location"][key] = toml_edit::value(value);
+    if let Err(e) = atomic_write_file(&path, doc.to_string().as_bytes()) {
+        eprintln!("error writing {}: {e}", path.display());
+        std::process::exit(1);
+    }
+}
+
+fn config_edit_location_bool(config_path: Option<&std::path::Path>, key: &str, value: bool) {
+    let (path, mut doc) = open_config_for_edit(config_path);
+    if doc.get("location").is_none() {
+        doc["location"] = toml_edit::Item::Table(toml_edit::Table::new());
+    }
+    doc["location"][key] = toml_edit::value(value);
+    if let Err(e) = atomic_write_file(&path, doc.to_string().as_bytes()) {
+        eprintln!("error writing {}: {e}", path.display());
+        std::process::exit(1);
+    }
+}
+
+fn config_remove_location_key(config_path: Option<&std::path::Path>, key: &str) {
+    let (path, mut doc) = open_config_for_edit(config_path);
+    if let Some(location) = doc.get_mut("location").and_then(|t| t.as_table_mut()) {
+        location.remove(key);
     }
     if let Err(e) = atomic_write_file(&path, doc.to_string().as_bytes()) {
         eprintln!("error writing {}: {e}", path.display());

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -78,6 +78,7 @@ struct Existing {
     // GPS
     latitude: Option<f64>,
     longitude: Option<f64>,
+    share_in_advert: bool,
     // Process plugins — preserved verbatim through reconfigure
     process_plugins_toml: Option<String>,
 }
@@ -239,6 +240,10 @@ fn load_existing(out_path: &Path) -> Existing {
     let longitude = location
         .and_then(|l| l.get("longitude"))
         .and_then(|v| v.as_float());
+    let share_in_advert = location
+        .and_then(|l| l.get("share_in_advert"))
+        .and_then(|v| v.as_bool())
+        .unwrap_or(true);
 
     // pymc-companion (HAT)
     let yaml_path = companion_yaml_path(out_path);
@@ -327,6 +332,7 @@ fn load_existing(out_path: &Path) -> Existing {
         mesh_radio,
         latitude,
         longitude,
+        share_in_advert,
         process_plugins_toml,
     }
 }
@@ -1102,6 +1108,16 @@ pub fn run_wizard(config_out: Option<&Path>) {
         (None, None)
     };
 
+    let gps_share = if set_gps {
+        Confirm::with_theme(&theme)
+            .with_prompt("Share Position in Advert? (broadcast these coordinates to the mesh)")
+            .default(ex.share_in_advert)
+            .interact()
+            .unwrap_or_else(|_| cancelled())
+    } else {
+        true
+    };
+
     // ── MeshCore Pi HAT: region + model ──────────────────────────────────────
     //
     // When pymc-companion.yaml already exists (reconfigure run) ask before
@@ -1181,6 +1197,7 @@ pub fn run_wizard(config_out: Option<&Path>) {
         web_backup_dir: web_backup_dir.as_deref(),
         latitude: gps_lat,
         longitude: gps_lon,
+        share_in_advert: gps_share,
         process_plugins_toml: ex.process_plugins_toml.as_deref(),
         mesh_radio: mesh_radio.as_ref(),
     });
@@ -1849,6 +1866,7 @@ struct TomlParams<'a> {
     // GPS
     latitude: Option<f64>,
     longitude: Option<f64>,
+    share_in_advert: bool,
     // Process plugins — preserved verbatim from the previous config
     process_plugins_toml: Option<&'a str>,
     // USB serial radio config (None = omit section)
@@ -1882,6 +1900,11 @@ fn build_toml(p: &TomlParams<'_>) -> String {
         writeln!(s, "\n[location]").unwrap();
         writeln!(s, "latitude  = {lat}").unwrap();
         writeln!(s, "longitude = {lon}").unwrap();
+        // share_in_advert defaults to true in code — only write it when the
+        // operator opted out, to keep a default config file minimal.
+        if !p.share_in_advert {
+            writeln!(s, "share_in_advert = false").unwrap();
+        }
     }
 
     // [plugins.mesh]


### PR DESCRIPTION
## Summary

MeshCore only includes lat/lon in outgoing self-adverts when the device's `advert_loc_policy` byte is set via `CMD_SET_OTHER_PARAMS`. The BBS was pushing raw coordinates (`SetAdvertLatlon`) but never touching that policy bit, so a node with GPS configured never actually appeared on public MeshCore maps.

- Adds a `[location].share_in_advert` config toggle (default `true`, matching prior documented behavior) that mirrors the official MeshCore app's own **"Share Position in Advert"** checkbox.
- `bbs-mesh`: syncs the device's `advert_loc_policy` on connect and on every periodic advert, carefully preserving the device's own `manual_add_contacts`/`telemetry_modes`/`multi_acks` fields it doesn't manage (`CMD_SET_OTHER_PARAMS` sets all four at once).
- `bbs-meshtastic`: gates whether a fixed position is pushed to the device at all, since Meshtastic has no separate device-side "share" bit and broadcasts any configured position automatically via its own Position app port.
- `Host` trait gains `share_location_in_advert()` / `set_share_location_in_advert()`, mirroring `node_location()`/`set_node_location()`, so the web admin can flip it live without a restart.
- Exposed everywhere GPS is already configurable: the web admin Settings page (new checkbox), the CLI (`config location <lat> <lon>|off`, `config share-position on|off`), and the setup wizard prompt.

## Verification

- `cargo fmt --all --check`, `cargo test --workspace` (all green), `cargo clippy --workspace -- -D warnings`, `cargo doc --workspace --no-deps --all-features` all pass.
- 3 new regression tests in `crates/bbs-mesh/tests/transport.rs` asserting the exact `CMD_SET_OTHER_PARAMS` wire bytes sent to the radio, including that the device's other three fields are preserved and that nothing is sent when the desired policy already matches.
- Ran a hostile multi-agent code audit against this diff; the highest-risk claim (the `CMD_SET_OTHER_PARAMS` byte-order mapping) was verified directly against upstream MeshCore firmware source (`github.com/meshcore-dev/MeshCore`) as Tier-1 evidence, not just internal self-consistency.

## Test plan

- [x] Full workspace build/test/clippy/doc gate green
- [x] New wire-format regression tests pass
- [ ] Manual smoke test against a real MeshCore radio recommended before release (toggle "Share Position in Advert" off/on in the web UI, confirm the node's map presence follows)

🤖 Generated with [Claude Code](https://claude.com/claude-code)