### PR TITLE
chore(mesh): migrate pymc_core dependency to openhop_core

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ to:
   shipping today. MeshCore connects either directly over USB serial to a
   device running the MeshCore companion firmware (no Python, no bridge
   process), or over TCP to
-  [`pymc_core`](https://github.com/meshcore-dev/pymc_core)'s
+  [`openhop_core`](https://github.com/openhop-dev/openhop_core)'s
   CompanionFrameServer, which also covers Raspberry Pi HAT radios as a
   special case. A third transport lets an operator run any executable
   (Telnet, Slack, Discord, APRS, SMS, ...) as a BBS transport over a

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -49,7 +49,7 @@ In scope:
 
 Out of scope (report to the upstream project):
 
-- Vulnerabilities in `pymc_core`, `meshcore_py`, or the MeshCore
+- Vulnerabilities in `openhop_core`, `meshcore_py`, or the MeshCore
   firmware itself. Report those at the relevant upstream repos.
 - Vulnerabilities in third-party plugins or UIs that consume our
   plugin API. Report to that plugin's maintainers.

--- a/config.example.toml
+++ b/config.example.toml
@@ -172,10 +172,10 @@
 
 [plugins.mesh]
 # How to reach the radio.
-#   "tcp"    — connect to a pymc_core CompanionFrameServer over TCP (default)
+#   "tcp"    — connect to an openhop_core CompanionFrameServer over TCP (default)
 #   "hat"    — same as tcp; the setup wizard offers Pi HAT GPIO/SPI hints
 #   "serial" — connect directly to a USB companion device (Heltec V3,
-#              T-Beam, RAK4631, etc.) — no pymc_core required (ADR-0013)
+#              T-Beam, RAK4631, etc.) — no openhop_core required (ADR-0013)
 # connection_type = "tcp"
 
 # ── Serial mode (connection_type = "serial") ──────────────────────
@@ -184,7 +184,7 @@
 # baud_rate = 115200
 
 # ── TCP / HAT mode (connection_type = "tcp" or "hat") ─────────────
-# Address of the pymc_core CompanionFrameServer.
+# Address of the openhop_core CompanionFrameServer.
 # addr = "127.0.0.1:5000"
 
 # Reconnection backoff after the bridge disconnects.

--- a/contrib/pymc-companion/pymc-companion.py
+++ b/contrib/pymc-companion/pymc-companion.py
@@ -1,11 +1,11 @@
 #!/usr/bin/env python3
 """
-pymc-companion — minimal pymc_core companion frame server for supply-drop-bbs.
+pymc-companion — minimal openhop_core companion frame server for supply-drop-bbs.
 
-Drives a LoRa HAT directly via SPI using pymc_core and exposes the MeshCore
+Drives a LoRa HAT directly via SPI using openhop_core and exposes the MeshCore
 companion frame protocol on a TCP port so supply-drop-bbs can connect to it.
 
-This is the same approach as mesh-citadel's HatRuntime — pymc_core runs
+This is the same approach as mesh-citadel's HatRuntime — openhop_core runs
 in-process as a library, not as a separate daemon.
 
 Usage:
@@ -62,13 +62,13 @@ def load_or_create_identity(LocalIdentity, identity_path: str | None):
 
 async def run(config: dict) -> None:
     try:
-        from pymc_core import LocalIdentity
-        from pymc_core.companion import CompanionFrameServer, CompanionRadio
-        from pymc_core.hardware.sx1262_wrapper import SX1262Radio
+        from openhop_core import LocalIdentity
+        from openhop_core.companion import CompanionFrameServer, CompanionRadio
+        from openhop_core.hardware.sx1262_wrapper import SX1262Radio
     except ImportError as e:
         log.error(
-            f"pymc_core is not installed: {e}\n"
-            "Install with: pip install pymc_core"
+            f"openhop_core is not installed: {e}\n"
+            "Install with: pip install openhop-core"
         )
         sys.exit(1)
 
@@ -106,9 +106,15 @@ async def run(config: dict) -> None:
     }
     if "dio3_tcxo_voltage" in radio_cfg:
         radio_kwargs["dio3_tcxo_voltage"] = float(radio_cfg["dio3_tcxo_voltage"])
-    for _opt_int in ("gpio_chip", "cs_id", "en_pin", "tx_led", "rx_led"):
+    for _opt_int in ("gpio_chip", "cs_id", "en_pin"):
         if _opt_int in radio_cfg:
             radio_kwargs[_opt_int] = int(radio_cfg[_opt_int])
+    # YAML key names (tx_led/rx_led) predate and differ from SX1262Radio's
+    # real constructor parameter names (txled_pin/rxled_pin) — kept as-is on
+    # the config side for stability, translated here.
+    for _yaml_key, _kwarg_name in (("tx_led", "txled_pin"), ("rx_led", "rxled_pin")):
+        if _yaml_key in radio_cfg:
+            radio_kwargs[_kwarg_name] = int(radio_cfg[_yaml_key])
     if radio_cfg.get("use_gpiod_backend"):
         radio_kwargs["use_gpiod_backend"] = True
 
@@ -192,7 +198,7 @@ async def run(config: dict) -> None:
 
 def main() -> None:
     parser = argparse.ArgumentParser(
-        description="pymc_core companion frame server for supply-drop-bbs"
+        description="openhop_core companion frame server for supply-drop-bbs"
     )
     parser.add_argument("--config", required=True, help="Path to YAML config file")
     parser.add_argument("--log-level", default="INFO", help="Log level (default: INFO)")

--- a/crates/bbs-core/src/mesh_name.rs
+++ b/crates/bbs-core/src/mesh_name.rs
@@ -15,7 +15,7 @@
 //! so a compliant sender never produces an oversized packet in the first
 //! place — the name is silently *shortened*, not rejected. supply-drop-bbs
 //! is itself always the sender here, though, and not every companion bridge
-//! it talks to replicates that self-truncation: the `pymc_core`/
+//! it talks to replicates that self-truncation: the `openhop_core`/
 //! `pymc-companion` bridge used for Pi HAT setups does not, so it happily
 //! signs an over-budget `app_data` in full — and *every* receiver then
 //! clamps those signed bytes before verifying, so the signature no longer

--- a/crates/bbs-mesh/src/config.rs
+++ b/crates/bbs-mesh/src/config.rs
@@ -2,12 +2,12 @@
 //!
 //! Deserialized from the `[plugins.mesh]` section of the operator's
 //! TOML config file.  All fields have sensible defaults so an
-//! operator running `pymc_core` on the same machine with default
+//! operator running `openhop_core` on the same machine with default
 //! settings needs zero configuration.
 //!
 //! # Connection types
 //!
-//! | `connection_type` | Transport        | pymc_core needed? |
+//! | `connection_type` | Transport        | openhop_core needed? |
 //! |-------------------|------------------|-------------------|
 //! | `tcp`             | TCP socket       | yes (default)     |
 //! | `hat`             | TCP socket       | yes (Pi HAT)      |
@@ -16,7 +16,7 @@
 //! Both `tcp` and `hat` connect to a `CompanionFrameServer` over TCP.
 //! `hat` is operationally identical to `tcp` at the BBS level; the
 //! distinction is that the setup wizard offers Pi HAT GPIO / SPI setup
-//! only for `hat`.  `serial` bypasses `pymc_core` entirely and speaks
+//! only for `hat`.  `serial` bypasses `openhop_core` entirely and speaks
 //! the companion-frame protocol directly to the USB device.
 
 use std::{net::SocketAddr, time::Duration};
@@ -28,20 +28,20 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Clone, Copy, Default, Deserialize, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "lowercase")]
 pub enum ConnectionType {
-    /// Connect via TCP to a `pymc_core` `CompanionFrameServer`.
+    /// Connect via TCP to an `openhop_core` `CompanionFrameServer`.
     /// The default — works for standalone Pi + USB radio setups managed
-    /// by `pymc_core`, or for any networked bridge.
+    /// by `openhop_core`, or for any networked bridge.
     #[default]
     Tcp,
 
-    /// Connect via TCP to a `pymc_core` `CompanionFrameServer` that
+    /// Connect via TCP to an `openhop_core` `CompanionFrameServer` that
     /// manages a Pi HAT radio (GPIO / SPI).  Operationally identical to
     /// `tcp` at the BBS level; the setup wizard uses this to offer HAT-
     /// specific configuration (pin presets, UART setup, service install).
     Hat,
 
     /// Connect directly to a USB companion device (e.g. Heltec V3,
-    /// T-Beam) via a local serial port.  `pymc_core` is not required;
+    /// T-Beam) via a local serial port.  `openhop_core` is not required;
     /// the BBS speaks the companion-frame protocol directly.  See
     /// ADR-0013 for the rationale.
     Serial,
@@ -101,13 +101,13 @@ pub struct RadioConfig {
 ///
 /// # Minimal TOML examples
 ///
-/// TCP (pymc_core on the same host, default port):
+/// TCP (openhop_core on the same host, default port):
 /// ```toml
 /// [plugins.mesh]
 /// # Nothing required — defaults connect to 127.0.0.1:5000
 /// ```
 ///
-/// USB serial (no pymc_core):
+/// USB serial (no openhop_core):
 /// ```toml
 /// [plugins.mesh]
 /// connection_type = "serial"
@@ -129,7 +129,7 @@ pub struct MeshConfig {
     /// Address of the `CompanionFrameServer` TCP listener.
     ///
     /// Used when `connection_type` is `tcp` or `hat`.
-    /// Defaults to `127.0.0.1:5000`, which is the `pymc_core` default
+    /// Defaults to `127.0.0.1:5000`, which is the `openhop_core` default
     /// when both processes run on the same host.
     #[serde(default = "default_addr")]
     pub addr: SocketAddr,

--- a/crates/bbs-mesh/src/lib.rs
+++ b/crates/bbs-mesh/src/lib.rs
@@ -1,7 +1,7 @@
 //! # bbs-mesh
 //!
 //! The MeshCore transport plugin for Supply Drop BBS.  Connects to
-//! `pymc_core`'s `CompanionFrameServer` over TCP and translates between
+//! `openhop_core`'s `CompanionFrameServer` over TCP and translates between
 //! MeshCore direct messages and the BBS `Command` / `Response` types
 //! defined in `bbs_plugin_api`.
 //!
@@ -9,7 +9,7 @@
 //!
 //! ```text
 //! ┌──────────────────────────────────────────────────────────────┐
-//! │  pymc_core CompanionFrameServer  (radio bridge, TCP :5000)   │
+//! │  openhop_core CompanionFrameServer  (radio bridge, TCP :5000)│
 //! └──────────────────────┬───────────────────────────────────────┘
 //!                        │ companion-frame TCP protocol
 //! ┌──────────────────────▼───────────────────────────────────────┐

--- a/crates/bbs-mesh/src/transport.rs
+++ b/crates/bbs-mesh/src/transport.rs
@@ -358,7 +358,7 @@ async fn broadcast_self_advert(
 
 /// The MeshCore transport plugin.
 ///
-/// Connects Supply Drop BBS to a `pymc_core` radio bridge over the companion-
+/// Connects Supply Drop BBS to an `openhop_core` radio bridge over the companion-
 /// frame TCP protocol.  Implements both [`Plugin`] (lifecycle) and
 /// [`TransportEngine`] (inbound command processing + outbound notifications).
 ///

--- a/crates/bbs-mesh/tests/transport.rs
+++ b/crates/bbs-mesh/tests/transport.rs
@@ -2,7 +2,7 @@
 //!
 //! Uses [`MockHost`] from `bbs-plugin-api` and an in-process TCP loopback
 //! (ephemeral port on 127.0.0.1) to exercise the full
-//! `init → start → frame → response` path without a real `pymc_core` process.
+//! `init → start → frame → response` path without a real `openhop_core` process.
 //!
 //! # Bridge protocol reminder
 //!

--- a/crates/meshcore-companion/src/client.rs
+++ b/crates/meshcore-companion/src/client.rs
@@ -3,7 +3,7 @@
 //! Supports two transports:
 //!
 //! - **TCP** ([`CompanionClient::connect`]) — connects to a
-//!   `CompanionFrameServer`, typically `pymc_core`'s TCP bridge.  Used in
+//!   `CompanionFrameServer`, typically `openhop_core`'s TCP bridge.  Used in
 //!   HAT and standalone TCP deployments.
 //!
 //! - **Serial** ([`CompanionClient::connect_serial`]) — opens a local USB

--- a/crates/meshcore-companion/src/frame.rs
+++ b/crates/meshcore-companion/src/frame.rs
@@ -803,7 +803,7 @@ fn build_payload(frame: &OutboundFrame) -> Vec<u8> {
             // (field `frequency_khz`).  The `OutboundFrame` field is named
             // `frequency_hz` for human clarity; we divide by 1000 here.
             //
-            // This matches the pymc_core CompanionFrameServer comment:
+            // This matches the openhop_core CompanionFrameServer comment:
             //   "Frequency in kHz (match firmware self-info; client sends same encoding)"
             // and the validation range (100_000–2_500_000 kHz = 100 MHz–2.5 GHz).
             let freq_khz = frequency_hz / 1000;

--- a/crates/meshcore-companion/src/lib.rs
+++ b/crates/meshcore-companion/src/lib.rs
@@ -1,7 +1,7 @@
 //! # meshcore-companion
 //!
 //! A pure-Rust client for the MeshCore companion-frame TCP
-//! protocol, as spoken by `pymc_core`'s `CompanionFrameServer`
+//! protocol, as spoken by `openhop_core`'s `CompanionFrameServer`
 //! (and by USB / serial MeshCore companion devices, with a
 //! transport adapter).
 //!

--- a/crates/meshcore-companion/tests/client.rs
+++ b/crates/meshcore-companion/tests/client.rs
@@ -1,7 +1,7 @@
 //! Tests for the companion TCP client.
 //!
 //! All tests use an in-process TCP loopback (ephemeral port on 127.0.0.1) so
-//! no real `pymc_core` process or external network is needed.  The test
+//! no real `openhop_core` process or external network is needed.  The test
 //! controls the "server" side manually via [`TcpBridge`].
 //!
 //! AppStart is always 11 wire bytes:

--- a/crates/meshcore-companion/tests/codec.rs
+++ b/crates/meshcore-companion/tests/codec.rs
@@ -2,7 +2,9 @@
 //!
 //! Each test section corresponds to a decoded frame type or an encoding
 //! command. Wire bytes are constructed by hand from the documented layouts
-//! (confirmed against `pymc_core/frame_server.py`).
+//! (confirmed as of 2026-09-08 against openhop_core 1.1.3's
+//! `openhop_core/companion/frame_server/server.py`; formerly
+//! `pymc_core/frame_server.py` in the pre-rename layout).
 
 use meshcore_companion::{
     constants::*,

--- a/docs-site/.vitepress/config.ts
+++ b/docs-site/.vitepress/config.ts
@@ -95,7 +95,7 @@ export default defineConfig({
             link: '/adr/0006-no-migration-from-mesh-citadel',
           },
           {
-            text: 'ADR-0007: pymc_core Bridge',
+            text: 'ADR-0007: pymc_core (now openhop_core) Bridge',
             link: '/adr/0007-bridge-stays-pymc-core',
           },
           {

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -109,7 +109,7 @@ serial port via `meshcore-companion`. No bridge process. No Python.
 
 ```
                   ┌──────────────────────────────┐
-                  │    pymc_core                  │
+                  │    openhop_core               │
                   │    CompanionFrameServer       │
                   │    (Python - radio bridge)    │
                   │                               │
@@ -147,9 +147,11 @@ The two processes are independent. Stopping one doesn't break the
 other; the BBS reports mesh unavailability cleanly and continues
 serving CLI and web clients.
 
-`pymc_core` is **not part of this project's source tree**. We install
-and configure it as part of the setup wizard for HAT deployments.
-See [ADR-0007](adr/0007-bridge-stays-pymc-core.md) and
+`openhop_core` (formerly published as `pymc_core` — the upstream
+project was rebranded from pyMC Core to openHop) is **not part of
+this project's source tree**. We install and configure it as part of
+the setup wizard for HAT deployments. See
+[ADR-0007](adr/0007-bridge-stays-pymc-core.md) and
 [ADR-0013](adr/0013-native-serial-transport-for-usb-devices.md).
 
 ### 2.2 Crate layout
@@ -179,7 +181,7 @@ supply-drop-bbs/
 │   │                         compiled Vue frontend via rust-embed.
 │   └── meshcore-companion/ ← Pure-Rust client for the
 │                             companion-frame TCP protocol that
-│                             pymc_core's CompanionFrameServer
+│                             openhop_core's CompanionFrameServer
 │                             speaks. Standalone crate; could be
 │                             published to crates.io eventually.
 ├── docs/                   ← what you're reading
@@ -587,7 +589,7 @@ authenticate the same way the bundled Vue UI does.
 
 The companion-frame protocol between the BBS and the radio bridge
 is documented in [`PROTOCOL.md`](PROTOCOL.md). It is not OpenAPI;
-it's a binary framing format inherited from `pymc_core` /
+it's a binary framing format inherited from `openhop_core` /
 MeshCore upstream.
 
 The application layer on top of mesh - the BBS commands users send
@@ -849,7 +851,7 @@ when it becomes real.
 
 - **WASM plugins.** Runtime-loadable, sandboxed, language-agnostic.
   Real long-term answer for "anyone can write a plugin." Not v1.
-- **Native Rust radio bridge.** Replace `pymc_core`'s
+- **Native Rust radio bridge.** Replace `openhop_core`'s
   CompanionFrameServer with a Rust binary that talks to the SX1262
   directly. Eliminates the Python supply chain entirely.
 - **MFA on sysop login.** TOTP or hardware key.
@@ -875,7 +877,7 @@ Decisions with their own dedicated record:
 | 0004 | Cargo features for plugin selection             | Accepted |
 | 0005 | DB strategy: disk WAL with SD-card tuning       | Accepted |
 | 0006 | No migration from mesh-citadel                  | Accepted |
-| 0007 | Pin pymc_core CompanionFrameServer for v1       | Accepted |
+| 0007 | Pin pymc_core (now openhop_core) CompanionFrameServer for v1 | Accepted |
 | 0008 | TOML config with env var + CLI overrides        | Accepted |
 | 0009 | Tracing-based logging that respects config      | Accepted |
 | 0010 | OpenAPI generated from Rust via utoipa          | Accepted |

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -336,7 +336,7 @@ arrive.
 ### Serial mode (`connection_type = "serial"`)
 
 Used for USB-native MeshCore devices (Heltec V3, T-Beam, etc.) that
-run companion-frame firmware. No `pymc_core` required.
+run companion-frame firmware. No `openhop_core` required.
 
 | Key           | Type    | Default          | Required | Description                              |
 |---------------|---------|------------------|----------|------------------------------------------|
@@ -345,10 +345,10 @@ run companion-frame firmware. No `pymc_core` required.
 
 ### TCP / HAT mode (`connection_type = "tcp"` or `"hat"`)
 
-Used when `pymc_core` is running separately (Pi HAT setups or any
+Used when `openhop_core` is running separately (Pi HAT setups or any
 external `CompanionFrameServer`). `"hat"` and `"tcp"` are identical at
 the transport level; the distinction tells the setup wizard to install
-`pymc_core` as a systemd dependency.
+`openhop_core` as a systemd dependency.
 
 | Key                          | Type    | Default            | Required | Description                                             |
 |------------------------------|---------|--------------------|----------|---------------------------------------------------------|

--- a/docs/DUAL_TRANSPORT.md
+++ b/docs/DUAL_TRANSPORT.md
@@ -4,7 +4,7 @@ Supply Drop BBS can serve MeshCore and Meshtastic users from a single instance. 
 
 Each transport connects to its own radio. Both MeshCore and Meshtastic support the same two connection types:
 
-- **Pi HAT** — a radio HAT connected to the Raspberry Pi's SPI/GPIO pins, managed by `pymc_core`
+- **Pi HAT** — a radio HAT connected to the Raspberry Pi's SPI/GPIO pins, managed by `openhop_core`
 - **USB device** — a radio such as a Heltec V3, T-Beam, or RAK4631 connected over USB serial
 
 Mix and match freely. Common setups include MeshCore HAT + Meshtastic USB, two USB devices, or two HATs if your Pi has the GPIO pins available.
@@ -29,12 +29,12 @@ The rest of this guide covers manual configuration for operators who prefer to e
 
 ```
 MeshCore radio (HAT or USB)
-    ├── HAT: pymc_core daemon → [plugins.mesh]  ──┐
-    └── USB: direct serial   → [plugins.mesh]  ──┤
-                                                  ├── Supply Drop BBS (shared DB + rooms)
-Meshtastic radio (HAT or USB)                     │
-    ├── HAT: pymc_core daemon → [plugins.meshtastic]  ──┤
-    └── USB: direct serial   → [plugins.meshtastic] ───┘
+    ├── HAT: openhop_core daemon → [plugins.mesh]       ──┐
+    └── USB: direct serial       → [plugins.mesh]       ──┤
+                                                          ├── Supply Drop BBS (shared DB + rooms)
+Meshtastic radio (HAT or USB)                             │
+    ├── HAT: openhop_core daemon → [plugins.meshtastic] ──┤
+    └── USB: direct serial       → [plugins.meshtastic] ──┘
 ```
 
 The two transports run as independent tasks inside the same BBS process. They share nothing except the host — rooms, users, and messages are the same regardless of which radio a user comes in on.
@@ -71,7 +71,7 @@ usb 1-1.2: cp210x converter now attached to ttyUSB0
 
 If you have two USB radios, plug them in one at a time and note which port each claims. The first USB serial device is usually `/dev/ttyUSB0`, the second `/dev/ttyUSB1` — but this depends on plug order and the chips involved, so always confirm with `dmesg`.
 
-HAT connections do not use a serial port number; the connection goes through `pymc_core` on `127.0.0.1:5000`.
+HAT connections do not use a serial port number; the connection goes through `openhop_core` on `127.0.0.1:5000`.
 
 ---
 
@@ -87,7 +87,7 @@ Edit your `config.toml` (typically `/etc/supply-drop-bbs/config.toml`) and add b
 [plugins.mesh]
 enabled         = true
 connection_type = "hat"
-addr            = "127.0.0.1:5000"  # pymc_core; default, change only if remote
+addr            = "127.0.0.1:5000"  # openhop_core; default, change only if remote
 
 [plugins.mesh.hat]
 preset = "zebrahat"  # see preset table below
@@ -179,10 +179,10 @@ INFO bbs_mesh::transport     connected
 INFO bbs_meshtastic           connected
 ```
 
-If the MeshCore HAT transport logs a connection error, check that `pymc_core` is running:
+If the MeshCore HAT transport logs a connection error, check that `openhop_core` is running:
 
 ```sh
-systemctl status pymc-core
+systemctl status pymc-companion
 ```
 
 If either transport logs a serial error, confirm the port name with `dmesg | grep tty` and update `serial_port` in the config. If the error is `Permission denied (os error 13)`, the service user lacks access to the port's group — see [OPERATIONS.md → Serial port: Permission denied](OPERATIONS.md#serial-port-permission-denied).

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -42,7 +42,7 @@ If you're a contributor or plugin author, see
 | Disk      | 2 GB free for DB + logs + backups; SD card OK |
 | Radio     | SX1262 Pi HAT **or** USB MeshCore companion device |
 | OS        | Linux - Raspberry Pi OS / Debian tested. Other Unixes likely work. |
-| Python    | 3.10+ - **Pi HAT mode only** (for `pymc_core`) |
+| Python    | 3.10+ - **Pi HAT mode only** (for `openhop_core`) |
 
 The BBS itself is a single static Rust binary with no runtime dependencies.
 Python is only required when using a Pi HAT
@@ -76,15 +76,15 @@ No bridge process, no Python. One service to manage.
 ### Pi HAT (two-process)
 
 ```
-   ┌──────────────────────┐         ┌────────────────────────┐
-   │  pymc-companion      │         │  supply-drop-bbs       │
-   │  (Python - pymc_core │◄─TCP──► │  (Rust BBS host)       │
-   │  CompanionRadio +    │         │                        │
-   │  CompanionFrameServer│         │  also exposes:         │
-   │                      │         │  - web UI (opt-in)     │
-   │  manages GPIO/SPI    │         └────────────────────────┘
-   │  for the LoRa HAT    │
-   └──────────────────────┘
+   ┌─────────────────────────┐      ┌────────────────────────┐
+   │  pymc-companion         │      │  supply-drop-bbs       │
+   │  (Python - openhop_core)│◄TCP► │  (Rust BBS host)       │
+   │  CompanionRadio +       │      │                        │
+   │  CompanionFrameServer   │      │  also exposes:         │
+   │                         │      │  - web UI (opt-in)     │
+   │  manages GPIO/SPI       │      └────────────────────────┘
+   │  for the LoRa HAT       │
+   └─────────────────────────┘
             │
             ▼
       SX1262 LoRa HAT
@@ -203,7 +203,7 @@ Append `-headless` to the binary name for a smaller build without the admin web 
 ### Option 3 — Guided setup script
 
 The `install.sh` script handles the full stack including Pi HAT configuration
-(`pymc_core`, SPI, `pymc-companion.service`). Download and read it before running:
+(`openhop_core`, SPI, `pymc-companion.service`). Download and read it before running:
 
 ```sh
 curl -fsSL https://raw.githubusercontent.com/Mesh-America/supply-drop-bbs/main/install.sh \
@@ -222,7 +222,7 @@ sudo bash install.sh
 6. Creates the `supply-drop` system user and the config/data directories
 7. Installs the `supply-drop-bbs.service` systemd unit
 8. Runs the **setup wizard**
-9. **Pi HAT only:** installs `pymc_core` in a Python venv, writes `pymc-companion.yaml`, and enables `pymc-companion.service`
+9. **Pi HAT only:** installs `openhop_core` in a Python venv, writes `pymc-companion.yaml`, and enables `pymc-companion.service`
 10. Enables and starts both services
 
 ### What the setup wizard asks
@@ -246,7 +246,7 @@ After the BBS wizard, the installer asks:
 The installer then:
 
 - Enables SPI via `raspi-config` if not already active
-- Creates `/opt/pymc-companion/venv` with `pymc_core`, `spidev`, and `lgpio`
+- Creates `/opt/pymc-companion/venv` with `openhop_core`, `spidev`, and `lgpio`
 - Writes `/etc/supply-drop-bbs/pymc-companion.yaml` with your HAT's pin config
 - Installs and enables `pymc-companion.service`
 

--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -3,7 +3,7 @@
 Two protocols are documented here:
 
 1. **Companion-frame** - the binary TCP protocol between Supply
-   Drop BBS and the radio bridge process (`pymc_core`'s
+   Drop BBS and the radio bridge process (`openhop_core`'s
    `CompanionFrameServer`)
 2. **BBS-over-mesh** - the application-layer command vocabulary
    that mesh users exchange with the BBS
@@ -13,7 +13,7 @@ OpenAPI: see [`openapi.json`](openapi.json) (generated from Rust;
 committed for diffability).
 
 > **Status:** stub. The companion-frame section captures what we
-> know from reading `meshcore_py` and `pymc_core` source; details
+> know from reading `meshcore_py` and `openhop_core` source; details
 > get pinned down precisely when we implement the
 > `meshcore-companion` crate. Sections marked **TBD** require
 > implementation experience to confirm.
@@ -22,7 +22,7 @@ committed for diffability).
 
 ### Purpose
 
-`pymc_core`'s `CompanionFrameServer` exposes a TCP server that
+`openhop_core`'s `CompanionFrameServer` exposes a TCP server that
 speaks the MeshCore "companion" wire protocol - the same protocol
 a USB or serial-attached MeshCore companion device speaks. This
 abstracts the radio: the BBS doesn't care if the bridge is on a
@@ -41,7 +41,7 @@ SX1262.
 ### Framing
 
 **TBD** - exact framing inherited from MeshCore companion protocol.
-Working hypothesis from `pymc_core` source:
+Working hypothesis from `openhop_core` source:
 
 - Each frame is length-prefixed
 - A single-byte frame type identifier
@@ -104,7 +104,7 @@ The companion-frame protocol surface produces:
 
 ### Versioning
 
-`pymc_core` versions it ships, and so does the companion protocol
+`openhop_core` versions it ships, and so does the companion protocol
 itself. Our `meshcore-companion` crate pins a version range it
 supports and refuses to talk to a bridge outside that range. The
 range is documented in the crate's README and in the BBS's
@@ -122,7 +122,7 @@ range is documented in the crate's README and in the BBS's
 - **Integration tests** against a `MockBridgeServer` - a Rust test
   harness that imitates the bridge well enough for the BBS to
   exercise its mesh transport without actual radio hardware.
-- **End-to-end tests** against a real `pymc_core` instance - gated
+- **End-to-end tests** against a real `openhop_core` instance - gated
   behind a `--features integration-tests-with-bridge` cargo flag,
   not run in default CI.
 
@@ -417,7 +417,7 @@ operation since plugins are in-process).
 - `crates/bbs-mesh/` - the BBS-side mesh transport plugin (TBD)
 - `crates/bbs-core/src/command.rs` - internal command/response
   types (TBD)
-- [`pymc_core`](https://github.com/meshcore-dev/pymc_core) -
-  upstream radio bridge
+- [`openhop_core`](https://github.com/openhop-dev/openhop_core) -
+  upstream radio bridge (formerly `pymc_core`)
 - [`meshcore_py`](https://github.com/meshcore-dev/meshcore_py) -
   Python reference client of the companion-frame protocol

--- a/docs/adr/0002-process-model.md
+++ b/docs/adr/0002-process-model.md
@@ -4,6 +4,11 @@
 - **Date:** 2026-05-08
 - **Deciders:** Mesh-America
 
+> **2026-09 update:** the radio-bridge's `pymc_core` dependency (referenced
+> below) was rebranded upstream to `openhop_core`; see
+> [ADR-0007](0007-bridge-stays-pymc-core.md)'s own update note. The
+> process-separation decision here is unaffected.
+
 ## Context
 
 The BBS needs to talk to a LoRa radio (SX1262 over SPI on a Pi).

--- a/docs/adr/0007-bridge-stays-pymc-core.md
+++ b/docs/adr/0007-bridge-stays-pymc-core.md
@@ -4,6 +4,14 @@
 - **Date:** 2026-05-08
 - **Deciders:** Mesh-America
 
+> **2026-09 update:** upstream `pymc_core` was rebranded to `openhop_core`
+> (PyPI package `openhop-core`); the old `pymc_core` PyPI package is no
+> longer maintained. The decision and rationale below are unaffected — we
+> still use the same upstream project's `CompanionFrameServer`, just under
+> its current name. See `supply-drop-bbs-4yv` / [#232](https://github.com/Mesh-America/supply-drop-bbs/issues/232)
+> for the migration. The rest of this document is left as originally
+> written, under the name in use at the time.
+
 ## Context
 
 The radio-bridge process (see [ADR-0002](0002-process-model.md))

--- a/docs/adr/0013-native-serial-transport-for-usb-devices.md
+++ b/docs/adr/0013-native-serial-transport-for-usb-devices.md
@@ -4,6 +4,13 @@
 - **Date:** 2026-05-08
 - **Deciders:** Mesh-America
 
+> **2026-09 update:** `pymc_core` (referenced throughout below) was
+> rebranded upstream to `openhop_core`; see
+> [ADR-0007](0007-bridge-stays-pymc-core.md)'s own update note. The
+> decision and every "pymc_core required/not required" statement below
+> are unaffected — they apply equally to `openhop_core` under its
+> current name.
+
 ## Context
 
 [ADR-0007](0007-bridge-stays-pymc-core.md) established that the radio

--- a/install.sh
+++ b/install.sh
@@ -605,19 +605,19 @@ if [[ "$_mesh_enabled" == true && "$_mesh_conn_type" == "hat" ]]; then
     apt-get install -y -qq $_syspkgs
     success "HAT system packages installed"
 
-    # ── Python venv + pymc_core ───────────────────────────────────────────────
+    # ── Python venv + openhop_core ────────────────────────────────────────────
     mkdir -p "$PYMC_DIR"
     if [[ ! -d "$PYMC_DIR/venv" ]]; then
         info "Creating Python venv at $PYMC_DIR/venv..."
         python3 -m venv "$PYMC_DIR/venv"
     fi
-    info "Installing pymc_core (this may take a minute)..."
+    info "Installing openhop-core (this may take a minute)..."
     "$PYMC_DIR/venv/bin/pip" install -q --upgrade pip
-    "$PYMC_DIR/venv/bin/pip" install -q pymc_core pyyaml spidev
+    "$PYMC_DIR/venv/bin/pip" install -q openhop-core pyyaml spidev
     if [[ "$_gpiod" == false ]]; then
         "$PYMC_DIR/venv/bin/pip" install -q lgpio python-periphery
     fi
-    success "pymc_core installed"
+    success "openhop-core installed"
 
     # ── Install companion script ───────────────────────────────────────────────
     install -m 755 \

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -588,7 +588,7 @@ pub fn run_wizard(config_out: Option<&Path>) {
         let conn_items = &[
             "USB / serial  (Heltec V3, T-Beam, RAK4631 — plug in via USB)",
             "Pi HAT        (ZebraHat, Waveshare, PiMesh, FemtoFox — SPI on GPIO)",
-            "TCP           (connect to a running pymc_core, default port 5000)",
+            "TCP           (connect to a running openhop_core, default port 5000)",
         ];
         let conn_default = if ex.mesh_connection_type == "hat" {
             1
@@ -613,7 +613,7 @@ pub fn run_wizard(config_out: Option<&Path>) {
             1 => ("hat", None, None, None),
             _ => {
                 let addr: String = Input::with_theme(&theme)
-                    .with_prompt("pymc_core address")
+                    .with_prompt("openhop_core address")
                     .default(
                         ex.mesh_addr
                             .clone()
@@ -665,7 +665,7 @@ pub fn run_wizard(config_out: Option<&Path>) {
     // ── MeshCore radio parameters (serial mode only) ──────────────────────────
     //
     // For HAT mode, radio parameters go into pymc-companion.yaml (handled
-    // later by configure_hat). For TCP mode, pymc_core owns the radio config.
+    // later by configure_hat). For TCP mode, openhop_core owns the radio config.
     // Only USB serial devices are configured here.
 
     let mesh_radio: Option<RadioChoice> = if use_mesh && mesh_conn_type == "serial" {
@@ -2184,8 +2184,8 @@ fn print_next_steps(
     config_chown_ok: bool,
 ) {
     if use_mesh && mesh_conn_type == "tcp" {
-        println!("MeshCore TCP mode: Supply Drop BBS will connect to pymc_core at");
-        println!("the configured address. Make sure pymc_core is running before");
+        println!("MeshCore TCP mode: Supply Drop BBS will connect to openhop_core at");
+        println!("the configured address. Make sure openhop_core is running before");
         println!("starting the BBS.");
         println!();
     }


### PR DESCRIPTION
## Summary

Upstream `pyMC_Core` was rebranded to **openHop Core**. The `pymc-core` PyPI package is now stale (last release 2026-05-22, v1.0.12) while `openhop-core` is actively maintained (v1.1.3, released 2026-09-08). This updates:

- `install.sh`'s `pip install` target (`pymc_core` → `openhop-core`)
- `contrib/pymc-companion/pymc-companion.py`'s imports (`from pymc_core...` → `from openhop_core...`)
- `pymc_core` references throughout Rust doc-comments and markdown docs → `openhop_core`

Verified against the real `openhop_core` GitHub source (not just docs) that this is a clean drop-in: submodule paths and class names (`CompanionFrameServer`, `CompanionRadio`, `LocalIdentity`, `hardware.sx1262_wrapper.SX1262Radio`) are unchanged — only the top-level package name changed.

A full hostile code-audit (one Extractor, one Verifier, four routed reviewer personas — Hostile QA, Maintainer, API-contract, Security) ran against this diff. 39 claims extracted, 39 verified (33 Verified, 2 Incorrect, 3 Misleading/fragile, 1 Needs-expert-review). Full report: `.audit/REPORT-openhop-migration.md` (gitignored, not in this PR).

## Also fixes

A real, pre-existing bug the audit surfaced in the same file: `pymc-companion.py` passed `tx_led`/`rx_led` config keys straight into `SX1262Radio()`, but the real constructor params (confirmed identical in both the old `pymc_core` 1.0.12 wheel and current `openhop_core`) are `txled_pin`/`rxled_pin`. Two shipped HAT presets ("Zindello UltraPeater E22"/"E22P") set these by default, so `pymc-companion.service` crashed with `TypeError` on every startup for anyone selecting either preset. Not a rename regression — confirmed pre-existing — but fixed here since it was found in the exact file this PR already touches.

Fixes #233.

## Filed, not fixed here (pre-existing, unrelated to the rename)

The audit also found three more pre-existing issues in the radio-bridge stack, each filed separately since they need more investigation/hardware verification than a same-session fix warrants:

- #235 — `radio.sync_word` is dead code in both old and current library versions (assigned, never applied to hardware). Not currently causing an observed outage (production is exchanging real MeshCore adverts), but the setting has zero effect regardless of configuration.
- #234 — `use_gpiod_backend: true` hits a broken code path in `GPIOPinManager` (upstream bug, identical in both library versions); reachable via 6 shipped HAT presets that default to it.
- #236 — `radio.begin() is False` doesn't catch all init-failure paths, and the `autoadd_config` default comment overstates what it covers.

## Test plan

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --workspace -- -D warnings`
- [x] `cargo test --workspace` (zero failures)
- [x] `cargo doc --workspace --no-deps --all-features`
- [x] `python3 -m py_compile contrib/pymc-companion/pymc-companion.py`
- [x] Confirmed on a second host (no HAT attached, but real infra): `pip install openhop-core` resolves to 1.1.3, and pymc-companion.py's exact imports (`LocalIdentity`, `companion.CompanionFrameServer`/`CompanionRadio`, `hardware.sx1262_wrapper.SX1262Radio`) succeed against the real installed package.
- [ ] Full end-to-end radio test (adv_type=3 actually reaching the wire) — **still not done**, no HAT hardware available. Flagging per `supply-drop-bbs-4yv`'s acceptance criteria.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
