### PR TITLE
fix(install): force the SRC_DIR self-healing fetch

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -233,7 +233,17 @@ if [[ -d "$SRC_DIR/.git" ]]; then
     # existing SRC_DIR left on the wrong branch by an older install — e.g.
     # one cloned before this pin existed, when a bare `git clone` picked up
     # whatever the repo's default branch was at the time.
-    git -C "$SRC_DIR" fetch --depth 1 origin "$SRC_BRANCH:refs/remotes/origin/$SRC_BRANCH"
+    #
+    # --force is required, not optional: on a real SRC_DIR with accumulated
+    # history (as opposed to a fresh clone), updating the local
+    # refs/remotes/origin/$SRC_BRANCH ref can be a non-fast-forward relative
+    # to what's already stored there — confirmed on a live host, where the
+    # unforced fetch below failed outright ("[rejected] ... non-fast-forward",
+    # exit 1). Under `set -e` that aborts the whole update instead of
+    # silently leaving a stale checkout, which is at least safe — but it
+    # defeats this block's entire purpose (self-healing an existing SRC_DIR
+    # onto the correct branch), so force it instead of letting it fail.
+    git -C "$SRC_DIR" fetch --depth 1 --force origin "$SRC_BRANCH:refs/remotes/origin/$SRC_BRANCH"
     git -C "$SRC_DIR" checkout -B "$SRC_BRANCH" "origin/$SRC_BRANCH"
     success "Source updated"
 else


### PR DESCRIPTION
## Summary

#241's `SRC_DIR` self-healing update (`git fetch --depth 1 origin main:refs/remotes/origin/main` + `git checkout -B main origin/main`) uses an unforced fetch. On a real `/opt/supply-drop-bbs` with accumulated history — not the fresh clones #241 was tested against — updating that local remote-tracking ref can be a genuine non-fast-forward, and the fetch fails outright (`[rejected] ... non-fast-forward`, exit 1).

**Confirmed live in production** recovering a host from the #237 upgrade gap, and **reproduced cleanly in a controlled test**: force a local `origin/main` ref to an old release tag's commit, fetch the real tip unforced — same rejection; forced fetch resolves it and the resulting checkout has current content.

Under `set -e` this aborts the update rather than silently corrupting state, but it defeats #241's whole purpose — any host with real accumulated `SRC_DIR` history can't self-heal via `install.sh` right now.

## Fix

Add `--force` to the fetch.

## Verified end-to-end on the same production host

After manually applying this fix's logic there: the fetch/checkout self-healed correctly, `pymc-companion.py` updated, and — independently confirmed by the operator via other MeshCore tooling (contact details in a MeshCore client, and the public corescope map) — the BBS now genuinely shows as Room Server, not Chat. This closes the loop on the original issue this whole chain of fixes traces back to.

Fixes #247.

## Test plan

- [x] `cargo fmt --all --check` / `cargo clippy --workspace -- -D warnings` / `cargo test --workspace` / `cargo doc --workspace --no-deps --all-features` — all pass (no Rust code touched)
- [x] `shellcheck -x install.sh` — clean (same pre-existing unrelated SC2015 note as prior install.sh PRs)
- [x] Reproduced the exact production failure in a controlled test, confirmed the fix resolves it
- [x] Verified end-to-end on the actual production host that hit this

🤖 Generated with [Claude Code](https://claude.com/claude-code)