### PR TITLE
fix(mesh): enforce MeshCore advert name/location byte budget in setup, CLI, web UI

### DIFF
--- a/crates/bbs-core/src/mesh_name.rs
+++ b/crates/bbs-core/src/mesh_name.rs
@@ -3,25 +3,57 @@
 //! The MeshCore firmware caps an advertisement's `app_data` at
 //! `MAX_ADVERT_DATA_SIZE` = **32 bytes** (firmware `MeshCore.h`). The advert
 //! `app_data` is laid out as `flags(1) + [lat(4) lon(4) if location] + name`,
-//! so with no shared location the node name may be at most **31 bytes**.
+//! so the node name may be at most **31 bytes** with no shared location, or
+//! **23 bytes** (`31 − 8`) when the advert also carries a shared GPS position.
 //!
-//! This limit is not advisory: a name that pushes `app_data` past 32 bytes is
-//! signed by the originator over its full length, but **every receiver clamps
-//! `app_data` to 32 bytes before verifying the signature** (firmware
-//! `Mesh.cpp` `onRecvPacket`). The clamped bytes no longer match the
-//! signature, so the advert is rejected as forged and silently dropped — the
-//! node never appears on the mesh, even though it transmits fine.
+//! This limit is not advisory: **every receiver clamps `app_data` to 32
+//! bytes before verifying the signature** (firmware `Mesh.cpp`
+//! `onRecvPacket`) — confirmed against upstream firmware source. Whether an
+//! over-budget name actually reaches that clamp depends on the *sender*:
+//! reference MeshCore firmware's own advert builder
+//! (`AdvertDataBuilder::encodeTo`) truncates the name locally before signing,
+//! so a compliant sender never produces an oversized packet in the first
+//! place — the name is silently *shortened*, not rejected. supply-drop-bbs
+//! is itself always the sender here, though, and not every companion bridge
+//! it talks to replicates that self-truncation: the `pymc_core`/
+//! `pymc-companion` bridge used for Pi HAT setups does not, so it happily
+//! signs an over-budget `app_data` in full — and *every* receiver then
+//! clamps those signed bytes before verifying, so the signature no longer
+//! matches and the advert is rejected as forged and silently dropped, with
+//! no error anywhere in the sending stack. This is exactly what happened in
+//! supply-drop-bbs#225: a name that fit without location silently stopped
+//! advertising the moment location-sharing was turned on. Validating here,
+//! before a name (or the location-sharing state it interacts with) is ever
+//! set, means supply-drop-bbs never depends on a downstream bridge or
+//! firmware to save it from that failure mode.
 //!
 //! `bbs.name` doubles as the MeshCore node name, so it is validated against
-//! this limit wherever it is set (setup wizard, web UI), and truncated
+//! the appropriate limit wherever it — or the location-sharing setting it
+//! interacts with — is set (setup wizard, CLI, web UI), and truncated
 //! defensively on the advert output path.
 
 /// Maximum node-name length in **bytes** (UTF-8) that fits in a MeshCore
 /// advert with no shared location: `MAX_ADVERT_DATA_SIZE (32) − flags (1)`.
-///
-/// If an advert ever carries a shared GPS location (`+8` bytes), the usable
-/// budget drops to 23. The BBS does not currently share location in adverts.
 pub const MAX_MESH_NODE_NAME_BYTES: usize = 31;
+
+/// Bytes an advert's packed lat/lon costs (`lat: i32` + `lon: i32`).
+const LOCATION_ADVERT_BYTES: usize = 8;
+
+/// Maximum node-name length in bytes when the advert also shares a GPS
+/// location: [`MAX_MESH_NODE_NAME_BYTES`] minus the 8 bytes lat/lon costs.
+pub const MAX_MESH_NODE_NAME_BYTES_WITH_LOCATION: usize =
+    MAX_MESH_NODE_NAME_BYTES - LOCATION_ADVERT_BYTES;
+
+/// The name-length budget for a node that does (`true`) or doesn't (`false`)
+/// share its GPS location in mesh self-adverts.
+#[must_use]
+pub const fn max_mesh_node_name_bytes(sharing_location: bool) -> usize {
+    if sharing_location {
+        MAX_MESH_NODE_NAME_BYTES_WITH_LOCATION
+    } else {
+        MAX_MESH_NODE_NAME_BYTES
+    }
+}
 
 /// Why a candidate node name was rejected.
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
@@ -30,13 +62,18 @@ pub enum InvalidNodeName {
     #[error("node name must not be empty")]
     Empty,
 
-    /// Longer than [`MAX_MESH_NODE_NAME_BYTES`] bytes.
-    #[error("node name is {actual} bytes; maximum is {max} (MeshCore advert limit)")]
+    /// Longer than the applicable limit — see [`max_mesh_node_name_bytes`].
+    #[error(
+        "node name is {actual} bytes; maximum is {max} ({}MeshCore advert limit)",
+        if *sharing_location { "with GPS location shared, " } else { "" }
+    )]
     TooLong {
         /// Actual byte length (UTF-8).
         actual: usize,
-        /// The maximum allowed.
+        /// The maximum allowed for `sharing_location`.
         max: usize,
+        /// Whether the limit was tightened for a shared GPS location.
+        sharing_location: bool,
     },
 
     /// Contains a control character (newline, tab, NUL, etc.).
