### PR TITLE
fix(release): correct cargo-release config so `cargo release` actually works

### DIFF
--- a/release.toml
+++ b/release.toml
@@ -11,6 +11,22 @@
 #   3. Commits with "chore(release): v{{version}}".
 #   4. Creates an annotated git tag "v{{version}}".
 #   5. Pushes the commit + tag — GitHub Actions release.yml then fires.
+#
+# Compatibility notes (verified against cargo-release 1.1.5, the latest on
+# crates.io as of this writing — https://crates.io/crates/cargo-release):
+#   - `post-release-commit-message` is NOT parseable by any released version;
+#     it only exists in cargo-release's unreleased docs (github.com/crate-ci/
+#     cargo-release, `master` branch docs are ahead of the last crates.io
+#     release). Setting this key — even to "" — makes cargo-release abort
+#     with "Failed to parse `release.toml`" before doing anything. We don't
+#     want a post-release dev-version bump anyway, so it's simply omitted.
+#   - `pre-release-hook` is ONE command's argv (`[program, arg, arg, ...]`),
+#     NOT a list of separate shell command lines — cargo-release does not
+#     shell-parse each string. A flat list of two full command strings (as
+#     this file used to have) gets read as a single argv whose "program" is
+#     the entire first string including its spaces, which then fails to
+#     launch ("No such file or directory"). Route through `sh -c` instead so
+#     the two steps run as one real shell command.
 
 # ── Version tag & commit ────────────────────────────────────────────
 tag         = true
@@ -22,13 +38,11 @@ push-remote = "origin"
 
 # ── Commit message ──────────────────────────────────────────────────
 pre-release-commit-message  = "chore(release): v{{version}}"
-# No post-release dev bump — we don't use alpha/dev suffixes.
-post-release-commit-message = ""
 
 # ── CHANGELOG via git-cliff ─────────────────────────────────────────
 pre-release-hook = [
-  "git cliff --tag v{{version}} --output CHANGELOG.md",
-  "git add CHANGELOG.md",
+  "sh", "-c",
+  "git cliff --tag v{{version}} --output CHANGELOG.md && git add CHANGELOG.md",
 ]
 
 # ── Don't publish to crates.io ──────────────────────────────────────


### PR DESCRIPTION
## Summary

`release.toml` had two bugs that made every published version of `cargo-release` (1.1.5, the latest on crates.io) abort with `Failed to parse \`release.toml\`` before doing anything at all. Confirmed via empirical bisection (a prior session's `HANDOFF.md` scratch notes recorded working around this by hand — cutting releases manually since at least v0.10.0 — without ever finding the actual root cause).

**Bug 1 — `post-release-commit-message`**: this key isn't parseable by any version of `cargo-release` actually published to crates.io. It only exists in the project's docs on GitHub's `master` branch, which is ahead of the last release (1.1.5, published 2026-08-11 — confirmed as `max_version`/`newest_version`/`max_stable_version` via the crates.io API). Including this key at all — even as `""` — aborts parsing immediately. This repo doesn't want a post-release dev-version bump anyway (no alpha/dev suffixes), so it's simply dropped rather than guessing at a replacement.

**Bug 2 — `pre-release-hook`**: this field is one command's argv (`[program, arg, arg, ...]`), not a list of separate full shell command lines — `cargo-release` does not shell-parse each string in the array. The old form (`["git cliff --tag ... --output CHANGELOG.md", "git add CHANGELOG.md"]`) got read as a single argv whose "program" was the entire first string including its embedded spaces, which then failed to launch (`No such file or directory`). Fixed by routing both steps through `sh -c` so they run as one real shell command.

## Verification

Bisected empirically against the actual `cargo-release` binary (not guessed from docs) to isolate exactly which key broke parsing, confirmed `post-release-commit-message` is absent from cargo-release 1.1.5's own `Config` struct (via docs.rs source), and confirmed the `pre-release-hook` argv theory by reproducing the exact "No such file or directory" failure with a manually-split argv.

Ran a full `cargo release minor` dry-run against the fixed config: it now parses correctly, computes the correct `1.0.1 → 1.1.0` bump across every workspace member, and the `git cliff` changelog hook actually executes successfully. It correctly stops at the (expected, from local dry-run testing) uncommitted-changes safety check rather than proceeding — exactly the intended behavior.

No Rust code changed — `cargo fmt --all --check` confirmed clean (this only touches the release tooling config, not anything compiled).

🤖 Generated with [Claude Code](https://claude.com/claude-code)