### PR TITLE
fix(ci): pin release build runner to ubuntu-22.04, not ubuntu-latest

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,21 @@ jobs:
   # ─── Build release binaries for all deployment targets ─────────────
   build:
     name: Build · ${{ matrix.target }}
-    runs-on: ubuntu-latest
+    # Pinned, NOT ubuntu-latest: the runner's glibc becomes the minimum glibc
+    # every release binary requires. ubuntu-latest floats and previously
+    # drifted from 22.04 (glibc 2.35) to 24.04 (glibc 2.39) with no code
+    # change on our side, silently breaking `install.sh`'s binary download on
+    # Raspberry Pi OS Bookworm (glibc 2.36) — see supply-drop-bbs-7je / #238.
+    # ubuntu-22.04 (glibc 2.35) stays compatible with Bookworm and newer.
+    # Do not change this back to ubuntu-latest.
+    #
+    # NOT a permanent fix: GitHub is deprecating ubuntu-22.04 runner images
+    # starting 2026-09-17 (brownouts), fully removed 2027-04-17
+    # (actions/runner-images#14254). Before then, this needs a durable
+    # solution decoupled from GitHub's runner-image lifecycle entirely —
+    # e.g. building inside an old-glibc Docker container (manylinux-style),
+    # or switching release targets to musl (static, no glibc dependency).
+    runs-on: ubuntu-22.04
     timeout-minutes: 60
     strategy:
       fail-fast: false


### PR DESCRIPTION
## Summary

`runs-on: ubuntu-latest` in `.github/workflows/release.yml`'s `build` job is a floating GitHub Actions label. It recently drifted from Ubuntu 22.04 (glibc 2.35) to Ubuntu 24.04 (**glibc 2.39**) with zero code changes on our side. Every release binary is linked against the runner's glibc.

**Raspberry Pi OS Bookworm** — the base for most real Supply Drop BBS deployments — ships glibc 2.36, older than 2.39, so the downloaded binary fails immediately:

```
/lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.39' not found (required by /usr/local/bin/supply-drop-bbs)
```

Confirmed via a real `install.sh` run hitting this exact failure while testing unrelated infrastructure. Independently corroborated by the identical failure mode in [rtk-ai/rtk#615](https://github.com/rtk-ai/rtk/issues/615).

Because `ubuntu-latest` floats, this isn't tied to any particular release's contents — **the next release built off `next`, whatever it contains, would silently break `install.sh`'s binary download for every operator on Bookworm or older.** `v1.1.1` (current latest) still works only because it was built before the runner moved.

## Fix

Pin `runs-on` to `ubuntu-22.04` (glibc 2.35, compatible with Bookworm and newer), with a comment explaining why so it doesn't get reverted later.

## Not a permanent fix — flagging honestly

`ubuntu-22.04` runner images are themselves being deprecated by GitHub starting **2026-09-17** (brownouts) and fully removed **2027-04-17** ([actions/runner-images#14254](https://github.com/actions/runner-images/issues/14254)) — discovered while writing this fix. This resolves the immediate breakage today, but a durable solution decoupled from GitHub's runner-image lifecycle (building inside a pinned old-glibc Docker container, or switching release targets to musl for static linking with no glibc dependency) should land before ~2027-04. Tracked as follow-up in `supply-drop-bbs-7je`.

Fixes #238.

## Test plan

- [x] `cargo fmt --all --check` / `cargo clippy --workspace -- -D warnings` / `cargo test --workspace` / `cargo doc --workspace --no-deps --all-features` — all pass (no Rust code touched, this is a pure CI-workflow change)
- [x] YAML validated (`python3 -c "import yaml; yaml.safe_load(...)"`)
- [ ] Verified against an actual triggered release build — **not done this session** (would require pushing a version tag); the change is a single `runs-on` value swap plus comments, low risk, but flagging that the workflow itself hasn't been exercised end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)