### PR TITLE
fix(install): pin install.sh's source clone to main, not the default branch

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -30,6 +30,16 @@ fi
 
 REPO="https://github.com/Mesh-America/supply-drop-bbs.git"
 GITHUB_API="https://api.github.com/repos/Mesh-America/supply-drop-bbs"
+# Pinned, NOT the repo's default branch: this script itself is only ever
+# fetched from `main` (see the curl one-liner in the header comment and in
+# docs/OPERATIONS.md) — `main` tracks released code, while GitHub's default
+# branch is `next` (integration branch, ahead of any release). Cloning
+# whatever the default branch happens to be would let this SRC_DIR checkout
+# silently drift ahead of the running script's own logic — e.g. a newer
+# contrib/pymc-companion/pymc-companion.py (installed further below from
+# SRC_DIR) importing a dependency this stale script never installs. Pinning
+# both to the same ref keeps the script and everything it copies in sync.
+SRC_BRANCH="main"
 SRC_DIR="/opt/supply-drop-bbs"
 BIN_PATH="/usr/local/bin/supply-drop-bbs"
 SERVICE_USER="supply-drop"
@@ -219,11 +229,16 @@ success "Base dependencies installed"
 
 if [[ -d "$SRC_DIR/.git" ]]; then
     info "Updating Supply Drop BBS source..."
-    git -C "$SRC_DIR" pull --ff-only
+    # fetch + checkout -B (not `pull --ff-only`) so this self-heals an
+    # existing SRC_DIR left on the wrong branch by an older install — e.g.
+    # one cloned before this pin existed, when a bare `git clone` picked up
+    # whatever the repo's default branch was at the time.
+    git -C "$SRC_DIR" fetch --depth 1 origin "$SRC_BRANCH:refs/remotes/origin/$SRC_BRANCH"
+    git -C "$SRC_DIR" checkout -B "$SRC_BRANCH" "origin/$SRC_BRANCH"
     success "Source updated"
 else
     info "Cloning Supply Drop BBS..."
-    git clone --depth 1 "$REPO" "$SRC_DIR"
+    git clone --depth 1 --branch "$SRC_BRANCH" "$REPO" "$SRC_DIR"
     success "Source cloned to $SRC_DIR"
 fi
 


### PR DESCRIPTION
## Summary

`install.sh`'s own `git clone`/`git pull` of its working copy (`/opt/supply-drop-bbs`) had no branch specified, so it tracked whatever GitHub's default branch was — currently **`next`** (confirmed via `gh api repos/Mesh-America/supply-drop-bbs --jq .default_branch`). But the `install.sh` script itself is only ever fetched by real users from **`main`** specifically (the documented curl one-liner is hardcoded to `.../main/install.sh`).

## Why this is urgent

Right now, `main`'s live install.sh still runs `pip install pymc_core` (its own unreleased logic), but its internal clone — tracking default-branch `next`, which already has #237 merged — copies a **new** `pymc-companion.py` that imports `openhop_core` instead. Any real Pi HAT install *or update* run via the documented method right now hits `ModuleNotFoundError: No module named 'openhop_core'` and crashes immediately. This affects existing users too — the documented "Guided script update" flow runs the Pi-HAT pip-install block unconditionally, regardless of the reconfigure prompt answer.

## Fix

Pin the internal source clone to an explicit `SRC_BRANCH="main"`. The update path uses `git fetch` + `git checkout -B` (not `git pull --ff-only`) so it self-heals an existing `/opt/supply-drop-bbs` stuck on the wrong branch from an older install, rather than just fast-forwarding whatever's currently checked out.

Tested against the real repo, three scenarios:
- Fresh clone → lands on `main`
- Existing clone stuck on `next` (simulating an install from before this fix) → self-heals to `main`
- Existing clone already on `main` → routine update still works cleanly

`shellcheck`-clean (one pre-existing, unrelated SC2015 info-level note elsewhere in the file — not touched by this change).

## Doesn't close today's gap by itself

This prevents the bug from recurring once it ships to `main`, but the fix living on `next` doesn't retroactively patch what's live on `main` right now. Closing today's active exposure still needs `next` → `main` merged.

Fixes #240.

## Test plan

- [x] `cargo fmt --all --check` / `cargo clippy --workspace -- -D warnings` / `cargo test --workspace` / `cargo doc --workspace --no-deps --all-features` — all pass (no Rust code touched)
- [x] `bash -n install.sh` (syntax) and `shellcheck -x install.sh` — clean
- [x] All three clone/update scenarios tested against the real repo (see Summary)

🤖 Generated with [Claude Code](https://claude.com/claude-code)