@@ -46,17 +83,22 @@ pub enum InvalidNodeName {
 
 /// Validate a candidate MeshCore node name (also used as the BBS display name).
 ///
-/// Rejects empty names, names longer than [`MAX_MESH_NODE_NAME_BYTES`] **bytes**
-/// (not chars — a flag emoji is 8 bytes), and names containing control
-/// characters.
-pub fn validate_mesh_node_name(s: &str) -> Result<(), InvalidNodeName> {
+/// Rejects empty names, names longer than [`max_mesh_node_name_bytes`]
+/// **bytes** for the given `sharing_location` (not chars — a flag emoji is 8
+/// bytes), and names containing control characters. Pass `sharing_location =
+/// true` whenever the node currently has (or will have) a GPS location
+/// configured *and* `[location].share_in_advert` enabled — that combination
+/// is what actually ships lat/lon in the advert and tightens the budget.
+pub fn validate_mesh_node_name(s: &str, sharing_location: bool) -> Result<(), InvalidNodeName> {
     if s.is_empty() {
         return Err(InvalidNodeName::Empty);
     }
-    if s.len() > MAX_MESH_NODE_NAME_BYTES {
+    let max = max_mesh_node_name_bytes(sharing_location);
+    if s.len() > max {
         return Err(InvalidNodeName::TooLong {
             actual: s.len(),
-            max: MAX_MESH_NODE_NAME_BYTES,
+            max,
+            sharing_location,
         });
     }
     if let Some(c) = s.chars().find(|c| c.is_control()) {
@@ -65,19 +107,21 @@ pub fn validate_mesh_node_name(s: &str) -> Result<(), InvalidNodeName> {
     Ok(())
 }
 
-/// Truncate `s` to at most [`MAX_MESH_NODE_NAME_BYTES`] bytes **without
-/// splitting a UTF-8 character** — a multi-byte emoji at the boundary is
-/// dropped whole rather than cut mid-codepoint.
+/// Truncate `s` to at most [`max_mesh_node_name_bytes`] bytes for the given
+/// `sharing_location` **without splitting a UTF-8 character** — a multi-byte
+/// emoji at the boundary is dropped whole rather than cut mid-codepoint.
 ///
 /// This is the defensive last line of defence on the advert output path: input
 /// is validated up front, but a hand-edited config could still carry an
-/// over-length name, and an over-length advert is silently un-deliverable.
+/// over-length name — or a valid name could be paired with location-sharing
+/// turned on afterward — and an over-length advert is silently un-deliverable.
 #[must_use]
-pub fn truncate_mesh_node_name(s: &str) -> &str {
-    if s.len() <= MAX_MESH_NODE_NAME_BYTES {
+pub fn truncate_mesh_node_name(s: &str, sharing_location: bool) -> &str {
+    let max = max_mesh_node_name_bytes(sharing_location);
+    if s.len() <= max {
         return s;
     }
-    let mut end = MAX_MESH_NODE_NAME_BYTES;
+    let mut end = max;
     while end > 0 && !s.is_char_boundary(end) {
         end -= 1;
     }
@@ -92,7 +136,7 @@ mod tests {
     fn accepts_normal_names() {
         for name in ["Supply Drop BBS", "Mesh America BBS", "🇺🇸 Mesh America BBS"] {
             assert!(
-                validate_mesh_node_name(name).is_ok(),
+                validate_mesh_node_name(name, false).is_ok(),
                 "expected {name:?} ({} bytes) to validate",
                 name.len()
             );
@@ -101,7 +145,10 @@ mod tests {
 
     #[test]
     fn rejects_empty() {
-        assert_eq!(validate_mesh_node_name(""), Err(InvalidNodeName::Empty));
+        assert_eq!(
+            validate_mesh_node_name("", false),
+            Err(InvalidNodeName::Empty)
+        );
     }
 
     #[test]
@@ -110,10 +157,11 @@ mod tests {
         let name = "🇺🇸 Mesh America BBS 🇺🇸";
         assert_eq!(name.len(), 34);
         assert_eq!(
-            validate_mesh_node_name(name),
+            validate_mesh_node_name(name, false),
             Err(InvalidNodeName::TooLong {
                 actual: 34,
-                max: 31
+                max: 31,
+                sharing_location: false,
             })
         );
     }
@@ -121,7 +169,7 @@ mod tests {
     #[test]
     fn rejects_control_character() {
         assert_eq!(
-            validate_mesh_node_name("Mesh\nBBS"),
+            validate_mesh_node_name("Mesh\nBBS", false),
             Err(InvalidNodeName::ControlCharacter('\n'))
         );
     }
@@ -129,13 +177,47 @@ mod tests {
     #[test]
     fn boundary_exactly_31_bytes_ok() {
         let name = "a".repeat(31);
-        assert!(validate_mesh_node_name(&name).is_ok());
+        assert!(validate_mesh_node_name(&name, false).is_ok());
         let too_long = "a".repeat(32);
         assert!(matches!(
-            validate_mesh_node_name(&too_long),
+            validate_mesh_node_name(&too_long, false),
             Err(InvalidNodeName::TooLong {
                 actual: 32,
-                max: 31
+                max: 31,
+                sharing_location: false,
+            })
+        ));
+    }
+
+    #[test]
+    fn sharing_location_tightens_budget_to_23_bytes() {
+        // This is the exact case that broke supply-drop-bbs#225: a 25-byte
+        // name (an 8-byte flag emoji + 17 bytes of text) fits comfortably
+        // under the 31-byte no-location limit, but pushes app_data to 34
+        // bytes — past the firmware's 32-byte MAX_ADVERT_DATA_SIZE — the
+        // moment location-sharing is turned on, so every receiver silently
+        // drops the advert as forged.
+        let name = "🇺🇸 Mesh America BBS"; // 25 bytes
+        assert_eq!(name.len(), 25);
+        assert!(validate_mesh_node_name(name, false).is_ok());
+        assert_eq!(
+            validate_mesh_node_name(name, true),
+            Err(InvalidNodeName::TooLong {
+                actual: 25,
+                max: 23,
+                sharing_location: true,
+            })
+        );
+
+        let short_name = "a".repeat(23);
+        assert!(validate_mesh_node_name(&short_name, true).is_ok());
+        let one_too_long = "a".repeat(24);
+        assert!(matches!(
+            validate_mesh_node_name(&one_too_long, true),
+            Err(InvalidNodeName::TooLong {
+                actual: 24,
+                max: 23,
+                sharing_location: true,
             })
         ));
     }
@@ -143,7 +225,7 @@ mod tests {
     #[test]
     fn truncate_leaves_short_names_unchanged() {
         assert_eq!(
-            truncate_mesh_node_name("Mesh America BBS"),
+            truncate_mesh_node_name("Mesh America BBS", false),
             "Mesh America BBS"
         );
     }
@@ -158,7 +240,7 @@ mod tests {
         // lone regional indicator) but the advert is deliverable, which is the
         // whole point of the defensive trim.
         let name = "🇺🇸 Mesh America BBS 🇺🇸";
-        let out = truncate_mesh_node_name(name);
+        let out = truncate_mesh_node_name(name, false);
         assert!(
             out.len() <= MAX_MESH_NODE_NAME_BYTES,
             "got {} bytes",
@@ -166,5 +248,57 @@ mod tests {
         );
         assert!(name.starts_with(out));
         assert_ne!(out, name, "an over-length name must actually be truncated");
+    }
+
+    #[test]
+    fn truncate_with_location_uses_the_tighter_budget() {
+        // Same 25-byte name that validates fine without location — truncating
+        // it *with* location sharing must shrink it further, to ≤ 23 bytes.
+        // Byte 23 of this particular string already sits on a char boundary
+        // (the flag emoji occupies bytes 0-7, the rest is plain ASCII), so
+        // this alone would pass even with a naive, non-boundary-safe `&s[..n]`
+        // slice — see `truncate_with_location_backs_off_a_mid_codepoint_cutoff`
+        // below for a fixture that actually forces the boundary backoff loop.
+        let name = "🇺🇸 Mesh America BBS";
+        assert_eq!(name.len(), 25);
+        let out = truncate_mesh_node_name(name, true);
+        assert!(
+            out.len() <= MAX_MESH_NODE_NAME_BYTES_WITH_LOCATION,
+            "got {} bytes",
+            out.len()
+        );
+        assert!(name.starts_with(out));
+    }
+
+    #[test]
+    fn truncate_with_location_backs_off_a_mid_codepoint_cutoff() {
+        // Built so the 23-byte with-location cutoff lands INSIDE a trailing
+        // 4-byte codepoint, forcing is_char_boundary's backoff loop to
+        // actually execute: 🇺🇸 (8 bytes, boundary at 8) + 14 ASCII bytes
+        // (boundary at 22) + 🌎 (4 bytes: 22,23,24,25 — byte 23 is the
+        // *second* byte of that sequence, not a boundary).
+        let name = format!("🇺🇸{}🌎", "A".repeat(14));
+        assert_eq!(name.len(), 8 + 14 + 4, "fixture must be 26 bytes");
+        assert!(
+            !name.is_char_boundary(MAX_MESH_NODE_NAME_BYTES_WITH_LOCATION),
+            "fixture must land the 23-byte cutoff mid-codepoint, or this test \
+             doesn't prove anything a naive &s[..23] slice wouldn't also pass"
+        );
+
+        let out = truncate_mesh_node_name(&name, true);
+
+        assert!(
+            out.len() < MAX_MESH_NODE_NAME_BYTES_WITH_LOCATION,
+            "must back off strictly below the 23-byte cutoff since 23 itself \
+             is mid-codepoint here — got {} bytes",
+            out.len()
+        );
+        assert_eq!(
+            out, "🇺🇸AAAAAAAAAAAAAA",
+            "must back off to the last full codepoint (22 bytes: the flag \
+             plus all 14 'A's), dropping the trailing 🌎 whole rather than \
+             emitting a truncated/invalid byte sequence for it"
+        );
+        assert!(name.starts_with(out));
     }
 }

--- a/crates/bbs-mesh/src/transport.rs
+++ b/crates/bbs-mesh/src/transport.rs
@@ -304,17 +304,22 @@ async fn sync_advert_location_policy(
 }
 
 /// Push the configured node name + location to the radio and broadcast a
-/// self-advert. Used by the on-connect advert, the periodic advert tick, and the
-/// web-UI "send advert" trigger. Refreshing the name/location first means the
-/// advert always carries the configured identity, even on a device that returned
-/// no SelfInfo on AppStart (issue #101). Adverts are typically flooded so they
-/// propagate mesh-wide and let repeaters (re)learn a route back to the BBS.
+/// self-advert. Used by the periodic advert tick and the web-UI "send advert"
+/// trigger — NOT the on-connect advert, which has its own hand-written
+/// sequence inline in the `SelfInfo` branch below (different ordering, plus
+/// the advert-bus registration and `SetPathHashMode` this function doesn't
+/// send; keep both in sync when changing name/location handling in either).
+/// Refreshing the name/location first means the advert always carries the
+/// configured identity, even on a device that returned no SelfInfo on
+/// AppStart (issue #101). Adverts are typically flooded so they propagate
+/// mesh-wide and let repeaters (re)learn a route back to the BBS.
 async fn broadcast_self_advert(
     cmd_tx: &mpsc::Sender<OutboundFrame>,
     host: &Arc<dyn Host>,
     state: &Arc<Mutex<SessionState>>,
     flood: bool,
 ) {
+    let sharing_location = host.node_location().is_some() && host.share_location_in_advert();
     if let Some((lat, lon)) = host.node_location() {
         let lat_1e6 = (lat * 1_000_000.0) as i32;
         let lon_1e6 = (lon * 1_000_000.0) as i32;
@@ -324,9 +329,17 @@ async fn broadcast_self_advert(
     }
     sync_advert_location_policy(cmd_tx, host, state).await;
     if let Some(node_name) = host.mesh_node_name() {
-        if !node_name.is_empty() {
+        // The cached name was truncated to the no-location budget when it was
+        // stored (share_in_advert can flip live, without a restart); re-check
+        // it here against the *current* sharing state — sharing a location
+        // tightens the safe byte budget from 31 to 23 (bbs_core::mesh_name),
+        // and an over-length name silently fails to advertise once it's on.
+        let name = bbs_core::mesh_name::truncate_mesh_node_name(&node_name, sharing_location);
+        if !name.is_empty() {
             let _ = cmd_tx
-                .send(OutboundFrame::SetAdvertName { name: node_name })
+                .send(OutboundFrame::SetAdvertName {
+                    name: name.to_owned(),
+                })
                 .await;
         }
     }
@@ -1038,10 +1051,29 @@ async fn event_loop(
 
                             // Push the configured node name to the radio so the BBS
                             // advertises with a human name instead of its key-derived
-                            // fallback (issue #101).  The host has already truncated it
-                            // to a MeshCore-safe length; the frame encoder also caps at
-                            // 31 bytes as a final guard.
+                            // fallback (issue #101). Re-truncated below to the
+                            // *current* sharing state — the cached copy was only
+                            // truncated to the no-location budget when it was
+                            // stored. The frame encoder (meshcore-companion's
+                            // OutboundFrame::SetAdvertName) also caps raw bytes at
+                            // 31 as a fallback, but that cap is NOT UTF-8-boundary
+                            // aware (a plain byte slice) — it's not a substitute for
+                            // truncate_mesh_node_name here, only a backstop against
+                            // a future caller that skips this step.
                             if let Some(node_name) = host.mesh_node_name() {
+                                // Sharing a location tightens the safe name
+                                // budget from 31 to 23 bytes (see
+                                // bbs_core::mesh_name) — re-check against the
+                                // *current* sharing state, since the cached
+                                // name was only truncated to the no-location
+                                // budget when it was stored.
+                                let sharing_location = host.node_location().is_some()
+                                    && host.share_location_in_advert();
+                                let node_name = bbs_core::mesh_name::truncate_mesh_node_name(
+                                    &node_name,
+                                    sharing_location,
+                                )
+                                .to_owned();
                                 if !node_name.is_empty() {
                                     info!(node_name = %node_name, "mesh: setting advert name");
                                     let _ = cmd_tx

--- a/crates/bbs-mesh/tests/transport.rs
+++ b/crates/bbs-mesh/tests/transport.rs
@@ -573,6 +573,101 @@ async fn advert_location_unshared_when_disabled_and_device_currently_sharing() {
     transport.stop().await.unwrap();
 }
 
+/// `OutboundFrame::SetAdvertName`'s payload is `CMD_SET_ADVERT_NAME` + name
+/// bytes + a trailing NUL terminator (matching firmware's C-string
+/// convention) — strip that terminator to get the actual name bytes sent.
+fn advert_name_payload(set_name_cmd: &[u8]) -> &str {
+    let raw = &set_name_cmd[1..];
+    let raw = raw.strip_suffix(&[0]).unwrap_or(raw);
+    std::str::from_utf8(raw).expect("advert name must be valid UTF-8")
+}
+
+/// A configured node name that fits the no-location 31-byte budget but
+/// exceeds the tighter 23-byte with-location budget must be truncated before
+/// `SetAdvertName` is sent, once GPS location-sharing is active — otherwise
+/// every receiver silently drops the advert as forged (MeshCore clamps
+/// app_data to 32 bytes before verifying the signature; see
+/// bbs_core::mesh_name and supply-drop-bbs#225, the bug this guards against).
+#[tokio::test]
+async fn advert_name_truncated_to_with_location_budget_when_sharing() {
+    let host = Arc::new(MockHost::new());
+    host.set_location(Some((37.7749, -122.4194)), true);
+    // Built so the 23-byte with-location cutoff lands INSIDE a trailing
+    // 4-byte codepoint — 🇺🇸 (8 bytes) + 14 ASCII bytes (boundary at 22) + 🌎
+    // (4 bytes: 22,23,24,25 — byte 23 is mid-sequence, not a boundary) — 26
+    // bytes total, over the 23-byte with-location budget. A fixture where
+    // the cutoff already sits on a boundary (e.g. plain "🇺🇸 Mesh America
+    // BBS") would pass this same assertion even with a naive, non-UTF-8-safe
+    // `&s[..23]` slice, so it wouldn't actually prove boundary-safe
+    // truncation happened on the real send path — this one does.
+    let long_name = format!("🇺🇸{}🌎", "A".repeat(14));
+    assert_eq!(long_name.len(), 26);
+    assert!(
+        !long_name.is_char_boundary(23),
+        "fixture must land the 23-byte cutoff mid-codepoint"
+    );
+    host.set_node_name(Some(long_name.clone()));
+    let (transport, mut bridge) = make_transport(Arc::clone(&host), None).await;
+
+    let app_start = bridge.recv_n(11).await;
+    assert_eq!(app_start[3], CMD_APP_START);
+    bridge
+        .send(&self_info_frame_with_policy("Node", ADVERT_LOC_SHARE))
+        .await;
+
+    let set_name = tokio::time::timeout(
+        Duration::from_secs(2),
+        bridge.read_until_cmd(CMD_SET_ADVERT_NAME),
+    )
+    .await
+    .expect("expected CMD_SET_ADVERT_NAME on connect");
+    let sent_name = advert_name_payload(&set_name);
+    assert_eq!(
+        sent_name, "🇺🇸AAAAAAAAAAAAAA",
+        "must back off to the last full codepoint (22 bytes), dropping the \
+         trailing 🌎 whole rather than emitting a truncated/invalid byte \
+         sequence for it"
+    );
+    assert!(
+        long_name.starts_with(sent_name),
+        "truncation must be a prefix of the configured name, not garbage"
+    );
+
+    transport.stop().await.unwrap();
+}
+
+/// The same over-length name must pass through *unmodified* when location
+/// sharing is off — the tighter 23-byte budget only applies once an advert
+/// actually carries lat/lon.
+#[tokio::test]
+async fn advert_name_not_truncated_below_31_bytes_when_not_sharing() {
+    let host = Arc::new(MockHost::new());
+    // No location configured at all: sharing has nothing to share regardless
+    // of the share_in_advert flag's own value.
+    let long_name = "🇺🇸 Mesh America BBS"; // 25 bytes — over 23, under 31.
+    assert_eq!(long_name.len(), 25);
+    host.set_node_name(Some(long_name.to_string()));
+    let (transport, mut bridge) = make_transport(Arc::clone(&host), None).await;
+
+    let app_start = bridge.recv_n(11).await;
+    assert_eq!(app_start[3], CMD_APP_START);
+    bridge.send(&self_info_frame("Node")).await;
+
+    let set_name = tokio::time::timeout(
+        Duration::from_secs(2),
+        bridge.read_until_cmd(CMD_SET_ADVERT_NAME),
+    )
+    .await
+    .expect("expected CMD_SET_ADVERT_NAME on connect");
+    let sent_name = advert_name_payload(&set_name);
+    assert_eq!(
+        sent_name, long_name,
+        "a 25-byte name must pass through unmodified with no location shared"
+    );
+
+    transport.stop().await.unwrap();
+}
+
 /// No location configured (the default `MockHost`) must never emit
 /// `CMD_SET_OTHER_PARAMS` — the desired policy (`ADVERT_LOC_NONE`) already
 /// matches what a freshly-flashed/default device reports, so there is

--- a/crates/bbs-plugin-api/src/testing.rs
+++ b/crates/bbs-plugin-api/src/testing.rs
@@ -103,6 +103,10 @@ struct MockHostState {
     /// [`MockHost::set_location`] or [`MockHost::set_share_location_in_advert`].
     /// `true` by default, matching the trait's own default.
     share_location_in_advert: bool,
+    /// Value returned by `mesh_node_name()`. Set via
+    /// [`MockHost::set_node_name`]. `None` by default, matching the trait's
+    /// own default.
+    node_name: Option<String>,
 }
 
 #[derive(Debug, Clone)]
@@ -148,6 +152,7 @@ impl MockHost {
                 mesh_key_tx: None,
                 location: None,
                 share_location_in_advert: true,
+                node_name: None,
             }),
             events: tx,
             advert_bus: Arc::new(AdvertBus::new()),
@@ -219,6 +224,19 @@ impl MockHost {
             .lock()
             .expect("mock poisoned")
             .share_location_in_advert = share;
+    }
+
+    /// Configure the value `mesh_node_name()` returns — the name the mesh
+    /// transport pushes to the radio via `SetAdvertName` on connect.
+    ///
+    /// Unlike the real `Host` trait's documented contract ("already
+    /// truncated to a MeshCore-safe length"), this echoes `name` back
+    /// verbatim, untruncated — deliberately, so a test can inject an
+    /// over-length name to exercise the transport's own defensive
+    /// re-truncation at the actual advert-send call sites, rather than
+    /// having the mock silently pre-truncate and mask a regression there.
+    pub fn set_node_name(&self, name: Option<String>) {
+        self.state.lock().expect("mock poisoned").node_name = name;
     }
 
     /// Inspect the commands that have been dispatched, in order.
@@ -384,6 +402,10 @@ impl Host for MockHost {
         // resolution, so this calls MockHost::set_share_location_in_advert
         // (above), not itself — no recursion.
         self.set_share_location_in_advert(share);
+    }
+
+    fn mesh_node_name(&self) -> Option<String> {
+        self.state.lock().expect("mock poisoned").node_name.clone()
     }
 
     /// Stores the sender, unlike the trait's default no-op body — so a test

--- a/crates/bbs-web/src/lib.rs
+++ b/crates/bbs-web/src/lib.rs
@@ -2436,6 +2436,66 @@ fn doc_remove_key(doc: &mut toml_edit::DocumentMut, section: &str, key: &str) {
     }
 }
 
+/// The effective `[bbs].name` and GPS-location-sharing state a [`ConfigPatch`]
+/// would produce once applied to `doc`, for validating the combination
+/// against [`bbs_core::mesh_name`]'s byte budget *before* writing anything.
+///
+/// Each of `bbs_name`, `location_share_in_advert`, `location_latitude` and
+/// `location_longitude` falls back independently to whatever `doc` already
+/// has on disk when the patch doesn't touch it — so a patch that only
+/// flips `share_in_advert`, or only changes the name, still gets validated
+/// against the *resulting* combined state, not just the field it touches.
+///
+/// Uses `.get()` chains, not `doc["section"]["key"]` bracket indexing —
+/// `toml_edit::DocumentMut`'s `Index` impl *panics* on a missing key
+/// (`.expect("index not found")`), and an empty/partial config.toml missing
+/// `[bbs]` or `[location]` entirely is a first-class supported shape
+/// (`config::load()`'s own doc comment: "an empty config file ... is valid").
+/// A request as simple as an empty-body `PATCH {}` against such a file would
+/// panic the handler outright — and under the `release-min` build profile
+/// (`panic = "abort"`, used for shipped release-tag builds), that takes down
+/// the whole process for every connected user, not just the one request.
+fn effective_advert_name_sharing(
+    patch: &ConfigPatch,
+    doc: &toml_edit::DocumentMut,
+) -> (String, bool) {
+    let doc_location = doc.get("location");
+    let effective_name = patch
+        .bbs_name
+        .clone()
+        .or_else(|| {
+            doc.get("bbs")
+                .and_then(|t| t.get("name"))
+                .and_then(|v| v.as_str())
+                .map(str::to_owned)
+        })
+        // Matches config::default_bbs_name() — must be a real fallback name,
+        // not "", which validate_mesh_node_name rejects as Empty and would
+        // permanently block every future PATCH (even an unrelated one) on a
+        // config missing [bbs].name.
+        .unwrap_or_else(|| "Supply Drop BBS".to_owned());
+    let effective_sharing = patch.location_share_in_advert.unwrap_or_else(|| {
+        doc_location
+            .and_then(|t| t.get("share_in_advert"))
+            .and_then(|v| v.as_bool())
+            .unwrap_or(true)
+    });
+    let effective_lat = match patch.location_latitude {
+        Some(v) => v,
+        None => doc_location
+            .and_then(|t| t.get("latitude"))
+            .and_then(|v| v.as_float()),
+    };
+    let effective_lon = match patch.location_longitude {
+        Some(v) => v,
+        None => doc_location
+            .and_then(|t| t.get("longitude"))
+            .and_then(|v| v.as_float()),
+    };
+    let sharing_location = effective_sharing && effective_lat.is_some() && effective_lon.is_some();
+    (effective_name, sharing_location)
+}
+
 /// Read a bool from `[plugins.<plugin>].<key>`.
 fn toml_plugin_bool(val: &toml::Value, plugin: &str, key: &str) -> Option<bool> {
     val.get("plugins")?.get(plugin)?.get(key)?.as_bool()
@@ -2572,12 +2632,16 @@ async fn api_patch_config(
     }
 
     // Validate bbs.name before mutating anything. It doubles as the MeshCore
-    // advert node name, which the firmware caps at 31 bytes — an over-length
-    // name silently fails to advertise on the mesh (see bbs_core::mesh_name).
-    if let Some(ref name) = patch.bbs_name {
-        if let Err(e) = bbs_core::mesh_name::validate_mesh_node_name(name) {
-            return (StatusCode::BAD_REQUEST, Json(json_error(&e.to_string()))).into_response();
-        }
+    // advert node name, which the firmware caps at 31 bytes — 23 if the
+    // advert also shares a GPS location (see bbs_core::mesh_name). Check the
+    // *effective* name and location-sharing state this patch would produce —
+    // whichever of the two this request doesn't touch falls back to what's
+    // already on disk — so changing either the name or the sharing toggle
+    // alone still catches a combination that would silently stop advertising.
+    let (effective_name, sharing_location) = effective_advert_name_sharing(&patch, &doc);
+    if let Err(e) = bbs_core::mesh_name::validate_mesh_node_name(&effective_name, sharing_location)
+    {
+        return (StatusCode::BAD_REQUEST, Json(json_error(&e.to_string()))).into_response();
     }
 
     // Apply patches — only touch keys explicitly present in the request.
@@ -4529,6 +4593,122 @@ mod tests {
                 .expect("numeric values must parse");
         assert_eq!(set.location_latitude, Some(Some(45.5)));
         assert_eq!(set.location_longitude, Some(Some(-122.6)));
+    }
+
+    // supply-drop-bbs#225: a name that fits without location can silently
+    // stop advertising the instant location-sharing turns on, with no error
+    // anywhere in the sending stack. These tests cover the four ways a PATCH
+    // request can produce that combination — changing the name alone,
+    // changing the sharing toggle alone, changing the coordinates alone, and
+    // touching nothing (so it's purely what's already on disk) — since each
+    // must be caught from whichever field the request actually touches, by
+    // falling back to what's already on disk for the rest.
+    mod effective_advert_name_sharing_tests {
+        use super::*;
+
+        fn empty_patch() -> ConfigPatch {
+            serde_json::from_str("{}").expect("an empty body must parse")
+        }
+
+        fn doc_with(toml: &str) -> toml_edit::DocumentMut {
+            toml.parse().expect("test fixture TOML must parse")
+        }
+
+        #[test]
+        fn falls_back_entirely_to_disk_when_patch_touches_nothing() {
+            let doc = doc_with(
+                "[bbs]\nname = \"Mesh America BBS\"\n\
+                 [location]\nlatitude = 1.0\nlongitude = 2.0\nshare_in_advert = true\n",
+            );
+            let (name, sharing) = effective_advert_name_sharing(&empty_patch(), &doc);
+            assert_eq!(name, "Mesh America BBS");
+            assert!(sharing);
+        }
+
+        // An empty (or [bbs]/[location]-less) config.toml is a first-class
+        // supported shape — config::load()'s own doc comment says so — not a
+        // corrupted-file edge case. doc["bbs"]["name"] bracket indexing
+        // panics on a missing key; a `.get()` chain doesn't. This must not
+        // regress back to the panicking form, since a request as ordinary as
+        // `PATCH {}` or a single-field patch would reach this exact path.
+        #[test]
+        fn missing_bbs_and_location_sections_does_not_panic() {
+            let doc = doc_with("logging_level = \"INFO\"\n");
+            let (name, sharing) = effective_advert_name_sharing(&empty_patch(), &doc);
+            // Matches config::default_bbs_name() — never "", which
+            // validate_mesh_node_name rejects as Empty.
+            assert_eq!(name, "Supply Drop BBS");
+            assert!(!sharing);
+        }
+
+        #[test]
+        fn unrelated_field_patch_against_missing_sections_does_not_panic() {
+            // The exact shape of a real caller: a patch that only touches an
+            // unrelated field (logging_level), against a config that has
+            // never had [bbs]/[location] written to it.
+            let doc = doc_with("logging_level = \"INFO\"\n");
+            let patch: ConfigPatch = serde_json::from_str(r#"{"logging_level":"DEBUG"}"#).unwrap();
+            let (name, sharing) = effective_advert_name_sharing(&patch, &doc);
+            assert_eq!(name, "Supply Drop BBS");
+            assert!(!sharing);
+            // And the fallback name must itself be a name validate_mesh_node_name
+            // accepts, or every such patch would be permanently rejected.
+            assert!(bbs_core::mesh_name::validate_mesh_node_name(&name, sharing).is_ok());
+        }
+
+        #[test]
+        fn patched_name_alone_is_checked_against_disk_sharing_state() {
+            // The request only changes the name; share_in_advert=true and a
+            // location are already on disk, so the *new* name must be
+            // checked against the tighter 23-byte with-location budget, even
+            // though this request never touches location at all.
+            let doc = doc_with(
+                "[bbs]\nname = \"short\"\n\
+                 [location]\nlatitude = 1.0\nlongitude = 2.0\nshare_in_advert = true\n",
+            );
+            let patch: ConfigPatch =
+                serde_json::from_str(r#"{"bbs_name":"🇺🇸 Mesh America BBS"}"#).unwrap();
+            let (name, sharing) = effective_advert_name_sharing(&patch, &doc);
+            assert_eq!(name, "🇺🇸 Mesh America BBS");
+            assert!(sharing);
+            assert!(bbs_core::mesh_name::validate_mesh_node_name(&name, sharing).is_err());
+        }
+
+        #[test]
+        fn patched_sharing_toggle_alone_is_checked_against_disk_name() {
+            // The request only flips share_in_advert on; the name and
+            // coordinates are already on disk. This is the exact scenario
+            // `supply-drop-bbs config share-position on` and the web UI
+            // checkbox both need to catch.
+            let doc = doc_with(
+                "[bbs]\nname = \"🇺🇸 Mesh America BBS\"\n\
+                 [location]\nlatitude = 1.0\nlongitude = 2.0\nshare_in_advert = false\n",
+            );
+            let patch: ConfigPatch =
+                serde_json::from_str(r#"{"location_share_in_advert":true}"#).unwrap();
+            let (name, sharing) = effective_advert_name_sharing(&patch, &doc);
+            assert_eq!(name, "🇺🇸 Mesh America BBS");
+            assert!(sharing);
+            assert!(bbs_core::mesh_name::validate_mesh_node_name(&name, sharing).is_err());
+        }
+
+        #[test]
+        fn clearing_location_relaxes_the_budget_even_if_sharing_stays_on() {
+            // share_in_advert=true on disk, but this request clears the
+            // coordinates — an advert can't carry lat/lon it doesn't have,
+            // so the name must fall back to the looser no-location budget.
+            let doc = doc_with(
+                "[bbs]\nname = \"🇺🇸 Mesh America BBS\"\n\
+                 [location]\nlatitude = 1.0\nlongitude = 2.0\nshare_in_advert = true\n",
+            );
+            let patch: ConfigPatch =
+                serde_json::from_str(r#"{"location_latitude":null,"location_longitude":null}"#)
+                    .unwrap();
+            let (name, sharing) = effective_advert_name_sharing(&patch, &doc);
+            assert_eq!(name, "🇺🇸 Mesh America BBS");
+            assert!(!sharing);
+            assert!(bbs_core::mesh_name::validate_mesh_node_name(&name, sharing).is_ok());
+        }
     }
 
     // Same bug, same fix, applied to all seven fields of PATCH

--- a/crates/bbs-web/web/src/pages/SettingsPage.vue
+++ b/crates/bbs-web/web/src/pages/SettingsPage.vue
@@ -66,6 +66,14 @@ const isDirty = computed(() => savedForm.value !== '' && JSON.stringify(form.val
 const isFormValid = computed<boolean>(() => {
   const f = form.value
   if (!f.bbs_name.trim()) return false
+  // Mirrors validate()'s byte-length check (see its comment for why) — kept
+  // in sync manually since this is a separate reactive computed, not a call
+  // into validate() itself (which has the side effect of populating
+  // validationErrors on every evaluation, which would show errors before
+  // the user has attempted to save).
+  const nameBytes = new TextEncoder().encode(f.bbs_name).length
+  const nameLimit = (f.location_enabled && f.location_share_in_advert) ? 23 : 31
+  if (nameBytes > nameLimit) return false
   if (!f.bbs_starting_room.trim()) return false
   if (!f.bbs_timezone.trim()) return false
   if (timezones.value.length && !timezones.value.includes(f.bbs_timezone)) return false
@@ -168,17 +176,27 @@ async function loadRooms() {
 function validate(): boolean {
   const errs: Record<string, string> = {}
 
+  // bbs.name doubles as the MeshCore advert node name, which the firmware
+  // caps at 31 bytes — 23 if the advert also shares a GPS location, since
+  // lat/lon costs 8 bytes of the same MAX_ADVERT_DATA_SIZE=32 budget (see
+  // bbs_core::mesh_name on the Rust side). An over-length name silently
+  // fails to advertise: every receiver clamps app_data before verifying the
+  // signature, so it looks forged and just gets dropped, with no error
+  // anywhere in the sending path.
+  const sharingLocation = form.value.location_enabled && form.value.location_share_in_advert
+  const nameLimit = sharingLocation ? 23 : 31
   if (!form.value.bbs_name.trim()) {
     errs.bbs_name = 'Name is required.'
   } else {
-    // bbs.name doubles as the MeshCore advert node name, capped at 31 bytes by
-    // the firmware (an over-length name silently fails to advertise). Count
-    // UTF-8 bytes, not characters — a flag emoji is 8 bytes.
+    // Count UTF-8 bytes, not characters — a flag emoji is 8 bytes.
     const bytes = new TextEncoder().encode(form.value.bbs_name).length
-    if (bytes > 31)
-      errs.bbs_name = `Name is ${bytes} bytes; maximum is 31 (MeshCore advert limit; emoji count as several bytes each).`
-    else if ([...form.value.bbs_name].some((ch) => { const c = ch.codePointAt(0) ?? 0; return c < 0x20 || (c >= 0x7f && c <= 0x9f) }))
+    if (bytes > nameLimit) {
+      errs.bbs_name = sharingLocation
+        ? `Name is ${bytes} bytes; maximum is 23 while sharing GPS location in adverts (31 otherwise — lat/lon costs 8 bytes of the same MeshCore advert-data limit).`
+        : `Name is ${bytes} bytes; maximum is 31 (MeshCore advert limit; emoji count as several bytes each).`
+    } else if ([...form.value.bbs_name].some((ch) => { const c = ch.codePointAt(0) ?? 0; return c < 0x20 || (c >= 0x7f && c <= 0x9f) })) {
       errs.bbs_name = 'Name must not contain control characters.'
+    }
   }
 
   if (!form.value.bbs_starting_room.trim())
@@ -1019,7 +1037,9 @@ chmod g+w {{ configFile }}</pre>
           <label>Name</label>
           <input v-model="form.bbs_name" type="text" />
           <p v-if="validationErrors.bbs_name" class="field-error">{{ validationErrors.bbs_name }}</p>
-          <p v-else class="hint">Display name shown to users on connect.</p>
+          <p v-else class="hint">Display name shown to users on connect. Also the MeshCore advert
+            name — max 31 bytes (23 if sharing GPS location below); emoji count as several bytes
+            each.</p>
         </div>
 
         <div class="field" :class="{ 'has-error': validationErrors.bbs_starting_room }">
@@ -1098,7 +1118,8 @@ chmod g+w {{ configFile }}</pre>
             Broadcast these coordinates to the mesh so your node appears on MeshCore maps.
             Uncheck to keep the BBS aware of its own location without publishing it —
             matches the same checkbox in the official MeshCore app. Has no effect while
-            "Set GPS coordinates" above is off.
+            "Set GPS coordinates" above is off. Tightens the BBS name's advert byte limit
+            from 31 to 23 (see the Name field above).
           </p>
         </div>
       </section>

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -217,6 +217,8 @@ Set or clear this node's GPS coordinates. Writes `latitude`/`longitude` to the `
 
 Setting coordinates alone does not make the node appear on public mesh maps — see `config share-position` below.
 
+If `share_in_advert` is already `on`, setting coordinates here is what actually starts putting lat/lon in the advert — this command checks `[bbs].name` against the tighter 23-byte with-location limit ([`[location]`](CONFIG.md#location---gps-coordinates)) and refuses to write an over-length combination.
+
 | Argument | Meaning |
 |----------|---------|
 | `<latitude> <longitude>` | WGS-84 decimal degrees, e.g. `37.7749 -122.4194` |
@@ -241,6 +243,8 @@ supply-drop-bbs config share-position <on|off> [OPTIONS]
 ```
 
 Enable or disable broadcasting the configured GPS coordinates in mesh self-adverts — mirrors the official MeshCore app's **"Share Position in Advert"** checkbox. Writes `share_in_advert` to the `[location]` section. Has no effect until coordinates are also set via `config location`. **Takes effect on the next BBS restart.**
+
+Turning this `on` while a location is already configured checks `[bbs].name` against the tighter 23-byte with-location limit ([`[location]`](CONFIG.md#location---gps-coordinates)) and refuses to write the change if the current name is too long — shorten it first.
 
 | Argument | Meaning |
 |----------|---------|

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -107,7 +107,7 @@ which plugin sections are valid.
 
 | Key              | Type   | Default                  | Required | Description                                      |
 |------------------|--------|--------------------------|----------|--------------------------------------------------|
-| `name`           | string | `"Supply Drop BBS"`      | no       | Display name shown to users on connect           |
+| `name`           | string | `"Supply Drop BBS"`      | no       | Display name shown to users on connect; also the MeshCore advert node name — max 31 UTF-8 bytes (23 if sharing GPS location, see [`[location]`](#location---gps-coordinates)) |
 | `data_dir`       | path   | `/var/lib/supply-drop-bbs` (root) or `~/.local/share/supply-drop-bbs` (user) | no | Where the BBS stores its data |
 | `starting_room`  | string | `"Lobby"`                | no       | Room a newly logged-in user lands in             |
 | `welcome_msg`    | string | `"Welcome to {name}."`   | no       | Banner shown on connect; supports `{name}` substitution |
@@ -162,8 +162,12 @@ supply-drop-bbs config guest-room off
 ## `[location]` - GPS coordinates
 
 When set, the mesh transport sends your node's coordinates to the radio
-immediately after each connection is established. **Takes effect on the
-next mesh transport reconnect — no server restart needed.**
+immediately after each connection is established. **Editing this section
+through the web admin's Settings page takes effect on the next mesh
+transport reconnect — no server restart needed** (see below). Editing
+`config.toml` directly — by hand, or via `config location`/`config
+share-position` on the CLI — requires restarting the BBS for the running
+process to pick up the change; the CLI itself prints this after every write.
 
 | Key               | Type    | Default | Required | Description                                    |
 |-------------------|---------|---------|----------|-------------------------------------------------|
@@ -185,6 +189,18 @@ device's `advert_loc_policy` byte (`CMD_SET_OTHER_PARAMS`); on Meshtastic
 it gates whether a fixed position is pushed to the device at all, since
 Meshtastic broadcasts any configured fixed position automatically via its
 own Position app port.
+
+**Interaction with `[bbs].name`:** MeshCore firmware caps an advert's data at
+32 bytes total (`flags` + `name`, plus `lat`/`lon` when shared). That leaves
+**31 bytes** for `[bbs].name` normally, or **23 bytes** once `share_in_advert`
+is `true` and a location is configured — count UTF-8 bytes, not characters,
+since an emoji can cost 4–8 bytes each. This isn't advisory: every receiver
+clamps advert data to 32 bytes *before* verifying its signature, so an
+over-length combination doesn't error — it just silently stops advertising,
+even though the BBS's own logs show a successful send. The setup wizard, CLI
+(`config location`, `config share-position`), and web admin Settings page all
+validate this combination and reject a change that would push the name over
+budget.
 
 The setup wizard prompts for `latitude`/`longitude` during initial
 configuration and writes them here. All three keys can also be edited live

--- a/src/main.rs
+++ b/src/main.rs
@@ -377,9 +377,15 @@ enum ConfigAction {
     Location {
         /// Latitude in decimal degrees (-90..90), or `off` to clear both
         /// coordinates.
+        // Without this, clap parses a negative value (e.g. -122.4194) as an
+        // unrecognized flag, not a positional argument — breaking every
+        // longitude in the Americas and every Southern Hemisphere latitude,
+        // including this command's own documented example.
+        #[arg(allow_hyphen_values = true)]
         latitude: String,
         /// Longitude in decimal degrees (-180..180). Required unless
         /// `latitude` is `off`.
+        #[arg(allow_hyphen_values = true)]
         longitude: Option<String>,
     },
 
@@ -953,9 +959,16 @@ async fn cmd_run(cli: &Cli) {
     // bbs.name is the MeshCore advert node name. Store an advert-safe
     // (truncated) copy so the mesh transport can push it to the radio via
     // SetAdvertName on connect — without this the node advertises with its
-    // key-derived fallback name (issue #101).
+    // key-derived fallback name (issue #101). Truncate to the looser
+    // no-location budget here: `[location].share_in_advert` can be flipped
+    // live via the web UI without a restart, and this cached copy is not
+    // re-read from config afterward, so truncating to the tighter
+    // with-location budget now could permanently lose bytes of the
+    // configured name if sharing is later turned off. bbs-mesh::transport
+    // re-truncates to the correct, current-state-aware budget at the actual
+    // point each advert is sent (see bbs_core::mesh_name).
     bbs.set_node_name(Some(
-        bbs_core::mesh_name::truncate_mesh_node_name(&cfg.bbs.name).to_owned(),
+        bbs_core::mesh_name::truncate_mesh_node_name(&cfg.bbs.name, false).to_owned(),
     ));
 
     if let Err(e) = bbs.ensure_guest_room().await {
@@ -1484,8 +1497,14 @@ fn cmd_config(config_path: Option<&std::path::Path>, action: ConfigAction) {
             longitude,
         } => {
             if latitude.eq_ignore_ascii_case("off") {
-                config_remove_location_key(config_path, "latitude");
-                config_remove_location_key(config_path, "longitude");
+                if longitude.is_some() {
+                    eprintln!(
+                        "error: unexpected extra argument after 'off' — did you mean \
+                         'config location <lat> <lon>'?"
+                    );
+                    std::process::exit(1);
+                }
+                config_remove_location_keys(config_path, &["latitude", "longitude"]);
                 println!("GPS coordinates cleared. Restart the BBS for the change to take effect.");
             } else {
                 let Some(longitude) = longitude else {
@@ -1506,8 +1525,25 @@ fn cmd_config(config_path: Option<&std::path::Path>, action: ConfigAction) {
                         std::process::exit(1);
                     }
                 };
-                config_edit_location_float(config_path, "latitude", lat);
-                config_edit_location_float(config_path, "longitude", lon);
+                // Sharing a location tightens the advert name budget from 31
+                // to 23 bytes (see bbs_core::mesh_name) — if sharing is
+                // already on, setting coordinates now is what actually
+                // starts putting lat/lon in the advert, so check the
+                // *current* name against that budget before writing.
+                if cfg.location.share_in_advert {
+                    if let Err(e) =
+                        bbs_core::mesh_name::validate_mesh_node_name(&cfg.bbs.name, true)
+                    {
+                        eprintln!(
+                            "error: {e}\nShorten [bbs].name first, or run \
+                             'supply-drop-bbs config share-position off' before setting a \
+                             location this long — an over-length name silently fails to \
+                             advertise once GPS sharing is on."
+                        );
+                        std::process::exit(1);
+                    }
+                }
+                config_edit_location_floats(config_path, &[("latitude", lat), ("longitude", lon)]);
                 println!("location = {lat}, {lon}. Restart the BBS for the change to take effect.");
             }
         }
@@ -1520,6 +1556,20 @@ fn cmd_config(config_path: Option<&std::path::Path>, action: ConfigAction) {
                     std::process::exit(1);
                 }
             };
+            // Turning sharing on tightens the advert name budget from 31 to
+            // 23 bytes (see bbs_core::mesh_name) — check the current name
+            // against that budget before writing, but only if a location is
+            // actually configured (an unconfigured location never puts
+            // lat/lon in the advert regardless of this flag).
+            if value && cfg.location.as_coords().is_some() {
+                if let Err(e) = bbs_core::mesh_name::validate_mesh_node_name(&cfg.bbs.name, true) {
+                    eprintln!(
+                        "error: {e}\nShorten [bbs].name first — an over-length name silently \
+                         fails to advertise once GPS location-sharing is on."
+                    );
+                    std::process::exit(1);
+                }
+            }
             config_edit_location_bool(config_path, "share_in_advert", value);
             println!("share_in_advert = {value}. Restart the BBS for the change to take effect.");
         }
@@ -1636,12 +1686,19 @@ fn config_remove_bbs_key(config_path: Option<&std::path::Path>, key: &str) {
     }
 }
 
-fn config_edit_location_float(config_path: Option<&std::path::Path>, key: &str, value: f64) {
+/// Set multiple `[location]` float keys in a single read-modify-write, so a
+/// crash or kill between writes can't leave one key set without the other —
+/// e.g. latitude persisted with no longitude, which `config location <lat>
+/// <lon>` would otherwise risk by writing each key through a separate
+/// `open_config_for_edit`/`atomic_write_file` round trip.
+fn config_edit_location_floats(config_path: Option<&std::path::Path>, pairs: &[(&str, f64)]) {
     let (path, mut doc) = open_config_for_edit(config_path);
     if doc.get("location").is_none() {
         doc["location"] = toml_edit::Item::Table(toml_edit::Table::new());
     }
-    doc["location"][key] = toml_edit::value(value);
+    for (key, value) in pairs {
+        doc["location"][*key] = toml_edit::value(*value);
+    }
     if let Err(e) = atomic_write_file(&path, doc.to_string().as_bytes()) {
         eprintln!("error writing {}: {e}", path.display());
         std::process::exit(1);
@@ -1660,10 +1717,14 @@ fn config_edit_location_bool(config_path: Option<&std::path::Path>, key: &str, v
     }
 }
 
-fn config_remove_location_key(config_path: Option<&std::path::Path>, key: &str) {
+/// Remove multiple `[location]` keys in a single read-modify-write — same
+/// atomicity rationale as [`config_edit_location_floats`].
+fn config_remove_location_keys(config_path: Option<&std::path::Path>, keys: &[&str]) {
     let (path, mut doc) = open_config_for_edit(config_path);
     if let Some(location) = doc.get_mut("location").and_then(|t| t.as_table_mut()) {
-        location.remove(key);
+        for key in keys {
+            location.remove(key);
+        }
     }
     if let Err(e) = atomic_write_file(&path, doc.to_string().as_bytes()) {
         eprintln!("error writing {}: {e}", path.display());

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -488,12 +488,14 @@ pub fn run_wizard(config_out: Option<&Path>) {
     // bbs.name is also the MeshCore advert node name, which the firmware caps
     // at 31 bytes (see bbs_core::mesh_name). Reject over-length / invalid names
     // here so an operator can't configure a node that silently fails to
-    // advertise on the mesh.
+    // advertise on the mesh. GPS location-sharing isn't decided yet at this
+    // point in the wizard, so this checks the looser no-location limit; the
+    // tighter 23-byte limit is re-checked below once `gps_share` is known.
     let bbs_name: String = Input::with_theme(&theme)
         .with_prompt("BBS name")
         .default(ex.bbs_name.clone())
         .validate_with(|input: &String| -> Result<(), String> {
-            bbs_core::mesh_name::validate_mesh_node_name(input).map_err(|e| e.to_string())
+            bbs_core::mesh_name::validate_mesh_node_name(input, false).map_err(|e| e.to_string())
         })
         .interact_text()
         .unwrap_or_else(|_| cancelled());
@@ -1116,6 +1118,33 @@ pub fn run_wizard(config_out: Option<&Path>) {
             .unwrap_or_else(|_| cancelled())
     } else {
         true
+    };
+
+    // Sharing location tightens the advert name budget from 31 to 23 bytes
+    // (see bbs_core::mesh_name) — re-check the name now that we know whether
+    // this node will actually broadcast its GPS position.
+    let sharing_location = set_gps && gps_share;
+    let bbs_name = if sharing_location
+        && bbs_core::mesh_name::validate_mesh_node_name(&bbs_name, true).is_err()
+    {
+        println!();
+        println!(
+            "\"{bbs_name}\" is {} bytes — sharing GPS location in adverts limits the \
+             node name to {} bytes (a MeshCore protocol limit; over-length names \
+             silently fail to advertise once location is included).",
+            bbs_name.len(),
+            bbs_core::mesh_name::MAX_MESH_NODE_NAME_BYTES_WITH_LOCATION
+        );
+        Input::with_theme(&theme)
+            .with_prompt("BBS name")
+            .default(bbs_core::mesh_name::truncate_mesh_node_name(&bbs_name, true).to_string())
+            .validate_with(|input: &String| -> Result<(), String> {
+                bbs_core::mesh_name::validate_mesh_node_name(input, true).map_err(|e| e.to_string())
+            })
+            .interact_text()
+            .unwrap_or_else(|_| cancelled())
+    } else {
+        bbs_name
     };
 
     // ── MeshCore Pi HAT: region + model ──────────────────────────────────────
@@ -1783,11 +1812,15 @@ fn build_companion_yaml(p: &HatParams) -> String {
     writeln!(s, "companion:").unwrap();
     // Truncate defensively: input is validated above, but a hand-edited
     // config.toml could carry an over-length bbs.name, and an over-length
-    // advert name is silently un-deliverable on the mesh.
+    // advert name is silently un-deliverable on the mesh. This generator
+    // doesn't know whether GPS location-sharing is on, so it truncates to
+    // the tighter with-location budget — safe either way, since the BBS's
+    // own SetAdvertName push at connect (bbs-mesh::transport) overrides this
+    // fallback default with the actually-validated name regardless.
     writeln!(
         s,
         "  node_name: {:?}",
-        bbs_core::mesh_name::truncate_mesh_node_name(&p.bbs_name)
+        bbs_core::mesh_name::truncate_mesh_node_name(&p.bbs_name, true)
     )
     .unwrap();
     writeln!(s, "  identity_path: {:?}", p.identity_path).unwrap();


### PR DESCRIPTION
## Summary

Adds byte-length validation for `[bbs].name` combined with GPS location-sharing, enforced consistently across the setup wizard, CLI (`config location`, `config share-position`), and web UI (`PATCH /api/config`). Root cause: MeshCore firmware caps an advert's `app_data` at 32 bytes (`MAX_ADVERT_DATA_SIZE`), leaving 31 bytes for the node name normally or 23 once GPS sharing also puts an 8-byte lat/lon in the same advert — and this isn't advisory, every receiver clamps to 32 bytes *before* verifying the signature, so an over-budget combination doesn't error anywhere in the sending stack, it just silently stops advertising. This is exactly what broke GPS-sharing on a real deployment (#225): a configured name with an 8-byte flag emoji, once combined with location-sharing, pushed `app_data` 2 bytes over budget.

`bbs_core::mesh_name` already validated the flat 31-byte case; its own doc comment flagged that the budget needed to shrink once location-sharing shipped, but it never did. This PR makes it location-aware end to end — see the commit message for the full breakdown.

## Hostile code-audit

Ran `anthropic-skills:code-audit` (4 parallel batches covering every touched file) before finalizing. It found and this PR fixes:

- **Critical**: the web UI's new combined-state validation used `doc["bbs"]["name"]` bracket indexing, which `toml_edit` panics on for a missing key — and an empty/partial `config.toml` is a documented-supported shape, not a corrupted-file edge case. Under the `release-min` build profile (`panic = "abort"`, used for shipped release-tag builds), an ordinary empty-body or single-field `PATCH /api/config` would have crashed the whole process for every connected user. Fixed, with tests covering the missing-sections case directly.
- **Critical, pre-existing**: `config location` couldn't accept a negative latitude/longitude at all (clap parsed `-122.4194` as a flag) — already shipped in v1.1.0, and it broke `docs/CLI.md`'s own example. One-line `allow_hyphen_values` fix.
- A test-coverage gap where the with-location truncation tests used a fixture whose 23-byte cutoff happened to already sit on a UTF-8 boundary, so they'd pass even with a non-boundary-safe naive slice (proven via an executed repro) — fixed with fixtures that force the boundary logic to actually fire.
- A non-atomic two-write pattern for `config location <lat> <lon>` that could orphan a lone latitude on a crash — batched into one write.
- Several misleading comments and a doc contradiction between CLI.md/CONFIG.md about restart behavior.
- A Vue form-validity check that could show Save as enabled for input the server would then reject.

Three findings were out of scope for this PR (pre-existing architecture, larger than this change) and filed as follow-ups:
- #226 — TOCTOU race between the advert-broadcast path and live web-UI location/sharing changes
- #227 — no file locking around `config.toml` read-modify-write
- #228 — `validate_mesh_node_name` doesn't block Unicode display-spoofing characters

## Test plan

- [x] `cargo fmt --all --check`
- [x] `cargo test --workspace` (all green, including 8 new/updated tests across `bbs-core`, `bbs-mesh`, `bbs-web`)
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo doc --workspace --no-deps --all-features`
- [x] Root-caused and empirically confirmed live on the reporter's production hardware (see #225)

🤖 Generated with [Claude Code](https://claude.com/claude-code)